### PR TITLE
Remove .psm1 from helpfile name

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -699,8 +699,9 @@ function Get-HelpFileName
         if ($moduleItem.Extension -eq '.psm1') {
             $fileName = $moduleItem.BaseName
         } else {
-            $fileName - $moduleItem.Name
+            $fileName = $moduleItem.Name
         }
+
         return "$fileName-help.xml"
     }
 }

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -285,7 +285,7 @@ function New-ExternalHelp
         $r = new-object -TypeName 'Markdown.MAML.Renderer.MamlRenderer'
         
         # TODO: this is just a place-holder, we can do better
-        $defaultOutputName = 'rename-me.psm1-help.xml'
+        $defaultOutputName = 'rename-me-help.xml'
         $groups = $MarkdownFiles | group { 
             $h = Get-MarkdownMetadata -FileInfo $_
             if ($h -and $h[$script:EXTERNAL_HELP_FILES]) 
@@ -695,7 +695,7 @@ function Get-HelpFileName
             $module = $module | Select -First 1
         }
 
-        $fileName = Split-Path -Leaf $module.Path
+        $fileName = (Split-Path -Leaf $module.Path).TrimEnd('.psm1')
         return "$fileName-help.xml"
     }
 }

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -695,7 +695,12 @@ function Get-HelpFileName
             $module = $module | Select -First 1
         }
 
-        $fileName = (Split-Path -Leaf $module.Path).TrimEnd('.psm1')
+        $moduleItem = Get-Item -Path $module.Path
+        if ($moduleItem.Extension -eq '.psm1') {
+            $fileName = $moduleItem.BaseName
+        } else {
+            $fileName - $moduleItem.Name
+        }
         return "$fileName-help.xml"
     }
 }


### PR DESCRIPTION
The file being created, Module.psm1-Help.xml is not being recognized by the shell because of the .psm1.  I have removed that from the Get-HelpFileName cmdlet.  This will not update any existing metadata, but it will fix new ones.  I think this should work fine with the dll modules, because then it needs to go Module.dll-Help.xml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/73)
<!-- Reviewable:end -->
