### PR TITLE
Resolve Issue: 195, allow about topics to have yaml metadata

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1080,7 +1080,7 @@ function GetMarkdownFilesFromPath
             }
             elseif (Test-Path -PathType Container $_)
             {
-                $MarkdownFiles += Get-ChildItem $_ -Filter $filter -Exclude "about_*"
+                $MarkdownFiles += Get-ChildItem $_ -Filter $filter | WHERE {$_.BaseName -notlike "*about_*"}
             }
             else 
             {

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1080,7 +1080,7 @@ function GetMarkdownFilesFromPath
             }
             elseif (Test-Path -PathType Container $_)
             {
-                $MarkdownFiles += Get-ChildItem $_ -Filter $filter
+                $MarkdownFiles += Get-ChildItem $_ -Filter $filter -Exclude "about_*"
             }
             else 
             {

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1000,9 +1000,15 @@ function GetAboutTopicsFromPath
             [string]$AboutFilePath
         )
 
-        if((Get-Content $AboutFilePath)[1].length -gt 3)
+        $MdContent = Get-Content -raw $AboutFilePath
+        $MdParser = new-object -TypeName 'Markdown.MAML.Parser.MarkdownParser' `
+                                -ArgumentList { param([int]$current, [int]$all) 
+                                Write-Progress -Activity "Parsing markdown" -status "Progress:" -percentcomplete ($current/$all*100)}
+        $MdObject = $MdParser.ParseString($MdContent)
+
+        if($MdObject.Children[1].text.length -gt 5)
         {
-            if((Get-Content $AboutFilePath)[1].substring(3,5).ToUpper() -eq "ABOUT")
+            if($MdObject.Children[1].text.substring(0,5).ToUpper() -eq "ABOUT")
             {
                 return $true
             }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -727,4 +727,14 @@ Describe 'Create About Topic Markdown and Txt' {
         (Get-ChildItem $AboutTxtFilePath | measure).Count | Should Be 1 
         $lineWidthCheck | Should Be $true
     }
+
+    It 'Adds a yaml block to the AboutTopic and verifies buidl as expected'{
+
+        $content = Get-Content (Join-Path $output ("about_$($aboutTopicName).md"))
+        $content = ("---Yaml: Stuff---" + $content)
+        Set-Content -Value $content -Path (Join-Path $output ("about_$($aboutTopicName).md")) -Force
+
+        Test-Path (Join-Path $output ("about_$($aboutTopicName).md")) | Should Be $true
+        Get-Content (Join-Path $output ("about_$($aboutTopicName).md")) | Should Be $content
+    }
 }


### PR DESCRIPTION
Added a test and code fix to allow about topics to have a metadata block and convert into External Help