### PR TITLE
Yingda/#167 : Default parameter values should be 'none' not 'false'

### DIFF
--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -346,7 +346,7 @@ namespace Markdown.MAML.Renderer
 
             PushTag("dev:defaultValue");
 
-            if (mamlType == "SwitchParameter" && parameter.DefaultValue == null)
+            if (mamlType == "SwitchParameter" && parameter.DefaultValue == "None")
             {
                 _stringBuilder.Append("False");
             }

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -292,7 +292,7 @@ namespace Markdown.MAML.Renderer
 
                 _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Required, set.Item2.Required, Environment.NewLine);
                 _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Position, set.Item2.IsNamed() ? "Named" : set.Item2.Position, Environment.NewLine);
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Default_value, parameter.DefaultValue, Environment.NewLine);
+                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Default_value, string.IsNullOrWhiteSpace(parameter.DefaultValue) ? "None" : parameter.DefaultValue, Environment.NewLine);
                 _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Accept_pipeline_input, parameter.PipelineInput, Environment.NewLine);
                 _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Accept_wildcard_characters, parameter.Globbing, Environment.NewLine);
 


### PR DESCRIPTION
Solution:
1. Set the default value of "None" in Markdown2Renderer class when call New-MarkdownHelp
2. Meanwhile update the hard cord to ensure generate maml help file with False from "SwitchParamter" conversion when call New-ExternalHelp
