### PR TITLE
Resolved bug #184

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -236,6 +236,10 @@ function New-MarkdownHelp
                 
                 if($WithModulePage)
                 {
+                    if(-not $ModuleGuid)
+                    {
+                        $ModuleGuid = "00000000-0000-0000-0000-000000000000"
+                    }
                     # yeild
                     NewModuleLandingPage  -Path $OutputFolder `
                                         -ModuleName $ModuleName `


### PR DESCRIPTION
Fixed missing GUID for Microsoft.PowerShell.Core and all other modules that do not have a GUID provided.

Provides 00000000-0000-0000-0000-000000000000 if none is found.