### PR TITLE
Update syntax of markdown files by using Update-MarkdownHelp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,11 @@ To build the whole project, use helper `build.ps1` script
 As part of build, module generate help for itself.
 The result of the build would be in `out\platyPS` folder.
 
+`build.ps1` also imports the module from `out\platyPS` and generates help for the tool itself.
+
+**Note**: if you changed C# code, script will try to overwrite a dll in-use. 
+You would need to re-open your powershell session. If you know a better workflow, please suggest it in the issues.
+
 ## Tests
 
 There are two part of projects and two test sets.

--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md
 ---
 
 # Get-HelpPreview
@@ -78,5 +79,3 @@ This cmdlet returns a **Help** object, which is the same output as **Get-Help**.
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md)
 
 [New-ExternalHelp](New-ExternalHelp.md)
-
-[Get-Help]

--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -1,13 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md
 ---
 
 # Get-HelpPreview
 ## SYNOPSIS
-Displays your generated external help as **Get-Help** output.
-
+Preview the output Get-Help would return from an external help file(s).
 ## SYNTAX
 
 ```
@@ -15,18 +13,17 @@ Get-HelpPreview -Path <String[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-HelpPreview** cmdlet displays your generated external help as **Get-Help** output.
-Specify one or more files in Microsoft Assistance Markup Language (MAML) format.
+You can use PowerShell help engine to display the text help output for external help.
+This cmdlet verifies how markdown-generated help will look in Get-Help output.
 
-
+It simulates the output produced by Get-Help cmdlet.
 ## EXAMPLES
 
-### Example 1: Preview the PlatyPS help
+### Example 1
 ```
-PS C:\> $Help = Get-HelpPreview -Path ".\out\platyPS\en-US\PlatyPS-help.xml"
+PS C:\> $help = Get-HelpPreview .\out\platyPS\en-US\platyPS-help.xml
 
-PS C:\> $Help.Name
-
+PS C:\> $help.Name
 Get-HelpPreview
 Get-MarkdownMetadata
 New-ExternalHelp
@@ -37,16 +34,13 @@ Update-MarkdownHelpModule
 Update-MarkdownHelpSchema
 ```
 
-The first command creates a **Help** object for the the specified MAML file.
-The command stores it in the $Help variable.
-
-The second command displays the **Name** property for each of the objects in $Help.
-
+Returns a help object get-help preview from maml xml and assign it to the $help variable.
+Gets the names of Cmdlet objects inside help.
 ## PARAMETERS
 
 ### -Path
-Specifies an array of paths of MAML external help files.
-
+Path to MAML help files.
+You can pass several of them.
 
 ```yaml
 Type: String[]
@@ -55,7 +49,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value:
+Default value: 
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
@@ -65,17 +59,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### String[]
-You can pipe an array of paths to this cmdlet.
-
+You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### Help Object
-This cmdlet returns a **Help** object, which is the same output as **Get-Help**.
-
+Help object, which is the same as Get-Help provides.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md)
-
-[New-ExternalHelp](New-ExternalHelp.md)

--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md
 ---
 
 # Get-HelpPreview
@@ -9,7 +10,7 @@ Preview the output Get-Help would return from an external help file(s).
 ## SYNTAX
 
 ```
-Get-HelpPreview -Path <String[]> [<CommonParameters>]
+Get-HelpPreview -Path <String[]> [-ConvertNotesToList] [-ConvertDoubleDashLists] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,6 +43,8 @@ Gets the names of Cmdlet objects inside help.
 Path to MAML help files.
 You can pass several of them.
 
+
+
 ```yaml
 Type: String[]
 Parameter Sets: (All)
@@ -49,8 +52,34 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -ConvertNotesToList
+Add bullet list into notes section to match TechNet format.```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConvertDoubleDashLists
+Convert two-hypen lists (common in MS-authored MAML) into one-hypen list (accepted in markdown).```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -5,25 +5,25 @@ schema: 2.0.0
 
 # Get-HelpPreview
 ## SYNOPSIS
-Preview the output Get-Help would return from an external help file(s).
+Displays your generated external help as **Get-Help** output.
+
 ## SYNTAX
 
 ```
-Get-HelpPreview -Path <String[]> [<CommonParameters>]
+Get-HelpPreview -Path <String[]>
 ```
 
 ## DESCRIPTION
-You can use PowerShell help engine to display the text help output for external help.
-This cmdlet verifies how markdown-generated help will look in Get-Help output.
+The **Get-HelpPreview** cmdlet displays your generated external help as [Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx) output. Specify one or more files in Microsoft Assistance Markup Language (MAML) format.
 
-It simulates the output produced by Get-Help cmdlet.
 ## EXAMPLES
 
-### Example 1
+### Example 1: Preview the PlatyPS help
 ```
-PS C:\> $help = Get-HelpPreview .\out\platyPS\en-US\platyPS-help.xml
+PS C:\> $Help = Get-HelpPreview -Path ".\out\platyPS\en-US\PlatyPS-help.xml"
 
-PS C:\> $help.Name
+PS C:\> $Help.Name
+
 Get-HelpPreview
 Get-MarkdownMetadata
 New-ExternalHelp
@@ -34,44 +34,43 @@ Update-MarkdownHelpModule
 Update-MarkdownHelpSchema
 ```
 
-Returns a help object get-help preview from maml xml and assign it to the $help variable.
-Gets the names of Cmdlet objects inside help.
+The first command creates a **Help** object for the the specified MAML file. The command stores it in the $Help variable.
+
+The second command displays the **Name** property for each of the objects in $Help.
+
 ## PARAMETERS
 
 ### -Path
-Path to MAML help files.
-You can pass several of them.
+Specifies an array of paths of MAML external help files.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
+
 ## OUTPUTS
 
 ### Help Object
-Help object, which is the same as Get-Help provides.
+This cmdlet returns a **Help** object, which is the same output as **Get-Help**.
+
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Get-HelpPreview.md)
 
+[New-ExternalHelp](New-ExternalHelp.md)
 
-
-
-
-
+[Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx)

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-MarkdownMetadata.md
 ---
 
 # Get-MarkdownMetadata
@@ -8,7 +9,7 @@ schema: 2.0.0
 Gets the markdown header metadata in the form of a hashtable.
 ## SYNTAX
 
-### FromPath
+### FromPath (Default)
 ```
 Get-MarkdownMetadata -Path <String[]> [<CommonParameters>]
 ```
@@ -86,6 +87,8 @@ Path to markdown file or folder.
 Markdown files typically use extension .md
 
 
+
+
 ```yaml
 Type: String[]
 Parameter Sets: FromPath
@@ -93,13 +96,15 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Markdown
 String object containing markdown.
+
+
 
 
 ```yaml

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -5,7 +5,7 @@ schema: 2.0.0
 
 # Get-MarkdownMetadata
 ## SYNOPSIS
-Gets the markdown header metadata in the form of a hashtable.
+Gets metadata from the header of a markdown file.
 ## SYNTAX
 
 ### FromPath
@@ -19,21 +19,17 @@ Get-MarkdownMetadata -Markdown <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-PlatyPS stores metadata information in the header block of the markdown file.
-It's stored as key-value string pairs.
+The **Get-MarkdownMetadata** cmdlet gets the metadata from the header of a markdown file that is supported by PlatyPS. The command returns the metadata as a hash table.
 
-By default, platyPS stores help file name and markdown schema version.
+PlatyPS stores metadata in the header block of a markdown file as key-value pairs of strings. By default, PlatyPS stores help file name and markdown schema version.
 
-The metadata section can contain user-provided key-value string pairs to be used by external tools.
-These pairs would be ignored by [New-ExternalHelp](New-ExternalHelp.md).
+Metadata section can contain user-provided values for use with external tools. The [New-ExternalHelp](New-ExternalHelp.md) cmdlet ignores this metadata.
 
-[Get-MarkdownMetadata](Get-MarkdownMetadata.md) provides a consistent way to retrieve these key-value pairs.
-The cmdlet returns a key-value \<Dictionary\[String, String\]\> object.
 ## EXAMPLES
 
-### Example 1 (Get metadata from a file)
+### Example 1: Get metadata from a file
 ```
-PS C:\> Get-MarkdownMetadata -Path .\docs\Get-MarkdownMetadata.md
+PS C:\> Get-MarkdownMetadata -Path "".\docs\Get-MarkdownMetadata.md"
 
 Key                Value
 ---                -----
@@ -41,11 +37,11 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-Retrives metadata from a markdown file at the path provided.
-### Example 2 (Get metadata from a markdown string)
+This command retrieves metadata from a markdown file.
+### Example 2: Get metadata from a markdown string
 ```
-PS C:\> $markdown = cat -Raw .\docs\Get-MarkdownMetadata.md 
-PS C:\> Get-MarkdownMetadata -Markdown $markdown
+PS C:\> $Markdown = Get-Content -Path ".\docs\Get-MarkdownMetadata.md" -Raw
+PS C:\> Get-MarkdownMetadata -Markdown $Markdown
 
 Key                Value
 ---                -----
@@ -53,10 +49,11 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-Retrives metadata from a markdown string.
-### Example 1 (Get metadata from all files in a folder)
+The first command gets the contents of a file, and stores them in the $Markdown variable.
+The second command retrieves metadata from the string in $Metadata.
+### Example 3: Get metadata from all files in a folder
 ```
-PS C:\> Get-MarkdownMetadata .\docs
+PS C:\> Get-MarkdownMetadata -Path ".\docs"
 
 Key                Value
 ---                -----
@@ -78,60 +75,55 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-Retrives metadata from all markdown file at the directory path provided.
+This command gets metadata from each of the markdown files in the .\docs folder.
 ## PARAMETERS
 
 ### -Path
-Path to markdown file or folder.
-Markdown files typically use extension .md
+Specifies an array of paths of markdown files or folders.
 
 
 ```yaml
 Type: String[]
 Parameter Sets: FromPath
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Markdown
-String object containing markdown.
+Specifies a string that contains markdown formatted text.
 
 
 ```yaml
 Type: String
 Parameter Sets: FromMarkdownString
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
 ## OUTPUTS
 
 ### Dictionary[String, String]
-The dictionary contains key-value pairs found in the markdown metadata block.
+The cmdlet returns a **Dictionary\[String, String\]** object. The dictionary contains key-value pairs found in the markdown metadata block.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Get-MarkdownMetadata.md)
 
-
-
-
-
-
+[New-ExternalHelp](New-ExternalHelp.md)

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -1,12 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-MarkdownMetadata.md
 ---
 
 # Get-MarkdownMetadata
 ## SYNOPSIS
-Gets metadata from the header of a markdown file.
+Gets the markdown header metadata in the form of a hashtable.
 ## SYNTAX
 
 ### FromPath
@@ -20,20 +19,21 @@ Get-MarkdownMetadata -Markdown <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-MarkdownMetadata** cmdlet gets the metadata from the header of a markdown file that is supported by PlatyPS.
-The command returns the metadata as a hash table.
+PlatyPS stores metadata information in the header block of the markdown file.
+It's stored as key-value string pairs.
 
-PlatyPS stores metadata in the header block of a markdown file as key-value pairs of strings.
-By default, PlatyPS stores help file name and markdown schema version.
+By default, platyPS stores help file name and markdown schema version.
 
-Metadata section can contain user-provided values for use with external tools.
-The [New-ExternalHelp](New-ExternalHelp.md) cmdlet ignores this metadata.
+The metadata section can contain user-provided key-value string pairs to be used by external tools.
+These pairs would be ignored by [New-ExternalHelp](New-ExternalHelp.md).
 
+[Get-MarkdownMetadata](Get-MarkdownMetadata.md) provides a consistent way to retrieve these key-value pairs.
+The cmdlet returns a key-value \<Dictionary\[String, String\]\> object.
 ## EXAMPLES
 
-### Example 1: Get metadata from a file
+### Example 1 (Get metadata from a file)
 ```
