### PR TITLE
Bug Fix Replaced UTF-8 NO-BREAK SPAC character with regular space

### DIFF
--- a/src/Markdown.MAML/Markdown.MAML.csproj
+++ b/src/Markdown.MAML/Markdown.MAML.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Model\Markdown\HardBreakSpan.cs" />
     <Compile Include="Parser\MarkdownPattern.cs" />
     <Compile Include="Parser\MarkdownPatternList.cs" />
+    <Compile Include="Renderer\RenderCleaner.cs" />
     <Compile Include="Renderer\MarkdownV2Renderer.cs" />
     <Compile Include="Resources\MarkdownStrings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -88,7 +88,7 @@ namespace Markdown.MAML.Renderer
                 _stringBuilder.AppendLine("</helpItems>");
             }
 
-            return _stringBuilder.ToString();
+           return RenderCleaner.NormalizeCharacters(_stringBuilder.ToString());
         }
 
         private void AddCommands(IEnumerable<MamlCommand> mamlCommands)

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -88,7 +88,7 @@ namespace Markdown.MAML.Renderer
                 _stringBuilder.AppendLine("</helpItems>");
             }
 
-           return RenderCleaner.NormalizeCharacters(_stringBuilder.ToString());
+           return RenderCleaner.NormalizeWhitespaces(_stringBuilder.ToString());
         }
 
         private void AddCommands(IEnumerable<MamlCommand> mamlCommands)

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -64,12 +64,7 @@ namespace Markdown.MAML.Renderer
             AddCommand(mamlCommand);
 
             // at the end, just normalize all ends
-            return NormalizeLineEnds(_stringBuilder.ToString());
-        }
-
-        private string NormalizeLineEnds(string text)
-        {
-            return Regex.Replace(text, "\r\n?|\n", "\r\n");
+            return RenderCleaner.NormalizeLineBreaks(_stringBuilder.ToString());
         }
 
         private void AddYamlHeader(Hashtable yamlHeader)

--- a/src/Markdown.MAML/Renderer/RenderCleaner.cs
+++ b/src/Markdown.MAML/Renderer/RenderCleaner.cs
@@ -10,7 +10,7 @@ namespace Markdown.MAML.Renderer
 {
     static class RenderCleaner
     {
-        public static string NormalizeCharacters(string text)
+        public static string NormalizeWhitespaces(string text)
         {
             text = Regex.Replace(text, "Â ", " ");
             return text;

--- a/src/Markdown.MAML/Renderer/RenderCleaner.cs
+++ b/src/Markdown.MAML/Renderer/RenderCleaner.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using Microsoft.PowerShell.Commands;
+
+namespace Markdown.MAML.Renderer
+{
+    static class RenderCleaner
+    {
+        public static string NormalizeCharacters(string text)
+        {
+            text = Regex.Replace(text, "Â ", " ");
+            return text;
+        }
+
+        public static string NormalizeLineBreaks(string text)
+        {
+            return Regex.Replace(text, "\r\n?|\n", "\r\n");
+        }
+    }
+}


### PR DESCRIPTION
This bug fix updates the renderer code and modifies the MAML renderer to use a new sanitization class RenderCleaner to replace the special whitespace characters with a regular space.

It also abstracts the line break sanitization in Markdown generation to the RenderCleaner class, as this was exclusively used by the MarkDown render for V2 cmdlets markdown. It was abstracted because this may have more widely applicable usage as we add features from the road map, such as AboutTopic generation and rendering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/116)
<!-- Reviewable:end -->
