### PR TITLE
Handle [ and ] correctly with a dirty hack

### DIFF
--- a/src/Markdown.MAML/Parser/MarkdownParser.cs
+++ b/src/Markdown.MAML/Parser/MarkdownParser.cs
@@ -85,8 +85,13 @@ namespace Markdown.MAML.Parser
                         "(?<emptyHyperlink>\\[(.+?)\\]\\(\\))",
                         this.CreateHyperlinkSpan },
 
+                        // Normal need a negative look-ahead for hyperlinks pattern.
+                    {   "normalWithHyperlink",
+                        @"\s*(?<normalWithHyperlink>[{0}{1}]+)\[.*\]\(.*\)",
+                        this.CreateNormalSpan },
+
                     {   "normal",
-                        @"\s*(?<normal>[{0}{1}]+)",
+                        @"\s*(?<normal>[{0}{1}\[\]]+)",
                         this.CreateNormalSpan },
 
                     {   "italic",
@@ -135,6 +140,7 @@ namespace Markdown.MAML.Parser
             {
                 string matchedGroupName = null;
                 Match regexMatch = markdownRegex.Match(_remainingText);
+                
                 if (!regexMatch.Success)
                 {
                     string textExcerpt =
@@ -155,8 +161,15 @@ namespace Markdown.MAML.Parser
                         regexMatch,
                         matchGroup);
 
+                // TODO: remove this special case hack
+                int groupLength = regexMatch.Length;
+                if (matchedGroupName == "normalWithHyperlink")
+                {
+                    groupLength = matchGroup.Length;
+                }
+
                 // Get rid of the entire matched string
-                _remainingText = _remainingText.Substring(regexMatch.Length);
+                _remainingText = _remainingText.Substring(groupLength);
 
                 if (!executedAction)
                 {

--- a/test/Markdown.MAML.Test/Parser/ParserTests.cs
+++ b/test/Markdown.MAML.Test/Parser/ParserTests.cs
@@ -145,6 +145,23 @@ about_Hash_Tables (http://go.microsoft.com/fwlink/?LinkID=135175).
             Assert.Equal(@"about_Hash_Tables (http://go.microsoft.com/fwlink/?LinkID=135175).", spans[0].Text);
         }
 
+        [Fact]
+        public void TextSpansCanContainSquareBrackets()
+        {
+            string documentText = @"
+# Foo
+Not a hyperlink [PSObject].
+";
+            MarkdownParser markdownParser = new MarkdownParser();
+            DocumentNode documentNode =
+                markdownParser.ParseString(
+                    documentText);
+            var children = documentNode.Children.ToArray();
+            Assert.Equal(2, children.Count());
+            var spans = Assert.IsType<ParagraphNode>(children[1]).Spans.ToArray();
+            Assert.Equal(@"Not a hyperlink [PSObject].", spans[0].Text);
+        }
+
 
         [Fact]
         public void ParsesParagraphWithSupportedCharacters()


### PR DESCRIPTION
@daviwil I still was not able to parse 3 backticks at the end of the file, but I believe that root problem was in treating `fooo [xx]` as normal text only for `fooo`, but not the whole thing.