-PS C:\> Get-MarkdownMetadata -Path ".\docs\Get-MarkdownMetadata.md"
+PS C:\> Get-MarkdownMetadata -Path .\docs\Get-MarkdownMetadata.md
 
 Key                Value
 ---                -----
@@ -41,11 +41,11 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-This command retrieves metadata from a markdown file.
-### Example 2: Get metadata from a markdown string
+Retrives metadata from a markdown file at the path provided.
+### Example 2 (Get metadata from a markdown string)
 ```
-PS C:\> $Markdown = Get-Content -Path ".\docs\Get-MarkdownMetadata.md" -Raw
-PS C:\> Get-MarkdownMetadata -Markdown $Markdown
+PS C:\> $markdown = cat -Raw .\docs\Get-MarkdownMetadata.md
+PS C:\> Get-MarkdownMetadata -Markdown $markdown
 
 Key                Value
 ---                -----
@@ -53,12 +53,10 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-The first command gets the contents of a file, and stores them in the $Markdown variable.
-
-The second command retrieves metadata from the string in $Metadata.
-### Example 3: Get metadata from all files in a folder
+Retrives metadata from a markdown string.
+### Example 1 (Get metadata from all files in a folder)
 ```
-PS C:\> Get-MarkdownMetadata -Path ".\docs"
+PS C:\> Get-MarkdownMetadata .\docs
 
 Key                Value
 ---                -----
@@ -80,11 +78,12 @@ external help file platyPS-help.xml
 schema             2.0.0
 ```
 
-This command gets metadata from each of the markdown files in the .\docs folder.
+Retrives metadata from all markdown file at the directory path provided.
 ## PARAMETERS
 
 ### -Path
-Specifies an array of paths of markdown files or folders.
+Path to markdown file or folder.
+Markdown files typically use extension .md
 
 
 ```yaml
@@ -94,13 +93,13 @@ Aliases:
 
 Required: True
 Position: Named
-Default value:
+Default value: 
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -Markdown
-Specifies a string that contains markdown formatted text.
+String object containing markdown.
 
 
 ```yaml
@@ -124,12 +123,9 @@ You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### Dictionary[String, String]
-The cmdlet returns a **Dictionary\[String, String\]** object.
 The dictionary contains key-value pairs found in the markdown metadata block.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Get-MarkdownMetadata.md)
-
-[New-ExternalHelp](New-ExternalHelp.md)

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Get-MarkdownMetadata.md
 ---
 
 # Get-MarkdownMetadata
@@ -123,7 +124,8 @@ You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### Dictionary[String, String]
-The cmdlet returns a **Dictionary\[String, String\]** object. The dictionary contains key-value pairs found in the markdown metadata block.
+The cmdlet returns a **Dictionary\[String, String\]** object.
+The dictionary contains key-value pairs found in the markdown metadata block.
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md
 ---
 
 # New-ExternalHelp
@@ -56,6 +57,8 @@ Path to a folder where you want to put your external help file(s).
 The name should end with a locale folder, i.e. ".\out\platyPS\en-US".
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -63,7 +66,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -75,6 +78,8 @@ It should be of the type \[System.Text.Encoding\].
 You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
 For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
 you can control BOM (Byte Order Mark) preferences with it.
+
+
 
 
 ```yaml
@@ -93,6 +98,8 @@ Accept wildcard characters: False
 Override existing files.
 
 
+
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -107,6 +114,8 @@ Accept wildcard characters: False
 
 ### -Path
 Path to markdown files or directories.
+
+
 
 
 ```yaml

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -5,8 +5,8 @@ schema: 2.0.0
 
 # New-ExternalHelp
 ## SYNOPSIS
-Create External help xml file from platyPS markdown. 
-Ship it with your module to provide [Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx) capability.
+Creates external help file based on markdown supported by PlatyPS.
+
 ## SYNTAX
 
 ```
