### PR TITLE
Adding the New-PlatyPsCab cmdlet to the psm1 for PlatyPs module

### DIFF
--- a/platyPS.schema.md
+++ b/platyPS.schema.md
@@ -52,16 +52,22 @@ It closely resembles output of `Get-Help`.
             {{Parameter description text}}
 
             // parameter metadata
-            ```yaml // this gives us key/value highlighting
-            Type: {Parameter type}  // can be ommitted, then default assumed
-            Required: {true | false}
-            Position: {1..n} | named
-            Default value: {None | False (for switch parameters) | the actual default value}
-            Accept pipeline input: {false | true (ByValue, ByPropertyName)}
-            Accept wildcard characters: {true | false}
-            Parameter Sets: {comma-separated list of names, i.e. "SetName1, SetName2"} // if ommitted => default
-            Aliases: {comma-separated list of aliases, i.e. "EA", "ERR"} // if ommitted => default
-            ```
+            // for every unique parameter metadata set 
+            // Note: two Parameter Sets can have the same parameter as mandatory and non-mandatory
+            // then we put them in two yaml snippets.
+            // If they have the same metadata, we put them in one yaml snippet.
+                ```yaml // this gives us key/value highlighting
+                Type: {Parameter type}  // can be ommitted, then default assumed
+                Parameter Sets: {comma-separated list of names, i.e. "SetName1, SetName2"} // if ommitted => default
+                Aliases: {comma-separated list of aliases, i.e. "EA", "ERR"} // if ommitted => default
+                // break line to improve readability and separate metadata block
+                                        
+                Required: {true | false}
+                Position: {1..n} | named
+                Default value: {None | False (for switch parameters) | the actual default value}
+                Accept pipeline input: {false | true (ByValue, ByPropertyName)}
+                Accept wildcard characters: {true | false}
+                ```
 
         ## INPUTS
         // for every input type

--- a/platyPS.schema.md
+++ b/platyPS.schema.md
@@ -35,10 +35,13 @@ It closely resembles output of `Get-Help`.
         // for every example
             ### {Example Name}
 
-            {{Example text explanation}}
+            {{Example introduction text}}
+            
             ```powershell
             {{Example body}}
             ```
+            
+            {{Example remarks}} // not a mandatory, i.e. TechNet articles don't use remarks
 
         ## PARAMETERS
 

--- a/platyPS.schema.md
+++ b/platyPS.schema.md
@@ -75,7 +75,7 @@ It closely resembles output of `Get-Help`.
         // for every link
             [{link name}]({link url})
 
-### Version 1.0.
+### Version 1.0.0
 
     // for every command:
         # {Command name}

--- a/platyPS.schema.md
+++ b/platyPS.schema.md
@@ -35,10 +35,10 @@ It closely resembles output of `Get-Help`.
         // for every example
             ### {Example Name}
 
+            {{Example text explanation}}
             ```powershell
             {{Example body}}
             ```
-            {{Example text explanation}}
 
         ## PARAMETERS
 

--- a/src/platyPS/platyPS.md
+++ b/src/platyPS/platyPS.md
@@ -312,3 +312,82 @@ Preview help from generated maml file.
 ## RELATED LINKS
 
 
