### PR TITLE
Forcing metadata in md files to be sorted alphabetically by key.

### DIFF
--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -81,10 +81,17 @@ namespace Markdown.MAML.Renderer
         private void AddYamlHeader(Hashtable yamlHeader)
         {
             _stringBuilder.AppendFormat("---{0}", Environment.NewLine);
+            
+            // Use a sorted dictionary to force the metadata into alphabetical order by key for consistency.
+            var sortedHeader = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (DictionaryEntry pair in yamlHeader)
             {
-                var value = pair.Value == null ? "" : pair.Value.ToString();
-                _stringBuilder.AppendFormat("{0}: {1}{2}", pair.Key.ToString(), value, Environment.NewLine);
+                sortedHeader[pair.Key.ToString()] = pair.Value == null ? "" : pair.Value.ToString();
+            }
+            
+            foreach (var pair in sortedHeader)
+            {
+                _stringBuilder.AppendFormat("{0}: {1}{2}", pair.Key, pair.Value, Environment.NewLine);
             }
 
             _stringBuilder.AppendFormat("---{0}{0}", Environment.NewLine);

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -192,14 +192,15 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
             });
 
+            // Note that the metadata should end up getting alphabetized.
             var metadata = new Hashtable();
             metadata["foo"] = "bar";
             metadata["null"] = null;
             string markdown = renderer.MamlModelToString(command, metadata);
             Assert.Equal(@"---
-schema: 2.0.0
 foo: bar
 null: 
+schema: 2.0.0
 ---
 
 # Get-Foo


### PR DESCRIPTION
We are using the platyPS module to generate the help for our Docker PowerShell project (https://github.com/Microsoft/Docker-PowerShell), and ran into this issue recently.  Since a hashtable is used for the key-value-pairs in the markdown files' metadata header, order was not guaranteed.  This means that the same module with no changes to the cmdlets could produce different markdown help files on each run of Update-MarkdownHelp, creating extra noise in git and mistakenly showing the help files as updated when in reality they are not.  Using a SortedDictionary when writing the header means that the header will be sorted alphabetically by key. This guarantees that the order will be maintained across multiple runs of the cmdlets generating the markdown files, which prevents extraneous changes to files that are otherwise unchanged.

One key scenario this enables for us is using the platyPS cmdlets during automated build and verification of pull requests to our project in order to see whether the person submitting the PR has forgotten to update help files.  Without this change, files can incorrectly register as changed due to changing order of the header, failing the automated verification and incorrectly treating the PR as if it is missing help updates.

@jterry75 @jstarks for FYI.