@@ -14,17 +14,16 @@ New-ExternalHelp -Path <String[]> -OutputPath <String> [-Encoding <Encoding>] [-
 ```
 
 ## DESCRIPTION
-Create External help file from platyPS markdown.
+The **New-ExternalHelp** cmdlet creates an external help file based on markdown help files supported by PlatyPS. You can ship this with a module to provide help by using the  [Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx) cmdlet.
 
-You will get error messages if the markdown files do not follow the schema described in
-[platyPS.schema.md](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md).
+If the markdown files that you specify do not follow the PlatyPS [Schema](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md), this cmdlet returns error messages.
 ## EXAMPLES
 
-### Example 1 (Markdown folder)
+### Example 1: Create external help based on the contents of a folder
 ```
-PS C:\> New-ExternalHelp -Path .\docs -OutputPath out\platyPS\en-US
+PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\platyPS\en-US"
 
-    Directory: D:\dev\platyPS\out\platyPS\en-US
+    Directory: D:\Working\PlatyPS\out\platyPS\en-US
 
 
 Mode                LastWriteTime         Length Name
@@ -32,14 +31,14 @@ Mode                LastWriteTime         Length Name
 -a----        5/19/2016  12:32 PM          46776 platyPS-help.xml
 ```
 
-Create external help file in output path directory.
-Note that directory should include language name.
-### Example 1 (With -Force and custom encoding)
+This command creates an external help file in the specified location. This command uses the best practice that the folder name includes the locale.
+
+### Example 2: Create help that uses custom encoding
 ```
-PS C:\> New-ExternalHelp .\docs -OutputPath out\platyPS\en-US -Force -Encoding ([System.Text.Encoding]::Unicode)
+PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\PlatyPS\en-US" -Force -Encoding ([System.Text.Encoding]::Unicode)
 
 
-    Directory: D:\dev\platyPS\out\platyPS\en-US
+    Directory: D:\Working\PlatyPS\out\PlatyPS\en-US
 
 
 Mode                LastWriteTime         Length Name
@@ -47,40 +46,33 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:34 PM         132942 platyPS-help.xml
 ```
 
-Create and overwrite existing external help file in output path directory.
-Use Unicode Encoding for output file.
+This command creates an external help file in the specified location. This command specifies the *Force* parameter, therefore, it overwrites an existing file. The command specifies Unicode encoding for the created file.
 ## PARAMETERS
 
 ### -OutputPath
-Path to a folder where you want to put your external help file(s).
-The name should end with a locale folder, i.e. ".\out\platyPS\en-US".
+Specifies the path of a folder where this cmdlet saves your external help file. The folder name should end with a locale folder, as in the following example: ```.\out\PlatyPS\en-US\```.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
-Character encoding for your external help file.
-
-It should be of the type \[System.Text.Encoding\].
-You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
-For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom), 
-you can control BOM (Byte Order Mark) preferences with it.
+Specifies the character encoding for your external help file. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -90,57 +82,57 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Override existing files.
+Indicates that this cmdlet overwrites an existing file that has the same name.
 
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Path to markdown files or directories.
+Specifies an array of paths of markdown files or folders. This cmdlet creates external help based on these files and folders.
 
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a FileInfo[] object for created files.
+This cmdlet returns a **FileInfo[]** object for created files.
 ## NOTES
 
 ## RELATED LINKS
 
-[PowerShell V2 External MAML Help](https://blogs.msdn.microsoft.com/powershell/2008/12/24/powershell-v2-external-maml-help/)
-
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md)
 
+[New-ExternalHelpCab](New-ExternalHelpCab.md)
 
+[Schema](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md)
 
+[PowerShell V2 External MAML Help](https://blogs.msdn.microsoft.com/powershell/2008/12/24/powershell-v2-external-maml-help/)
 
-
-
+[Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx)

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md
 ---
 
 # New-ExternalHelp
@@ -144,5 +145,3 @@ This cmdlet returns a **FileInfo[]** object for created files.
 [Schema](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md)
 
 [PowerShell V2 External MAML Help](https://blogs.msdn.microsoft.com/powershell/2008/12/24/powershell-v2-external-maml-help/)
-
-[Get-Help]

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -1,13 +1,12 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md
 ---
 
 # New-ExternalHelp
 ## SYNOPSIS
-Creates external help file based on markdown supported by PlatyPS.
-
+Create External help xml file from platyPS markdown.
+Ship it with your module to provide [Get-Help](https://msdn.microsoft.com/en-us/library/dd878343.aspx) capability.
 ## SYNTAX
 
 ```
@@ -15,17 +14,17 @@ New-ExternalHelp -Path <String[]> -OutputPath <String> [-Encoding <Encoding>] [-
 ```
 
 ## DESCRIPTION
-The **New-ExternalHelp** cmdlet creates an external help file based on markdown help files supported by PlatyPS.
-You can ship this with a module to provide help by using the **Get-Help** cmdlet.
+Create External help file from platyPS markdown.
 
-If the markdown files that you specify do not follow the PlatyPS [Schema](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md), this cmdlet returns error messages.
+You will get error messages if the markdown files do not follow the schema described in
+[platyPS.schema.md](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md).
 ## EXAMPLES
 
-### Example 1: Create external help based on the contents of a folder
+### Example 1 (Markdown folder)
 ```
-PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\platyPS\en-US"
+PS C:\> New-ExternalHelp -Path .\docs -OutputPath out\platyPS\en-US
 
-    Directory: D:\Working\PlatyPS\out\platyPS\en-US
+    Directory: D:\dev\platyPS\out\platyPS\en-US
 
 
 Mode                LastWriteTime         Length Name
@@ -33,15 +32,14 @@ Mode                LastWriteTime         Length Name
 -a----        5/19/2016  12:32 PM          46776 platyPS-help.xml
 ```
 
-This command creates an external help file in the specified location.
-This command uses the best practice that the folder name includes the locale.
-
-### Example 2: Create help that uses custom encoding
+Create external help file in output path directory.
+Note that directory should include language name.
+### Example 1 (With -Force and custom encoding)
 ```
-PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\PlatyPS\en-US" -Force -Encoding ([System.Text.Encoding]::Unicode)
+PS C:\> New-ExternalHelp .\docs -OutputPath out\platyPS\en-US -Force -Encoding ([System.Text.Encoding]::Unicode)
 
 
-    Directory: D:\Working\PlatyPS\out\PlatyPS\en-US
+    Directory: D:\dev\platyPS\out\platyPS\en-US
 
 
 Mode                LastWriteTime         Length Name
@@ -49,14 +47,13 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:34 PM         132942 platyPS-help.xml
 ```
 
-This command creates an external help file in the specified location.
-This command specifies the *Force* parameter, therefore, it overwrites an existing file.
-The command specifies Unicode encoding for the created file.
+Create and overwrite existing external help file in output path directory.
+Use Unicode Encoding for output file.
 ## PARAMETERS
 
 ### -OutputPath
-Specifies the path of a folder where this cmdlet saves your external help file.
-The folder name should end with a locale folder, as in the following example: `.\out\PlatyPS\en-US\`.
+Path to a folder where you want to put your external help file(s).
+The name should end with a locale folder, i.e. ".\out\platyPS\en-US".
 
 
 ```yaml
@@ -66,17 +63,18 @@ Aliases:
 
 Required: True
 Position: Named
-Default value:
+Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the character encoding for your external help file.
-Specify a **System.Text.Encoding** object.
-For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
-For example, you can control Byte Order Mark (BOM) preferences.
-For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Character encoding for your external help file.
+
+It should be of the type \[System.Text.Encoding\].
+You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
+For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
+you can control BOM (Byte Order Mark) preferences with it.
 
 
 ```yaml
@@ -92,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Indicates that this cmdlet overwrites an existing file that has the same name.
+Override existing files.
 
 
 ```yaml
@@ -108,8 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of markdown files or folders.
-This cmdlet creates external help based on these files and folders.
+Path to markdown files or directories.
 
 
 ```yaml
@@ -129,19 +126,15 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### String[]
-You can pipe an array of paths to this cmdlet.
+You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo[]** object for created files.
+This cmdlet returns a FileInfo[] object for created files.
 ## NOTES
 
 ## RELATED LINKS
 
-[Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md)
-
-[New-ExternalHelpCab](New-ExternalHelpCab.md)
-
-[Schema](https://github.com/PowerShell/platyPS/blob/master/platyPS.schema.md)
-
 [PowerShell V2 External MAML Help](https://blogs.msdn.microsoft.com/powershell/2008/12/24/powershell-v2-external-maml-help/)
+
+[Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelp.md)

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelpCab.md
 ---
 
 # New-ExternalHelpCab
@@ -38,6 +39,8 @@ Generates the cab file, containing the content folder files and correctlty named
 The folder containing all of the help content that should be placed into the cab file.
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -53,6 +56,8 @@ Accept wildcard characters: False
 ### -LandingPagePath
 The path and name of the Module Markdown file containing all of the metadata required to name the cab.
 See the top of the [New-MarkdownHelp -WithLandingPage](New-MarkdownHelp.md) output for a list of all required metadata.
+
+
 
 
 ```yaml
@@ -71,6 +76,8 @@ Accept wildcard characters: False
 This is the location of the cab file and helpinfo.xml created by New-ExternalHelpCab
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -78,7 +85,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -5,7 +5,7 @@ schema: 2.0.0
 
 # New-ExternalHelpCab
 ## SYNOPSIS
-Generates a cabinet file, compressing the provided files.
+Generates generates a .cab file.
 ## SYNTAX
 
 ```
@@ -14,93 +14,87 @@ New-ExternalHelpCab -CabFilesFolder <String> -LandingPagePath <String> -OutputFo
 ```
 
 ## DESCRIPTION
-The New-ExternalHelpCab cmdlet generates a cabinet file containing all of the non-recursive content in a provided folder.
+The **New-ExternalHelpCab** cmdlet generates a .cab file that contains all the non-recursive content in a folder. This cmdlet compresses the provided files.
 
-It is reccomended to use content only provided as AboutTopics.Txt and the output from [New-ExternalHelp](New-ExternalHelp.MD)
+We recommend that you provide as content only about_ topics and the output from the [New-ExternalHelp](New-ExternalHelp.md) cmdlet to this cmdlet.
 
-Using Metadata provided in the Module MD file, the out put cab file is correctly named.
-This naming aligns it to the pattern required by the PowerShell help engine to use as updatable help.
-This metadeta is part of the module file created by [New-Markdown](New-MarkdownHelp.md) with the -WithModulePage switch. 
+This cmdlet uses metadata stored in the module markdown file to name your .cab file. This naming matches the pattern that the Windows PowerShell help system requires for use as updatable help. This metadata is part of the module file created by using the [New-MarkdownHelp](New-MarkdownHelp.md) cmdlet with the *WithModulePage* parameter.  
 
-A helpinfo.xml is also generated, or updated if existing.
-This helpinfo.xml provides help verioning and locale details to the PowerShell help engine.
+This cmdlet also generates or updates an existing helpinfo.xml file. That file provides versioning and locale details to the Windows PowerShell help system.
 ## EXAMPLES
 
-### Example 1
+### Example 1: Create a CAB file
 ```
-PS C:\> New-ExternalHelpCab -CabFilesFolder 'C:\Module\ExternalHelpContent'  -LandingPagePath 'C:\Module\SomeModuleName.md' -OutputPath 'C:\Module\Cab\'
+PS C:\> New-ExternalHelpCab -CabFilesFolder 'C:\Module\ExternalHelpContent' -LandingPagePath 'C:\Module\ModuleName.md' -OutputPath 'C:\Module\Cab\'
 ```
 
-Generates the cab file, containing the content folder files and correctlty named for updatable help, and places in the output path directory.
+This commmand creates a .cab file that contains the content folder files. The .cab file is named for updatable help based on metadata. The command places the .cab file in the output folder.
 ## PARAMETERS
 
 ### -CabFilesFolder
-The folder containing all of the help content that should be placed into the cab file.
+Specifies the folder that contains the help content that this cmdlet packages into a .cab file.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -LandingPagePath
-The path and name of the Module Markdown file containing all of the metadata required to name the cab. 
-See the top of the [New-MarkdownHelp -WithLandingPage](New-MarkdownHelp.md) output for a list of all required metadata.
+Specifies the full path of the Module Markdown file that contains all the metadata required to name the .cab file. For the required metadata, run the **New-MarkdownHelp** with the *WithLandingPage* parameter.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -OutputFolder
-This is the location of the cab file and helpinfo.xml created by New-ExternalHelpCab
+Specifies the location of the .cab file and helpinfo.xml file that this cmdlet creates.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### None
-This cmdlet does not take in input over the pipeline.
+You cannot pipe values to this cmdlet.
 ## OUTPUTS
 
 ### None
-This cmdlet does not output to the console. The only output is in the output folder specificed by the -OutputPath parameter.
+This cmdlet does not generate output. The cmldet saves its results in the output folder that the *OutputPath* parameter specifies.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelpCab.md)
 
+[New-ExternalHelp](New-ExternalHelp.MD)
 
-
-
-
-
+[New-MarkdownHelp](New-MarkdownHelp.md)

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -1,12 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelpCab.md
 ---
 
 # New-ExternalHelpCab
 ## SYNOPSIS
-Generates generates a .cab file.
+Generates a cabinet file, compressing the provided files.
 ## SYNTAX
 
 ```
@@ -15,31 +14,28 @@ New-ExternalHelpCab -CabFilesFolder <String> -LandingPagePath <String> -OutputFo
 ```
 
 ## DESCRIPTION
-The **New-ExternalHelpCab** cmdlet generates a .cab file that contains all the non-recursive content in a folder.
-This cmdlet compresses the provided files.
+The New-ExternalHelpCab cmdlet generates a cabinet file containing all of the non-recursive content in a provided folder.
 
-We recommend that you provide as content only about_ topics and the output from the [New-ExternalHelp](New-ExternalHelp.md) cmdlet to this cmdlet.
+It is reccomended to use content only provided as AboutTopics.Txt and the output from [New-ExternalHelp](New-ExternalHelp.MD)
 
-This cmdlet uses metadata stored in the module markdown file to name your .cab file.
-This naming matches the pattern that the Windows PowerShell help system requires for use as updatable help.
-This metadata is part of the module file created by using the [New-MarkdownHelp](New-MarkdownHelp.md) cmdlet with the *WithModulePage* parameter.
+Using Metadata provided in the Module MD file, the out put cab file is correctly named.
+This naming aligns it to the pattern required by the PowerShell help engine to use as updatable help.
+This metadeta is part of the module file created by [New-Markdown](New-MarkdownHelp.md) with the -WithModulePage switch.
 
-This cmdlet also generates or updates an existing helpinfo.xml file.
-That file provides versioning and locale details to the Windows PowerShell help system.
+A helpinfo.xml is also generated, or updated if existing.
+This helpinfo.xml provides help verioning and locale details to the PowerShell help engine.
 ## EXAMPLES
 
-### Example 1: Create a CAB file
+### Example 1
 ```
-PS C:\> New-ExternalHelpCab -CabFilesFolder 'C:\Module\ExternalHelpContent' -LandingPagePath 'C:\Module\ModuleName.md' -OutputPath 'C:\Module\Cab\'
+PS C:\> New-ExternalHelpCab -CmdletContentFolder 'C:\Module\ExternalHelpContent' -OutputPath 'C:\Module\Cab\' -ModuleMdPageFullPath 'C:\Module\SomeModuleName.md'
 ```
 
-This commmand creates a .cab file that contains the content folder files.
-The .cab file is named for updatable help based on metadata.
-The command places the .cab file in the output folder.
+Generates the cab file, containing the content folder files and correctlty named for updatable help, and places in the output path directory.
 ## PARAMETERS
 
 ### -CabFilesFolder
-Specifies the folder that contains the help content that this cmdlet packages into a .cab file.
+The folder containing all of the help content that should be placed into the cab file.
 
 
 ```yaml
@@ -55,8 +51,8 @@ Accept wildcard characters: False
 ```
 
 ### -LandingPagePath
-Specifies the full path of the Module Markdown file that contains all the metadata required to name the .cab file.
-For the required metadata, run **New-MarkdownHelp** with the *WithLandingPage* parameter.
+The path and name of the Module Markdown file containing all of the metadata required to name the cab.
+See the top of the [New-MarkdownHelp -WithLandingPage](New-MarkdownHelp.md) output for a list of all required metadata.
 
 
 ```yaml
@@ -72,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutputFolder
-Specifies the location of the .cab file and helpinfo.xml file that this cmdlet creates.
+This is the location of the cab file and helpinfo.xml created by New-ExternalHelpCab
 
 
 ```yaml
@@ -82,7 +78,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value:
+Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -92,18 +88,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### None
-You cannot pipe values to this cmdlet.
+This cmdlet does not take in input over the pipeline.
 ## OUTPUTS
 
 ### None
-This cmdlet does not generate output.
-The cmldet saves its results in the output folder that the *OutputPath* parameter specifies.
+This cmdlet does not output to the console. The only output is in the output folder specificed by the -OutputPath parameter.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelpCab.md)
-
-[New-ExternalHelp](New-ExternalHelp.MD)
-
-[New-MarkdownHelp](New-MarkdownHelp.md)

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-ExternalHelpCab.md
 ---
 
 # New-ExternalHelpCab