+# New-PlatyPSCab
+
+## SYNOPSIS
+New-PlatyPSCab [-Source] \<string\> [-Destination] \<string\> [-Module] \<string\> [-Guid] \<string\> [-Locale] \<string\> [\<CommonParameters\>]
+
+## DESCRIPTION
+Creates a cab file containing the files specified by the user. It will format the name of the cab file as required by the PowerShell Help engine: <ModuleName>_<ModuleGuid>_<Locale>_helpcontent.cab
+
+## PARAMETERS
+
+### Destination [string]
+
+```powershell
+[Parameter(
+  Mandatory = $true,
+  Position = 1,
+  ParameterSetName = 'Set 1')]
+```
+The directory the cab will be placed in on completion.
+
+### Guid [string]
+
+```powershell
+[Parameter(
+  Mandatory = $true,
+  Position = 3,
+  ParameterSetName = 'Set 1')]
+```
+The GUID for the module that the help represents.
+
+### Locale [string]
+
+```powershell
+[Parameter(
+  Mandatory = $true,
+  Position = 4,
+  ParameterSetName = 'Set 1')]
+```
+The locale code for the language. en-US
+
+### Module [string]
+
+```powershell
+[Parameter(
+  Mandatory = $true,
+  Position = 2,
+  ParameterSetName = 'Set 1')]
+```
+The name of the module that cab contains help for.
+
+### Source [string]
+
+```powershell
+[Parameter(
+  Mandatory = $true,
+  Position = 0,
+  ParameterSetName = 'Set 1')]
+```
+The directory containing the files to be placed in the cab file.
+
+## INPUTS
+### None
+
+## OUTPUTS
+### None
+
+## NOTES
+### None
+
+## EXAMPLES
+### ----------------------------- Example 1 (platyPS) ------------------------------------
+
+```powershell
+New-PlatyPSCab -Source 'C:\InputDirectory\' -Destination 'C:\OutputDirectory\' -Module "moduleName" -Locale "localeCode" -Guid "0bdcabef-a4b7-4a6d-bf7e-d879817ebbff"
+```
+Creates a cab using the files in the source directory, and dropping the properly named Cab file in the destination directory. 
+The Output file will be called: "PlatyPS_0bdcabef-a4b7-4a6d-bf7e-d879817ebbff_en-US_helpcontent.cab"
+
+## RELATED LINKS

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -309,20 +309,61 @@ function New-PlatyPSCab
     [Cmdletbinding()]
     param(
         [parameter(Mandatory=$true)]
-        [ValidateScript({Test-Path $_ -PathType Container})]
+        [ValidateScript(
+            {
+                if(Test-Path $_ -PathType Container)
+                {
+                    $True
+                }
+                else
+                {
+                    Throw "$_ source path is not a valid directory."
+                }
+            })]
         [string] $Source,
         [parameter(Mandatory=$true)]
-        [ValidateScript({Test-Path $_ -PathType Container})]
+        [ValidateScript(
+            {
+                if(Test-Path $_ -PathType Container)
+                {
+                    $True
+                }
+                else
+                {
+                    Throw "$_ source path is not a valid directory."
+                }
+            })]
         [string] $Destination,
         [parameter(Mandatory=$true)]
         [string] $Module,
         [parameter(Mandatory=$true)]
-        [ValidateScript({$_ -in ([System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)).Name})]
-        [string] $Locale,
+        [ValidateScript({
+                if($_ -match '[a-zA-Z0-9]{8}[-][a-zA-Z0-9]{4}[-][a-zA-Z0-9]{4}[-][a-zA-Z0-9]{4}[-][a-zA-Z0-9]{12}')
+                {
+                    $true
+                }
+                else
+                {
+                    Throw "$_ does not match the valid pattern for a PowerShell module GUID. The GUID consists of letters and numbers in this format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                }
+            
+            })]
+        [string] $Guid = $(throw 'GUID was not a valid format.'),
         [parameter(Mandatory=$true)]
-        [string] $Guid
+        [ValidateScript(
+            {
+                if($_ -in ([System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)).Name)
+                {
+                    $True
+                }
+                else
+                {
+                    Throw "$_ is not a valid Locale code in the .Net framework installed."
+                }
+            })]
+        [string] $Locale
     )
-
+    
     #Testing for MakeCab.exe
     Write-Verbose "Testing that MakeCab.exe is present on this machine."
     $MakeCab = Get-Command MakeCab

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -309,12 +309,15 @@ function New-PlatyPSCab
     [Cmdletbinding()]
     param(
         [parameter(Mandatory=$true)]
+        [ValidateScript({Test-Path $_ -PathType Container})]
         [string] $Source,
         [parameter(Mandatory=$true)]
+        [ValidateScript({Test-Path $_ -PathType Container})]
         [string] $Destination,
         [parameter(Mandatory=$true)]
         [string] $Module,
         [parameter(Mandatory=$true)]
+        [ValidateScript({$_ -in ([System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::AllCultures)).Name})]
         [string] $Locale,
         [parameter(Mandatory=$true)]
         [string] $Guid

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -22,8 +22,8 @@ Describe 'New-PlatyPsCab' {
         New-PlatyPsCab -Source $Source -Destination $Destination -Module $Module -GUID $GUID -Locale $Locale
         expand "$Destination\PlatyPs_00000000-0000-0000-0000-000000000000_en-US_helpcontent.cab" /f:* "$outFolder\CabTesting\OutXml\" 
         
-        (Get-ChildItem -Filter "*.cab" -Path "$Destination\CabTesting").Name | Should Be "PlatyPs_00000000-0000-0000-0000-000000000000_en-US_helpcontent.cab"
-        (Get-ChildItem -Filter "*.xml" -Path "$Destination\CabTesting\OutXml").Name | Should Be "HelpXml.xml"
+        (Get-ChildItem -Filter "*.cab" -Path "$Destination").Name | Should Be "PlatyPs_00000000-0000-0000-0000-000000000000_en-US_helpcontent.cab"
+        (Get-ChildItem -Filter "*.xml" -Path "$Destination\OutXml").Name | Should Be "HelpXml.xml"
     }
     
  }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -1,0 +1,32 @@
+﻿Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+$root = (Resolve-Path $PSScriptRoot\..\..).Path
+$outFolder = "$root\out"
+
+New-Item -ItemType Directory -Path "$outFolder\CabTesting\Source\Xml\" -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path "$outFolder\CabTesting\OutXml" -ErrorAction SilentlyContinue
+New-Item -ItemType File -Path "$outFolder\CabTesting\Source\Xml\" -Name "HelpXml.xml" -force
+
+Import-Module $outFolder\platyPS -Force
+
+Describe 'New-PlatyPsCab' {
+
+    $markdown = cat -Raw $PSScriptRoot\SMA.Help.md
+    It 'validates the output of Cab creation' {
+        $Source = "$outFolder\CabTesting\Source\Xml\"
+        $Destination = "$outFolder\CabTesting\"
+        $Module = "PlatyPs" 
+        $GUID = "00000000-0000-0000-0000-000000000000"
+        $Locale = "en-US"
+        
+        New-PlatyPsCab -Source $Source -Destination $Destination -Module $Module -GUID $GUID -Locale $Locale
+        expand "$Destination\PlatyPs_00000000-0000-0000-0000-000000000000_en-US_helpcontent.cab" /f:* "$outFolder\CabTesting\OutXml\" 
+        
+        (Get-ChildItem -Filter "*.cab" -Path "$Destination\CabTesting").Name | Should Be "PlatyPs_00000000-0000-0000-0000-000000000000_en-US_helpcontent.cab"
+        (Get-ChildItem -Filter "*.xml" -Path "$Destination\CabTesting\OutXml").Name | Should Be "HelpXml.xml"
+    }
+    
+    Get-PlatyPSTextHelpFromMaml $outFolder\SMA.dll-help.xml -TextOutputPath $outFolder\SMA.generated.txt
+    Get-PlatyPSTextHelpFromMaml $pshome\en-US\System.Management.Automation.dll-help.xml -TextOutputPath $outFolder\SMA.original.txt
+}

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -12,7 +12,6 @@ Import-Module $outFolder\platyPS -Force
 
 Describe 'New-PlatyPsCab' {
 
-    $markdown = cat -Raw $PSScriptRoot\SMA.Help.md
     It 'validates the output of Cab creation' {
         $Source = "$outFolder\CabTesting\Source\Xml\"
         $Destination = "$outFolder\CabTesting\"
@@ -27,6 +26,5 @@ Describe 'New-PlatyPsCab' {
         (Get-ChildItem -Filter "*.xml" -Path "$Destination\CabTesting\OutXml").Name | Should Be "HelpXml.xml"
     }
     
-    Get-PlatyPSTextHelpFromMaml $outFolder\SMA.dll-help.xml -TextOutputPath $outFolder\SMA.generated.txt
-    Get-PlatyPSTextHelpFromMaml $pshome\en-US\System.Management.Automation.dll-help.xml -TextOutputPath $outFolder\SMA.original.txt
-}
+ }
+ 


### PR DESCRIPTION
Added a new cmdlet to the psm1 file for  PlatyPS.
Addresses Issue #35 

```PowerShell
New-PlatyPsCab -Source <string> -Destination <string> `
                      -Module <string> -Locale <string> -Guid <string> 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/41)
<!-- Reviewable:end -->
