### PR TITLE
Remove the ':' from online version link

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -667,7 +667,7 @@ function Update-MamlObject
     # Online Version URL
     if (-not ($MamlCommandObject.Links | ? {$_.LinkName -eq 'Online Version:'} )) {
         $mamlLink = New-Object -TypeName Markdown.MAML.Model.MAML.MamlLink
-        $mamlLink.LinkName = 'Online Version:'
+        $mamlLink.LinkName = 'Online Version'
         $mamlLink.LinkUri = $OnlineVersionUrl
         $MamlCommandObject.Links.Add($mamlLink)
     }


### PR DESCRIPTION
removed the colon from the Online Version markdown link.  It just looks silly when the markdown is rendered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/81)
<!-- Reviewable:end -->