@@ -21,7 +22,7 @@ We recommend that you provide as content only about_ topics and the output from 
 
 This cmdlet uses metadata stored in the module markdown file to name your .cab file.
 This naming matches the pattern that the Windows PowerShell help system requires for use as updatable help.
-This metadata is part of the module file created by using the [New-MarkdownHelp](New-MarkdownHelp.md) cmdlet with the *WithModulePage* parameter.  
+This metadata is part of the module file created by using the [New-MarkdownHelp](New-MarkdownHelp.md) cmdlet with the *WithModulePage* parameter.
 
 This cmdlet also generates or updates an existing helpinfo.xml file.
 That file provides versioning and locale details to the Windows PowerShell help system.
@@ -95,7 +96,8 @@ You cannot pipe values to this cmdlet.
 ## OUTPUTS
 
 ### None
-This cmdlet does not generate output. The cmldet saves its results in the output folder that the *OutputPath* parameter specifies.
+This cmdlet does not generate output.
+The cmldet saves its results in the output folder that the *OutputPath* parameter specifies.
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md
 ---
 
 # New-MarkdownHelp
@@ -74,7 +75,10 @@ Mode                LastWriteTime         Length Name
 
 The first command loads the PlatyPS module into the current session by using the **Import-Module** cmdlet.
 
-The second command creates help for all the cmdlets in the PlatyPS module. It stores them in the .\docs folder. This command specifies the *Force* parameter. Therefore, it overwrites existing help markdown files that have the same name.  
+The second command creates help for all the cmdlets in the PlatyPS module.
+It stores them in the .\docs folder.
+This command specifies the *Force* parameter.
+Therefore, it overwrites existing help markdown files that have the same name.
 
 
 ### Example 3: Create help from an existing MAML file
@@ -93,7 +97,9 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:56 PM          15320 Set-PSReadlineOption.md
 ```
 
-This command creates help in markdown format for the specified help MAML file. You do not have to load the module, as in the previous example. If the module is already loaded, this command creates help based on the MAML file, not on the currently installed module.
+This command creates help in markdown format for the specified help MAML file.
+You do not have to load the module, as in the previous example.
+If the module is already loaded, this command creates help based on the MAML file, not on the currently installed module.
 
 
 ### Example 4: Create help from an existing MAML file for use in a CAB file
@@ -114,12 +120,15 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:59 PM            942 PSReadLine.md
 ```
 
-This command creates help in markdown format for the specified help MAML file, as in the previous example. This command also specifies the *WithModulePage* parameter and the *ModuleName* parameter. The command creates a file named PSReadLine.md that contains links to the other markdown files in this module and metadata that can be used to create .cab files.
+This command creates help in markdown format for the specified help MAML file, as in the previous example.
+This command also specifies the *WithModulePage* parameter and the *ModuleName* parameter.
+The command creates a file named PSReadLine.md that contains links to the other markdown files in this module and metadata that can be used to create .cab files.
 
 ## PARAMETERS
 
 ### -Command
-Specifies the name of a command in your current session. This can be any command supported by Windows PowerShell help, such as a cmdlet or a function.
+Specifies the name of a command in your current session.
+This can be any command supported by Windows PowerShell help, such as a cmdlet or a function.
 
 
 ```yaml
@@ -135,7 +144,11 @@ Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the character encoding for your markdown help files. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Specifies the character encoding for your markdown help files.
+Specify a **System.Text.Encoding** object.
+For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
+For example, you can control Byte Order Mark (BOM) preferences.
+For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
@@ -167,7 +180,9 @@ Accept wildcard characters: False
 ```
 
 ### -FwLink
-Specifies the forward link for the module page. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
+Specifies the forward link for the module page.
+This value is required for .cab file creation.
+This value is used as markdown header metadata in the module page.
 
 
 ```yaml
@@ -183,7 +198,9 @@ Accept wildcard characters: False
 ```
 
 ### -HelpVersion
-Specifies the version of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
+Specifies the version of your help.
+This value is required for .cab file creation.
+This value is used as markdown header metadata in the module page.
 
 
 ```yaml
@@ -199,7 +216,9 @@ Accept wildcard characters: False
 ```
 
 ### -Locale
-Specifies the locale of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
+Specifies the locale of your help.
+This value is required for .cab file creation.
+This value is used as markdown header metadata in the module page.
 
 
 ```yaml
@@ -231,9 +250,11 @@ Accept wildcard characters: False
 ```
 
 ### -Metadata
-Specifies metadata that this cmdlet includes in the help markdown files as a hash table of string-to-sting key-value pairs. This cmdlet writes the metadata in the header of each markdown help file.
+Specifies metadata that this cmdlet includes in the help markdown files as a hash table of string-to-sting key-value pairs.
+This cmdlet writes the metadata in the header of each markdown help file.
 
-The **New-ExternalHelp** cmdlet does not use this metadata. External tools can use this metadata.
+The **New-ExternalHelp** cmdlet does not use this metadata.
+External tools can use this metadata.
 
 
 ```yaml
@@ -265,7 +286,9 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleGuid
-Specifies the GUID of the module of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
+Specifies the GUID of the module of your help.
+This value is required for .cab file creation.
+This value is used as markdown header metadata in the module page.
 
 
 ```yaml
@@ -281,7 +304,9 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleName
-Specifies the name of the module of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
+Specifies the name of the module of your help.
+This value is required for .cab file creation.
+This value is used as markdown header metadata in the module page.
 
 
 ```yaml
@@ -313,7 +338,8 @@ Accept wildcard characters: False
 ```
 
 ### -OnlineVersionUrl
-Specifies the URL where the updatable help function downloads updated help. If you do not specify a value, the cmdlet uses an empty string.
+Specifies the URL where the updatable help function downloads updated help.
+If you do not specify a value, the cmdlet uses an empty string.
 
 
 ```yaml
@@ -345,7 +371,9 @@ Accept wildcard characters: False
 ```
 
 ### -WithModulePage
-Indicates that this cmdlet creates a module page in the output folder. This file has the name that the *ModuleName* parameter specifies. If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
+Indicates that this cmdlet creates a module page in the output folder.
+This file has the name that the *ModuleName* parameter specifies.
+If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
 
 
 ```yaml
@@ -365,7 +393,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### String[]
-You can pipe module names to this cmdlet. These are the modules from which this cmdlet creates help markdown.
+You can pipe module names to this cmdlet.
+These are the modules from which this cmdlet creates help markdown.
 
 ## OUTPUTS
 
@@ -377,8 +406,6 @@ This cmdlet returns a **FileInfo\[\]** object for created files.
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md)
-
-[Import-Module]
 
 [New-ExternalHelp](New-ExternalHelp.md)
 

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md
 ---
 
 # New-MarkdownHelp
@@ -23,9 +24,10 @@ New-MarkdownHelp -Command <String[]> [-Force] [-Metadata <Hashtable>] [-OnlineVe
 
 ### FromMaml
 ```
