### PR TITLE
Move Module Param in New-Markdown to Dynamic Param

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -54,6 +54,8 @@ function New-Markdown
     )
 
     DynamicParam {
+        $modules = @(Get-Module | Select-Object -ExpandProperty Name)
+        $modules += 'Microsoft.PowerShell.Core'
         $moduleParamAttributes = New-Object -TypeName System.Management.Automation.ParameterAttribute -Property @{
             Mandatory = $true
             ParameterSetName = 'FromModule'
@@ -62,7 +64,7 @@ function New-Markdown
         $moduleParamCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection[System.Attribute]'
         $moduleParamCollection.Add($moduleParamAttributes)
         $moduleParameter = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameter -ArgumentList ('Module', [Object], $moduleParamCollection)
-        $moduleParameter.Attributes.Add((New-Object -TypeName System.Management.Automation.ValidateSetAttribute(@(Get-Module | Select-Object -ExpandProperty Name))))
+        $moduleParameter.Attributes.Add((New-Object -TypeName System.Management.Automation.ValidateSetAttribute($modules)))
 
         $dictionary = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameterDictionary
         $dictionary.Add('Module', $moduleParameter)


### PR DESCRIPTION
Moved Module Param to a Dynamic Param to allow to validate set with
Get-Module | Select Name.  This gives intellisense for loaded modules,
and moves the validation of the module  being loaded to the parameter,
rather then in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/89)
<!-- Reviewable:end -->