-New-MarkdownHelp -MamlFile <String[]> [-Force] [-Metadata <Hashtable>] -OutputFolder <String> [-NoMetadata]
- [-Encoding <Encoding>] [-WithModulePage] [-Locale <String>] [-HelpVersion <String>] [-FwLink <String>]
- [-ModuleName <String>] [-ModuleGuid <String>] [<CommonParameters>]
+New-MarkdownHelp -MamlFile <String[]> [-ConvertNotesToList] [-ConvertDoubleDashLists] [-Force]
+ [-Metadata <Hashtable>] -OutputFolder <String> [-NoMetadata] [-Encoding <Encoding>] [-WithModulePage]
+ [-Locale <String>] [-HelpVersion <String>] [-FwLink <String>] [-ModuleName <String>] [-ModuleGuid <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -126,6 +128,8 @@ Name of a command from your PowerShell session.
 
 
 
+
+
 ```yaml
 Type: String[]
 Parameter Sets: FromCommand
@@ -149,6 +153,8 @@ you can control BOM (Byte Order Mark) preferences with it.
 
 
 
+
+
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
@@ -163,6 +169,8 @@ Accept wildcard characters: False
 
 ### -Force
 Override existing files.
+
+
 
 
 
@@ -186,6 +194,8 @@ It would be used as markdown header metadata in the module page.
 
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: FromModule, FromMaml
@@ -205,6 +215,8 @@ It would be used as markdown header metadata in the module page.
 
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: FromModule, FromMaml
@@ -212,7 +224,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -220,6 +232,8 @@ Accept wildcard characters: False
 ### -Locale
 Metadata for module page, to enable cab creation.
 It would be used as markdown header metadata in the module page.
+
+
 
 
 
@@ -238,6 +252,8 @@ Accept wildcard characters: False
 
 ### -MamlFile
 Path to a MAML xml external help file.
+
+
 
 
 
@@ -262,6 +278,8 @@ It would be ignored by New-ExternalHelp, but can be used by external tools.
 
 
 
+
+
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
@@ -276,6 +294,8 @@ Accept wildcard characters: False
 
 ### -Module
 Name of the modules to be used in markdown help generation.
+
+
 
 
 
@@ -299,6 +319,8 @@ It would be used as markdown header metadata in the module page.
 
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: FromMaml
@@ -314,6 +336,8 @@ Accept wildcard characters: False
 ### -ModuleName
 Metadata for module page, to enable cab creation.
 It would be used to name module page.
+
+
 
 
 
@@ -335,6 +359,8 @@ Don't emit any metadata in generated markdown.
 
 
 
+
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -350,6 +376,8 @@ Accept wildcard characters: False
 ### -OnlineVersionUrl
 The URL where help can be downloaded using the updatable help function in PowerShell.
 Empty string would be used, if no value provided.
+
+
 
 
 ```yaml
@@ -369,6 +397,8 @@ Path to the directory to output markdown help files.
 
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -385,6 +415,8 @@ Accept wildcard characters: False
 Generate module page in the output directory.
 
 
+
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromModule, FromMaml
@@ -393,6 +425,32 @@ Aliases:
 Required: False
 Position: Named
 Default value:
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConvertNotesToList
+Add bullet list into notes section to match TechNet format.```yaml
+Type: SwitchParameter
+Parameter Sets: FromMaml
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConvertDoubleDashLists
+Convert two-hypen lists (common in MS-authored MAML) into one-hypen list (accepted in markdown).```yaml
+Type: SwitchParameter
+Parameter Sets: FromMaml
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -1,13 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md
 ---
 
 # New-MarkdownHelp
 ## SYNOPSIS
-Creates help in markdown format.
-
+Convert your existing external help into markdown or generate it from Help object.
 ## SYNTAX
 
 ### FromModule
@@ -31,34 +29,36 @@ New-MarkdownHelp -MamlFile <String[]> [-Force] [-Metadata <Hashtable>] -OutputFo
 ```
 
 ## DESCRIPTION
-The **New-MarkdownHelp** cmdlet creates help in markdown format based on a module, a command, or a file in Microsoft Assistance Markup Language (MAML) format.
+An easy way to start with platyPS.
+This cmdlet generates help stub from:
+
+-  Module.
+-  Command.
+-  External help xml (aka maml).
 ## EXAMPLES
 
-### Example 1: Create help from a command
+### Example 1 (from command)
 ```
-PS C:\> function Command03 {param([string]$Value)}
-PS C:\> New-MarkdownHelp -Command "Command03" -OutputFolder ".\docs"
+PS C:\> function foo {param([string]$bar)}
+PS C:\> New-MarkdownHelp -command foo -OutputFolder .\docs
 
 
-    Directory: D:\Working\docs
+    Directory: D:\dev\platyPS\docs
 
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        5/22/2016   6:53 PM            664 Command03.md
+-a----        5/22/2016   6:53 PM            664 foo.md
 ```
 
-The first command creates a function named Command03 by using standard Windows PowerShell syntax.
-
-The second command creates help for that stub function in the .\docs folder.
-
-### Example 2: Create help from a module
+Create stub markdown on the fly from the function foo.
+### Example 2 (from module)
 ```
-PS C:\> Import-Module -Module "PlatyPS"
-PS C:\> New-MarkdownHelp -Module "PlatyPS" -OutputFolder ".\docs" -Force
+PS C:\> Import-Module platyPS
+PS C:\> New-MarkdownHelp -module platyPS -OutputFolder .\docs-new -Force
 
 
-    Directory: D:\Working\PlatyPS\docs
+    Directory: D:\dev\platyPS\docs-new
 
 
 Mode                LastWriteTime         Length Name
@@ -73,19 +73,15 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-The first command loads the PlatyPS module into the current session by using the **Import-Module** cmdlet.
-
-The second command creates help for all the cmdlets in the PlatyPS module.
-It stores them in the .\docs folder.
-This command specifies the *Force* parameter.
-Therefore, it overwrites existing help markdown files that have the same name.
-
-
-### Example 3: Create help from an existing MAML file
+The module should be loaded in the PS Session first.
+ Markdown generated for all commands in the module.
+### Example 3 (from maml file path)
 ```
-PS C:\> New-MarkdownHelp -OutputFolder "D:\PSReadline\docs" -MamlFile 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
+PS C:\> $mamlPath = 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
+PS C:\> New-MarkdownHelp -OutputFolder .\psreadline-docs -MamlFile $mamlPath
 
-    Directory: D:\PSReadline\docs
+
+    Directory: D:\dev\platyPS\psreadline-docs
 
 
 Mode                LastWriteTime         Length Name
@@ -97,17 +93,16 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:56 PM          15320 Set-PSReadlineOption.md
 ```
 
-This command creates help in markdown format for the specified help MAML file.
-You do not have to load the module, as in the previous example.
-If the module is already loaded, this command creates help based on the MAML file, not on the currently installed module.
-
-
-### Example 4: Create help from an existing MAML file for use in a CAB file
+Create markdown help for inbox PSReadLine module.
+You don't need to load the module itself to do it.
+Only the help file would be used.
+### Example 4 (from maml file with module page)
 ```
-PS C:\> New-MarkdownHelp -OutputFolder "D:\PSReadline\docs" -MamlFile 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml' -WithModulePage  -Force -ModuleName "PSReadLine"
+PS C:\> $mamlPath = 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
+PS C:\> New-MarkdownHelp -OutputFolder .\psreadline-docs -MamlFile $mamlPath -WithModulePage  -Force -ModuleName PSReadLine
 
 
-    Directory: D:\PSReadline\docs
+    Directory: D:\dev\platyPS\psreadline-docs
 
 
 Mode                LastWriteTime         Length Name
@@ -120,15 +115,15 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:59 PM            942 PSReadLine.md
 ```
 
-This command creates help in markdown format for the specified help MAML file, as in the previous example.
-This command also specifies the *WithModulePage* parameter and the *ModuleName* parameter.
-The command creates a file named PSReadLine.md that contains links to the other markdown files in this module and metadata that can be used to create .cab files.
-
+Create markdown help for inbox PSReadLine module.
+Create a "ModulePage" with name PSReadLine.md, links to other help files
+and metadata needed for creating cab files.
 ## PARAMETERS
 
 ### -Command
-Specifies the name of a command in your current session.
-This can be any command supported by Windows PowerShell help, such as a cmdlet or a function.
+Name of a command from your PowerShell session.
+
+
 
 
 ```yaml
@@ -144,11 +139,14 @@ Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the character encoding for your markdown help files.
-Specify a **System.Text.Encoding** object.
-For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
-For example, you can control Byte Order Mark (BOM) preferences.
-For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Character encoding for your markdown help files.
+
+It should be of the type \[System.Text.Encoding\].
+You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
+For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
+you can control BOM (Byte Order Mark) preferences with it.
+
+
 
 
 ```yaml
@@ -164,7 +162,9 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Indicates that this cmdlet overwrites existing files that have the same names.
+Override existing files.
+
+
 
 
 ```yaml
@@ -180,9 +180,10 @@ Accept wildcard characters: False
 ```
 
 ### -FwLink
-Specifies the forward link for the module page.
-This value is required for .cab file creation.
-This value is used as markdown header metadata in the module page.
+Metadata for module page, to enable cab creation.
+It would be used as markdown header metadata in the module page.
+
+
 
 
 ```yaml
@@ -198,9 +199,10 @@ Accept wildcard characters: False
 ```
 
 ### -HelpVersion
-Specifies the version of your help.
-This value is required for .cab file creation.
-This value is used as markdown header metadata in the module page.
+Metadata for module page, to enable cab creation.
+It would be used as markdown header metadata in the module page.
+
+
 
 
 ```yaml
@@ -210,15 +212,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value:
+Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Locale
-Specifies the locale of your help.
-This value is required for .cab file creation.
-This value is used as markdown header metadata in the module page.
+Metadata for module page, to enable cab creation.
+It would be used as markdown header metadata in the module page.
+
+
 
 
 ```yaml
@@ -234,7 +237,9 @@ Accept wildcard characters: False
 ```
 
 ### -MamlFile
-Specifies an array of paths path of MAML xml help files.
+Path to a MAML xml external help file.
+
+
 
 
 ```yaml
@@ -250,11 +255,11 @@ Accept wildcard characters: False
 ```
 
 ### -Metadata
-Specifies metadata that this cmdlet includes in the help markdown files as a hash table of string-to-sting key-value pairs.
-This cmdlet writes the metadata in the header of each markdown help file.
+String-to-string hashtable.
+It would be writed in a header of every markdown help file.
+It would be ignored by New-ExternalHelp, but can be used by external tools.
 
-The **New-ExternalHelp** cmdlet does not use this metadata.
-External tools can use this metadata.
+
 
 
 ```yaml
@@ -270,7 +275,9 @@ Accept wildcard characters: False
 ```
 
 ### -Module
-Specifies an array of names of modules for which this cmdlet creates help in markdown format.
+Name of the modules to be used in markdown help generation.
+
+
 
 
 ```yaml
@@ -286,9 +293,10 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleGuid
-Specifies the GUID of the module of your help.
-This value is required for .cab file creation.
-This value is used as markdown header metadata in the module page.
+Metadata for module page, to enable cab creation.
+It would be used as markdown header metadata in the module page.
+
+
 
 
 ```yaml
@@ -304,9 +312,10 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleName
-Specifies the name of the module of your help.
-This value is required for .cab file creation.
-This value is used as markdown header metadata in the module page.
+Metadata for module page, to enable cab creation.
+It would be used to name module page.
+
+
 
 
 ```yaml
@@ -322,7 +331,8 @@ Accept wildcard characters: False
 ```
 
 ### -NoMetadata
-Indicates that this cmdlet does not write any metadata in the generated markdown.
+Don't emit any metadata in generated markdown.
+
 
 
 ```yaml
@@ -338,8 +348,8 @@ Accept wildcard characters: False
 ```
 
 ### -OnlineVersionUrl
-Specifies the URL where the updatable help function downloads updated help.
-If you do not specify a value, the cmdlet uses an empty string.
+The URL where help can be downloaded using the updatable help function in PowerShell.
+Empty string would be used, if no value provided.
 
 
 ```yaml
@@ -358,6 +368,7 @@ Accept wildcard characters: False
 Path to the directory to output markdown help files.
 
 
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -371,9 +382,7 @@ Accept wildcard characters: False
 ```
 
 ### -WithModulePage
-Indicates that this cmdlet creates a module page in the output folder.
-This file has the name that the *ModuleName* parameter specifies.
-If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
+Generate module page in the output directory.
 
 
 ```yaml
@@ -394,23 +403,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### String[]
 You can pipe module names to this cmdlet.
-These are the modules from which this cmdlet creates help markdown.
-
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo\[\]** object for created files.
-
+This cmdlet returns a FileInfo[] object for created files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md)
-
-[New-ExternalHelp](New-ExternalHelp.md)
-
-[Update-MarkdownHelp](Update-MarkdownHelp.md)
-
-[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
-
-[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -5,60 +5,58 @@ schema: 2.0.0
 
 # New-MarkdownHelp
 ## SYNOPSIS
-Convert your existing external help into markdown or generate it from Help object.
+Creates help in markdown format.
+
 ## SYNTAX
 
-### FromModule
+### UNNAMED_PARAMETER_SET_1
 ```
-New-MarkdownHelp -Module <String[]> [-Force] [-Metadata <Hashtable>] -OutputFolder <String> [-NoMetadata]
- [-Encoding <Encoding>] [-WithModulePage] [-Locale <String>] [-HelpVersion <String>] [-FwLink <String>]
- [<CommonParameters>]
-```
-
-### FromCommand
-```
-New-MarkdownHelp -Command <String[]> [-Force] [-Metadata <Hashtable>] [-OnlineVersionUrl <String>]
- -OutputFolder <String> [-NoMetadata] [-Encoding <Encoding>] [<CommonParameters>]
+New-MarkdownHelp -Command <String[]> [-Encoding <Encoding>] [-Force] [-Metadata <Hashtable>] [-NoMetadata]
+ [-OnlineVersionUrl <String>] -OutputFolder <String>
 ```
 
-### FromMaml
+### UNNAMED_PARAMETER_SET_2
 ```
-New-MarkdownHelp -MamlFile <String[]> [-Force] [-Metadata <Hashtable>] -OutputFolder <String> [-NoMetadata]
- [-Encoding <Encoding>] [-WithModulePage] [-Locale <String>] [-HelpVersion <String>] [-FwLink <String>]
- [-ModuleName <String>] [-ModuleGuid <String>] [<CommonParameters>]
+New-MarkdownHelp [-Encoding <Encoding>] [-Force] [-FwLink <String>] [-HelpVersion <String>] [-Locale <String>]
+ [-Metadata <Hashtable>] -Module <String[]> [-NoMetadata] -OutputFolder <String> [-WithModulePage]
+```
+
+### UNNAMED_PARAMETER_SET_3
+```
+New-MarkdownHelp [-Encoding <Encoding>] [-Force] [-FwLink <String>] [-HelpVersion <String>] [-Locale <String>]
+ -MamlFile <String[]> [-Metadata <Hashtable>] [-ModuleGuid <String>] [-ModuleName <String>] [-NoMetadata]
+ -OutputFolder <String> [-WithModulePage]
 ```
 
 ## DESCRIPTION
-An easy way to start with platyPS.
-This cmdlet generates help stub from:
-
--  Module.
--  Command.
--  External help xml (aka maml).
+The **New-MarkdownHelp** cmdlet creates help in markdown format based on a module, a command, or a file in Microsoft Assistance Markup Language (MAML) format.
 ## EXAMPLES
 
-### Example 1 (from command)
+### Example 1: Create help from a command
 ```
-PS C:\> function foo {param([string]$bar)}
-PS C:\> New-MarkdownHelp -command foo -OutputFolder .\docs
+PS C:\> function Command03 {param([string]$Value)}
+PS C:\> New-MarkdownHelp -Command "Command03" -OutputFolder ".\docs"
 
 
-    Directory: D:\dev\platyPS\docs
+    Directory: D:\Working\docs
 
 
 Mode                LastWriteTime         Length Name
 ----                -------------         ------ ----
--a----        5/22/2016   6:53 PM            664 foo.md
+-a----        5/22/2016   6:53 PM            664 Command03.md
 ```
 
-Create stub markdown on the fly from the function foo.
-### Example 2 (from module)
+The first command creates a function named Command03 by using standard Windows PowerShell syntax.
+
+The second command creates help for that stub function in the .\docs folder.
+
+### Example 2: Create help from a module
 ```
-PS C:\> Import-Module platyPS
-PS C:\> New-MarkdownHelp -module platyPS -OutputFolder .\docs-new -Force
+PS C:\> Import-Module -Module "PlatyPS"
+PS C:\> New-MarkdownHelp -Module "PlatyPS" -OutputFolder ".\docs" -Force
 
 
-    Directory: D:\dev\platyPS\docs-new
+    Directory: D:\Working\PlatyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -73,15 +71,16 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-The module should be loaded in the PS Session first.
- Markdown generated for all commands in the module.
-### Example 3 (from maml file path)
+The first command loads the PlatyPS module into the current session by using the **Import-Module** cmdlet.
+
+The second command creates help for all the cmdlets in the PlatyPS module. It stores them in the .\docs folder. This command specifies the *Force* parameter. Therefore, it overwrites existing help markdown files that have the same name.  
+
+
+### Example 3: Create help from an existing MAML file
 ```
-PS C:\> $mamlPath = 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
-PS C:\> New-MarkdownHelp -OutputFolder .\psreadline-docs -MamlFile $mamlPath
+PS C:\> New-MarkdownHelp -OutputFolder "D:\PSReadline\docs" -MamlFile 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
 
-
-    Directory: D:\dev\platyPS\psreadline-docs
+    Directory: D:\PSReadline\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -93,16 +92,15 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:56 PM          15320 Set-PSReadlineOption.md
 ```
 
-Create markdown help for inbox PSReadLine module. 
-You don't need to load the module itself to do it.
-Only the help file would be used.
-### Example 4 (from maml file with module page)
+This command creates help in markdown format for the specified help MAML file. You do not have to load the module, as in the previous example. If the module is already loaded, this command creates help based on the MAML file, not on the currently installed module.
+
+
+### Example 4: Create help from an existing MAML file for use in a CAB file
 ```
-PS C:\> $mamlPath = 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml'
-PS C:\> New-MarkdownHelp -OutputFolder .\psreadline-docs -MamlFile $mamlPath -WithModulePage  -Force -ModuleName PSReadLine
+PS C:\> New-MarkdownHelp -OutputFolder "D:\PSReadline\docs" -MamlFile 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.1\en-US\Microsoft.PowerShell.PSReadline.dll-help.xml' -WithModulePage  -Force -ModuleName "PSReadLine"
 
 
-    Directory: D:\dev\platyPS\psreadline-docs
+    Directory: D:\PSReadline\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -115,44 +113,33 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:59 PM            942 PSReadLine.md
 ```
 
-Create markdown help for inbox PSReadLine module. 
-Create a "ModulePage" with name PSReadLine.md, links to other help files
-and metadata needed for creating cab files.
+This command creates help in markdown format for the specified help MAML file, as in the previous example. This command also specifies the *WithModulePage* parameter and the *ModuleName* parameter. The command creates a file named PSReadLine.md that contains links to the other markdown files in this module and metadata that can be used to create .cab files.
+
 ## PARAMETERS
 
 ### -Command
-Name of a command from your PowerShell session.
-
-
-
+Specifies the name of a command in your current session. This can be any command supported by Windows PowerShell help, such as a cmdlet or a function.
 
 ```yaml
 Type: String[]
-Parameter Sets: FromCommand
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_1
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
-Character encoding for your markdown help files.
-
-It should be of the type \[System.Text.Encoding\].
-You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
-For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom), 
-you can control BOM (Byte Order Mark) preferences with it.
-
-
+Specifies the character encoding for your markdown help files. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -162,261 +149,226 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Override existing files.
-
-
-
+Indicates that this cmdlet overwrites existing files that have the same names.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -FwLink
-Metadata for module page, to enable cab creation.
-It would be used as markdown header metadata in the module page.
-
-
-
+Specifies the forward link for the module page. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
 
 ```yaml
 Type: String
-Parameter Sets: FromModule, FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_2, UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -HelpVersion
-Metadata for module page, to enable cab creation.
-It would be used as markdown header metadata in the module page.
-
-
-
+Specifies the version of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
 
 ```yaml
 Type: String
-Parameter Sets: FromModule, FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_2, UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Locale
-Metadata for module page, to enable cab creation.
-It would be used as markdown header metadata in the module page.
-
-
-
+Specifies the locale of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
 
 ```yaml
 Type: String
-Parameter Sets: FromModule, FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_2, UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -MamlFile
-Path to a MAML xml external help file. 
-
-
-
+Specifies an array of paths path of MAML xml help files.
 
 ```yaml
 Type: String[]
-Parameter Sets: FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Metadata
-String-to-string hashtable.
-It would be writed in a header of every markdown help file.
-It would be ignored by New-ExternalHelp, but can be used by external tools.
+Specifies metadata that this cmdlet includes in the help markdown files as a hash table of string-to-sting key-value pairs. This cmdlet writes the metadata in the header of each markdown help file.
 
-
-
+The **New-ExternalHelp** cmdlet does not use this metadata. External tools can use this metadata.
 
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Module
-Name of the modules to be used in markdown help generation.
-
-
-
+Specifies an array of names of modules for which this cmdlet creates help in markdown format.
 
 ```yaml
 Type: String[]
-Parameter Sets: FromModule
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_2
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
 ### -ModuleGuid
-Metadata for module page, to enable cab creation.
-It would be used as markdown header metadata in the module page.
-
-
+Specifies the GUID of the module of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
 
 
 ```yaml
 Type: String
-Parameter Sets: FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ModuleName
-Metadata for module page, to enable cab creation.
-It would be used to name module page.
-
-
+Specifies the name of the module of your help. This value is required for .cab file creation. This value is used as markdown header metadata in the module page.
 
 
 ```yaml
 Type: String
-Parameter Sets: FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -NoMetadata
-Don't emit any metadata in generated markdown.
-
-
+Indicates that this cmdlet does not write any metadata in the generated markdown.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -OnlineVersionUrl
-The URL where help can be downloaded using the updatable help function in PowerShell.
-Empty string would be used, if no value provided.
-
+Specifies the URL where the updatable help function downloads updated help. If you do not specify a value, the cmdlet uses an empty string.
 
 ```yaml
 Type: String
-Parameter Sets: FromCommand
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_1
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -OutputFolder
-Path to the directory to output markdown help files.
-
-
+Specifies the folder where this cmdlet creates markdown help files.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WithModulePage
-Generate module page in the output directory.
-
+Indicates that this cmdlet creates a module page in the output folder. This file has the name that the *ModuleName* parameter specifies. If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: FromModule, FromMaml
-Aliases: 
+Parameter Sets: UNNAMED_PARAMETER_SET_2, UNNAMED_PARAMETER_SET_3
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe module names to this cmdlet.
+You can pipe module names to this cmdlet. These are the modules from which this cmdlet creates help markdown.
+
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a FileInfo[] object for created files.
+This cmdlet returns a **FileInfo\[\]** object for created files.
+
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/New-MarkdownHelp.md)
 
+[Import-Module]
 
+[New-ExternalHelp](New-ExternalHelp.md)
 
+[Update-MarkdownHelp](Update-MarkdownHelp.md)
 
+[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
 
-
-
-
+[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelp.md
 ---
 
 # Update-MarkdownHelp
@@ -72,6 +73,8 @@ For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-wri
 you can control BOM (Byte Order Mark) preferences with it.
 
 
+
+
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
@@ -86,6 +89,8 @@ Accept wildcard characters: False
 
 ### -LogAppend
 Don't overwrite log file, instead append to it.
+
+
 
 
 ```yaml
@@ -105,6 +110,8 @@ Put log information into a provided file path.
 By default, VERBOSE stream is used for it.
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -119,6 +126,8 @@ Accept wildcard characters: False
 
 ### -Path
 Path to markdown files or folder.
+
+
 
 
 ```yaml

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -5,7 +5,7 @@ schema: 2.0.0
 
 # Update-MarkdownHelp
 ## SYNOPSIS
-Update platyPS markdown help files in place.
+Update PlatyPS markdown help files.
 ## SYNTAX
 
 ```
@@ -14,25 +14,24 @@ Update-MarkdownHelp [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath] <Str
 ```
 
 ## DESCRIPTION
-Update platyPS markdown help files in place.
-Files content would be alternated.
+The **Update-MarkdownHelp** cmdlet updates PlatyPS markdown help files without completely replacing the content of the files.
 
-Some parameters attributes changes over time, i.e. parameter sets, types, default value, required, etc.
+Some parameters attributes changes over time. For instance, parameter sets, types, default value, and required. The cmdlet updates markdown help to reflect those changes. It also adds placeholder text to the markdown file for any new parameter.
 
-Automatically propogate these changes to your markdown help file:
+To propagate changes to your markdown help files, do the following:
 
-- Load new version of the module in your PowerShell session.
-- Call Update-MarkdownHelp.
+- Load the new version of the module into your Windows PowerShell session.
+- Run the **Update-MarkdownHelp** cmdlet to update the files.
 - Check new parameters metadata in the markdown files.
 
-It also will contain placeholders for new parameters to speed-up your help-authoring expirience.
+
 ## EXAMPLES
 
-### Example 1 (Update all files in a folder)
+### Example 1: Update all files in a folder
 ```
-PS C:\> Update-MarkdownHelp .\docs
+PS C:\> Update-MarkdownHelp -Path ".\docs"
 
-    Directory: D:\dev\platyPS\docs
+    Directory: D:\working\PlatyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -47,12 +46,12 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-Update all markdown files is a folder with information from the 'live' commands.
-### Example 2 (Update one file and capture log)
+This command updates all markdown help files in the specified path to match the current cmdlets.
+### Example 2: Update one file and capture log
 ```
-PS C:\> Update-MarkdownHelp .\docs\Update-MarkdownHelp.md -LogPath .\my.log
+PS C:\> Update-MarkdownHelp -Path ".\docs\Update-MarkdownHelp.md" -LogPath ".\markdown.log"
 
-    Directory: D:\dev\platyPS\docs
+    Directory: D:\Working\PlatyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -60,22 +59,17 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   8:20 PM           9993 New-MarkdownHelp.md
 ```
 
-Update markdown help file and write log to "my.log" file. 
+This command updates a markdown help file. It writes log information to the markdown.log file.
 ## PARAMETERS
 
 ### -Encoding
-Character encoding for your updated markdown help files.
-
-It should be of the type \[System.Text.Encoding\].
-You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
-For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom), 
-you can control BOM (Byte Order Mark) preferences with it.
+Specifies the character encoding for your markdown help files. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -85,72 +79,71 @@ Accept wildcard characters: False
 ```
 
 ### -LogAppend
-Don't overwrite log file, instead append to it.
+Indicates that this cmdlet appends information to the log instead overwriting it.
 
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -LogPath
-Put log information into a provided file path.
-By default, VERBOSE stream is used for it.
+Specifies a file path for log information. By default, the cmdlet writes the VERBOSE stream to the log.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Path to markdown files or folder.
+Specifies an array of paths of markdown files and folders to update.
 
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a FileInfo[] object for updated files.
+This cmdlet returns a **FileInfo[]** object for updated files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelp.md)
 
+[New-MarkdownHelp](New-MarkdownHelp.md)
 
+[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
 
-
-
-
+[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -1,12 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelp.md
 ---
 
 # Update-MarkdownHelp
 ## SYNOPSIS
-Update PlatyPS markdown help files.
+Update platyPS markdown help files in place.
 ## SYNTAX
 
 ```
@@ -15,27 +14,25 @@ Update-MarkdownHelp [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath] <Str
 ```
 
 ## DESCRIPTION
-The **Update-MarkdownHelp** cmdlet updates PlatyPS markdown help files without completely replacing the content of the files.
+Update platyPS markdown help files in place.
+Files content would be alternated.
 
-Some parameters attributes changes over time.
-For instance, parameter sets, types, default value, and required.
-The cmdlet updates markdown help to reflect those changes.
-It also adds placeholder text to the markdown file for any new parameter.
+Some parameters attributes changes over time, i.e. parameter sets, types, default value, required, etc.
 
-To propagate changes to your markdown help files, do the following:
+Automatically propogate these changes to your markdown help file:
 
-- Load the new version of the module into your Windows PowerShell session.
-- Run the **Update-MarkdownHelp** cmdlet to update the files.
+- Load new version of the module in your PowerShell session.
+- Call Update-MarkdownHelp.
 - Check new parameters metadata in the markdown files.
 
-
+It also will contain placeholders for new parameters to speed-up your help-authoring expirience.
 ## EXAMPLES
 
-### Example 1: Update all files in a folder
+### Example 1 (Update all files in a folder)
 ```
-PS C:\> Update-MarkdownHelp -Path ".\docs"
+PS C:\> Update-MarkdownHelp .\docs
 
-    Directory: D:\working\PlatyPS\docs
+    Directory: D:\dev\platyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -50,12 +47,12 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-This command updates all markdown help files in the specified path to match the current cmdlets.
-### Example 2: Update one file and capture log
+Update all markdown files is a folder with information from the 'live' commands.
+### Example 2 (Update one file and capture log)
 ```
-PS C:\> Update-MarkdownHelp -Path ".\docs\Update-MarkdownHelp.md" -LogPath ".\markdown.log"
+PS C:\> Update-MarkdownHelp .\docs\Update-MarkdownHelp.md -LogPath .\my.log
 
-    Directory: D:\Working\PlatyPS\docs
+    Directory: D:\dev\platyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -63,16 +60,16 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   8:20 PM           9993 New-MarkdownHelp.md
 ```
 
-This command updates a markdown help file.
-It writes log information to the markdown.log file.
+Update markdown help file and write log to "my.log" file.
 ## PARAMETERS
 
 ### -Encoding
-Specifies the character encoding for your markdown help files.
-Specify a **System.Text.Encoding** object.
-For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
-For example, you can control Byte Order Mark (BOM) preferences.
-For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Character encoding for your updated markdown help files.
+
+It should be of the type \[System.Text.Encoding\].
+You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
+For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
+you can control BOM (Byte Order Mark) preferences with it.
 
 
 ```yaml
@@ -88,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -LogAppend
-Indicates that this cmdlet appends information to the log instead overwriting it.
+Don't overwrite log file, instead append to it.
 
 
 ```yaml
@@ -104,8 +101,8 @@ Accept wildcard characters: False
 ```
 
 ### -LogPath
-Specifies a file path for log information.
-By default, the cmdlet writes the VERBOSE stream to the log.
+Put log information into a provided file path.
+By default, VERBOSE stream is used for it.
 
 
 ```yaml
@@ -121,7 +118,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of markdown files and folders to update.
+Path to markdown files or folder.
 
 
 ```yaml
@@ -141,19 +138,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### String[]
-You can pipe an array of paths to this cmdlet.
+You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo[]** object for updated files.
+This cmdlet returns a FileInfo[] object for updated files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelp.md)
-
-[New-MarkdownHelp](New-MarkdownHelp.md)
-
-[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
-
-[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelp.md
 ---
 
 # Update-MarkdownHelp
@@ -62,7 +63,8 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   8:20 PM           9993 New-MarkdownHelp.md
 ```
 
-This command updates a markdown help file. It writes log information to the markdown.log file.
+This command updates a markdown help file.
+It writes log information to the markdown.log file.
 ## PARAMETERS
 
 ### -Encoding

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -14,16 +14,14 @@ Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath
 ```
 
 ## DESCRIPTION
-This cmdlet provides a way to update existing help and create new markdown for newly created commands.
-
-It combines Update-MarkdownHelp and New-MarkdownHelp and provides a convinient way to do a bulk update.
+The **Update-MarkdownHelpModule** cmdlet updates existing help markdown files and creates markdown files for new cmdlets in a module. This cmdlet combines functionality of the [Update-MarkdownHelp](Update-MarkdownHelp) and [New-MarkdownHelp](New-MarkdownHelp) cmdlets to perform a bulk update.
 ## EXAMPLES
 
 ### Example 1
 ```
-PS C:\> Update-MarkdownHelpModule .\docs
+PS C:\> Update-MarkdownHelpModule -Path ".\docs"
 
-    Directory: D:\dev\platyPS\docs
+    Directory: D:\Working\PlatyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -38,23 +36,17 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-Update all markdown files is a folder with information from the 'live' commands.
-Create help markdown for commands, that didn't have them before.
+This command updates all the files in the specified folder based on the cmdlets as loaded into your current session. The command creates markdown help topics for any cmdlets that are not already included in the .\docs folder.
 ## PARAMETERS
 
 ### -Encoding
-Character encoding for your updated markdown help files.
-
-It should be of the type \[System.Text.Encoding\].
-You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
-For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom), 
-you can control BOM (Byte Order Mark) preferences with it.
+Specifies the character encoding for your markdown help files. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -64,70 +56,72 @@ Accept wildcard characters: False
 ```
 
 ### -LogAppend
-Don't overwrite log file, instead append to it.
-
+Indicates that this cmdlet appends information to the log instead overwriting it.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -LogPath
-Put log information into a provided file path.
-By default, VERBOSE stream is used for it.
+Specifies a file path for log information. By default, the cmdlet writes the VERBOSE stream to the log.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Path to markdown help module folder.
-Folder should contain module page to retrive module name.
+Specifies an array of paths of markdown folders to update. The folder must contain a module page from which this cmdlet can get the module name.
 
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### System.String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a FileInfo[] object for updated and newly created files.
+This cmdlet returns a **FileInfo[]** object for updated and new files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpModule.md)
 
+[New-MarkdownHelp](New-MarkdownHelp.md)
 
+[Update-MarkdownHelp](Update-MarkdownHelp.md)
 
+[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
+
+[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpModule.md
 ---
 
 # Update-MarkdownHelpModule
@@ -51,6 +52,8 @@ For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-wri
 you can control BOM (Byte Order Mark) preferences with it.
 
 
+
+
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
@@ -65,6 +68,8 @@ Accept wildcard characters: False
 
 ### -LogAppend
 Don't overwrite log file, instead append to it.
+
+
 
 
 ```yaml
@@ -84,6 +89,8 @@ Put log information into a provided file path.
 By default, VERBOSE stream is used for it.
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -99,6 +106,8 @@ Accept wildcard characters: False
 ### -Path
 Path to markdown help module folder.
 Folder should contain module page to retrive module name.
+
+
 
 
 ```yaml

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpModule.md
 ---
 
 # Update-MarkdownHelpModule
@@ -43,7 +44,8 @@ The command creates markdown help topics for any cmdlets that are not already in
 
 ### -Encoding
 Specifies the character encoding for your markdown help files.
-Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
+Specify a **System.Text.Encoding** object.
+For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
 For example, you can control Byte Order Mark (BOM) preferences.
 For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
@@ -76,7 +78,8 @@ Accept wildcard characters: False
 ```
 
 ### -LogPath
-Specifies a file path for log information. By default, the cmdlet writes the VERBOSE stream to the log.
+Specifies a file path for log information.
+By default, the cmdlet writes the VERBOSE stream to the log.
 
 
 ```yaml
@@ -92,7 +95,8 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of markdown folders to update. The folder must contain a module page from which this cmdlet can get the module name.
+Specifies an array of paths of markdown folders to update.
+The folder must contain a module page from which this cmdlet can get the module name.
 
 
 ```yaml

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -1,7 +1,6 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpModule.md
 ---
 
 # Update-MarkdownHelpModule
@@ -15,15 +14,16 @@ Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath
 ```
 
 ## DESCRIPTION
-The **Update-MarkdownHelpModule** cmdlet updates existing help markdown files and creates markdown files for new cmdlets in a module.
-This cmdlet combines functionality of the [Update-MarkdownHelp](Update-MarkdownHelp) and [New-MarkdownHelp](New-MarkdownHelp) cmdlets to perform a bulk update.
+This cmdlet provides a way to update existing help and create new markdown for newly created commands.
+
+It combines Update-MarkdownHelp and New-MarkdownHelp and provides a convinient way to do a bulk update.
 ## EXAMPLES
 
 ### Example 1
 ```
-PS C:\> Update-MarkdownHelpModule -Path ".\docs"
+PS C:\> Update-MarkdownHelpModule .\docs
 
-    Directory: D:\Working\PlatyPS\docs
+    Directory: D:\dev\platyPS\docs
 
 
 Mode                LastWriteTime         Length Name
@@ -38,16 +38,17 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   6:54 PM           1630 Update-MarkdownHelpSchema.md
 ```
 
-This command updates all the files in the specified folder based on the cmdlets as loaded into your current session.
-The command creates markdown help topics for any cmdlets that are not already included in the .\docs folder.
+Update all markdown files is a folder with information from the 'live' commands.
+Create help markdown for commands, that didn't have them before.
 ## PARAMETERS
 
 ### -Encoding
-Specifies the character encoding for your markdown help files.
-Specify a **System.Text.Encoding** object.
-For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
-For example, you can control Byte Order Mark (BOM) preferences.
-For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Character encoding for your updated markdown help files.
+
+It should be of the type \[System.Text.Encoding\].
+You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
+For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
+you can control BOM (Byte Order Mark) preferences with it.
 
 
 ```yaml
@@ -63,7 +64,8 @@ Accept wildcard characters: False
 ```
 
 ### -LogAppend
-Indicates that this cmdlet appends information to the log instead overwriting it.
+Don't overwrite log file, instead append to it.
+
 
 ```yaml
 Type: SwitchParameter
@@ -78,8 +80,8 @@ Accept wildcard characters: False
 ```
 
 ### -LogPath
-Specifies a file path for log information.
-By default, the cmdlet writes the VERBOSE stream to the log.
+Put log information into a provided file path.
+By default, VERBOSE stream is used for it.
 
 
 ```yaml
@@ -95,8 +97,8 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of markdown folders to update.
-The folder must contain a module page from which this cmdlet can get the module name.
+Path to markdown help module folder.
+Folder should contain module page to retrive module name.
 
 
 ```yaml
@@ -116,21 +118,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String[]
-You can pipe an array of paths to this cmdlet.
+You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo[]** object for updated and new files.
+This cmdlet returns a FileInfo[] object for updated and newly created files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpModule.md)
-
-[New-MarkdownHelp](New-MarkdownHelp.md)
-
-[Update-MarkdownHelp](Update-MarkdownHelp.md)
-
-[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
-
-[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelpSchema.md
+++ b/docs/Update-MarkdownHelpSchema.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpSchema.md
 ---
 
 # Update-MarkdownHelpSchema

--- a/docs/Update-MarkdownHelpSchema.md
+++ b/docs/Update-MarkdownHelpSchema.md
@@ -1,12 +1,11 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
-online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpSchema.md
 ---
 
 # Update-MarkdownHelpSchema
 ## SYNOPSIS
-Migrates markdown help files to the latest markdown help schema.
+Upgrade markdown help from version 1.0.0 to the latest one (2.0.0).
 ## SYNTAX
 
 ```
@@ -15,18 +14,20 @@ Update-MarkdownHelpSchema [-Path] <String[]> [-OutputFolder] <String> [[-Encodin
 ```
 
 ## DESCRIPTION
-The **Update-MarkdownHelpSchema** cmdlet migrates markdown help files to the latest PlatyPS markdown help schema.
-We recommend you update to the latest schema.
+Migrate to the latest markdown help schema.
 
-As of release 0.4.0, there are two schemas: 1.0.0 and 2.0.0.
+As a release 0.4.0, there are two schemas: 1.0.0 and 2.0.0
+We highly encourage you to migrate to the latest schema.
+
+It's easlier and provides visually apealing expirience.
 ## EXAMPLES
 
 ### Example 1
 ```
-PS C:\> Update-MarkdownHelpSchema -Path ".\Examples\PSReadLine.dll-help.md" -OutputFolder ".\PSReadLine"
+PS C:\> Update-MarkdownHelpSchema .\Examples\PSReadLine.dll-help.md -OutputFolder .\PSReadLine
 
 
-    Directory: D:\Working\PlatyPS\PSReadLine
+    Directory: D:\dev\platyPS\PSReadLine
 
 
 Mode                LastWriteTime         Length Name
@@ -37,15 +38,16 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   8:47 PM          10964 Set-PSReadlineOption.md
 ```
 
-This commad upgrades the PSReadLine platyPS markdown to the latest version, which is currently 2.0.0.
+Upgrade PSReadLine platyPS markdown from version 1.0.0 to the latest one (2.0.0).
 ## PARAMETERS
 
 ### -Encoding
-Specifies the character encoding for your markdown help files.
-Specify a **System.Text.Encoding** object.
-For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
-For example, you can control Byte Order Mark (BOM) preferences.
-For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+Character encoding for created markdown help files.
+
+It should be of the type \[System.Text.Encoding\].
+You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
+For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom),
+you can control BOM (Byte Order Mark) preferences with it.
 
 
 ```yaml
@@ -61,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Indicates that this cmdlet overwrites existing files that have the same names.
+Override existing files.
 
 
 ```yaml
@@ -77,7 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutputFolder
-Specifies the folder where this cmdlet saves updated markdown help files.
+Path to the directory to output markdown help files.
 
 
 ```yaml
@@ -93,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies an array of paths of markdown files and folders to update.
+Path to markdown files or directories.
 
 
 ```yaml
@@ -113,17 +115,13 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### String[]
-You can pipe an array of paths to this cmdlet.
+You can pipe a collection of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo[]** object for updated files.
+This cmdlet returns a FileInfo[] object for created files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpSchema.md)
-
-[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
-
-[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelpSchema.md
+++ b/docs/Update-MarkdownHelpSchema.md
@@ -5,7 +5,7 @@ schema: 2.0.0
 
 # Update-MarkdownHelpSchema
 ## SYNOPSIS
-Upgrade markdown help from version 1.0.0 to the latest one (2.0.0).
+Migrates markdown help files to the latest markdown help schema.
 ## SYNTAX
 
 ```
@@ -14,20 +14,18 @@ Update-MarkdownHelpSchema [-Path] <String[]> [-OutputFolder] <String> [[-Encodin
 ```
 
 ## DESCRIPTION
-Migrate to the latest markdown help schema.
+The **Update-MarkdownHelpSchema** cmdlet migrates markdown help files to the latest PlatyPS markdown help schema. We recommend you update to the latest schema.
 
-As a release 0.4.0, there are two schemas: 1.0.0 and 2.0.0
-We highly encourage you to migrate to the latest schema.
+As of release 0.4.0, there are two schemas: 1.0.0 and 2.0.0.
 
-It's easlier and provides visually apealing expirience.
 ## EXAMPLES
 
 ### Example 1
 ```
-PS C:\> Update-MarkdownHelpSchema .\Examples\PSReadLine.dll-help.md -OutputFolder .\PSReadLine
+PS C:\> Update-MarkdownHelpSchema -Path ".\Examples\PSReadLine.dll-help.md" -OutputFolder ".\PSReadLine"
 
 
-    Directory: D:\dev\platyPS\PSReadLine
+    Directory: D:\Working\PlatyPS\PSReadLine
 
 
 Mode                LastWriteTime         Length Name
@@ -38,93 +36,88 @@ Mode                LastWriteTime         Length Name
 -a----        5/22/2016   8:47 PM          10964 Set-PSReadlineOption.md
 ```
 
-Upgrade PSReadLine platyPS markdown from version 1.0.0 to the latest one (2.0.0).
+This commad upgrades the PSReadLine platyPS markdown to the latest version, which is currently 2.0.0.
 ## PARAMETERS
 
 ### -Encoding
-Character encoding for created markdown help files.
-
-It should be of the type \[System.Text.Encoding\].
-You can control [precise details](https://msdn.microsoft.com/en-us/library/ms404377.aspx) about your encoding.
-For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom), 
-you can control BOM (Byte Order Mark) preferences with it.
+Specifies the character encoding for your markdown help files. Specify a **System.Text.Encoding** object. For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network. For example, you can control Byte Order Mark (BOM) preferences. For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
 
 
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
-Override existing files.
+Indicates that this cmdlet overwrites existing files that have the same names.
 
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -OutputFolder
-Path to the directory to output markdown help files.
+Specifies the folder where this cmdlet saves updated markdown help files.
 
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
-Default value: 
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Path to markdown files or directories.
-
+Specifies an array of paths of markdown files and folders to update.
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
-Default value: 
+Default value:
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### String[]
-You can pipe a collection of paths to this cmdlet.
+You can pipe an array of paths to this cmdlet.
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a FileInfo[] object for created files.
+This cmdlet returns a **FileInfo[]** object for updated files.
 ## NOTES
 
 ## RELATED LINKS
 
 [Online Version:](https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpSchema.md)
 
+[Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
 
-
+[Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)

--- a/docs/Update-MarkdownHelpSchema.md
+++ b/docs/Update-MarkdownHelpSchema.md
@@ -1,6 +1,7 @@
 ---
 external help file: platyPS-help.xml
 schema: 2.0.0
+online version: https://github.com/PowerShell/platyPS/blob/master/docs/Update-MarkdownHelpSchema.md
 ---
 
 # Update-MarkdownHelpSchema
@@ -50,6 +51,8 @@ For [example](http://stackoverflow.com/questions/5596982/using-powershell-to-wri
 you can control BOM (Byte Order Mark) preferences with it.
 
 
+
+
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
@@ -64,6 +67,8 @@ Accept wildcard characters: False
 
 ### -Force
 Override existing files.
+
+
 
 
 ```yaml
@@ -82,6 +87,8 @@ Accept wildcard characters: False
 Path to the directory to output markdown help files.
 
 
+
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -96,6 +103,8 @@ Accept wildcard characters: False
 
 ### -Path
 Path to markdown files or directories.
+
+
 
 
 ```yaml


### PR DESCRIPTION
This is the first part of a two part update of the PlatyPS markdown files. I ran Update-MarkdownHelp on the previous version of these files. I added the online-help metadata by hand, since I know it's supposed to be there. (I assumed Update-MarkdownHelp would add it, but it didn't.)
I'll make text changes once these are in the repo without problems. 