### PR TITLE
Added xmlns to the XML_PREAMBULA

### DIFF
--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -18,7 +18,7 @@ namespace Markdown.MAML.Renderer
         private Stack<string> _tagStack = new Stack<string>();
 
         public const string XML_PREAMBULA = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<helpItems schema=""maml"">
+<helpItems xmlns=""http://msh"" schema=""maml"">
 ";
         public const string COMMAND_PREAMBULA = @"<command:command xmlns:maml=""http://schemas.microsoft.com/maml/2004/10"" xmlns:command=""http://schemas.microsoft.com/maml/dev/command/2004/10"" xmlns:dev=""http://schemas.microsoft.com/maml/dev/2004/10"" xmlns:MSHelp=""http://msdn.microsoft.com/mshelp"">";
 

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -18,11 +18,11 @@ namespace Markdown.MAML.Test.EndToEnd
 ## Synopsis
 This is Synopsis
 ");
-            string[] name = GetXmlContent(maml, "/helpItems/command:command/command:details/command:name");
+            string[] name = GetXmlContent(maml, "/msh:helpItems/command:command/command:details/command:name");
             Assert.Equal(1, name.Length);
             Assert.Equal("Get-Foo", name[0]);
 
-            string[] synopsis = GetXmlContent(maml, "/helpItems/command:command/command:details/maml:description/maml:para");
+            string[] synopsis = GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal("This is Synopsis", synopsis[0]);
         }
@@ -43,7 +43,7 @@ I'm a multiline description.
 And this is my last line.
 ");
 
-            string[] description = GetXmlContent(maml, "/helpItems/command:command/maml:description/maml:para");
+            string[] description = GetXmlContent(maml, "/msh:helpItems/command:command/maml:description/maml:para");
             Assert.Equal(3, description.Length);
         }
 
@@ -59,11 +59,11 @@ This is Synopsis #hashtagNotAHeader.
 I'm description
 ");
 
-            string[] description = GetXmlContent(maml, "/helpItems/command:command/maml:description/maml:para");
+            string[] description = GetXmlContent(maml, "/msh:helpItems/command:command/maml:description/maml:para");
             Assert.Equal(1, description.Length);
             Assert.Equal("I'm description", description[0]);
 
-            string[] synopsis = GetXmlContent(maml, "/helpItems/command:command/command:details/maml:description/maml:para");
+            string[] synopsis = GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal("This is Synopsis #hashtagNotAHeader.", synopsis[0]);
         }
@@ -82,12 +82,12 @@ I'm description
 [bar](bar://bar.md)
 ");
 
-            string[] linkText = GetXmlContent(maml, "/helpItems/command:command/command:relatedLinks/maml:navigationLink/maml:linkText");
+            string[] linkText = GetXmlContent(maml, "/msh:helpItems/command:command/command:relatedLinks/maml:navigationLink/maml:linkText");
             Assert.Equal(2, linkText.Length);
             Assert.Equal("foo", linkText[0]);
             Assert.Equal("bar", linkText[1]);
 
-            string[] linkUri = GetXmlContent(maml, "/helpItems/command:command/command:relatedLinks/maml:navigationLink/maml:uri");
+            string[] linkUri = GetXmlContent(maml, "/msh:helpItems/command:command/command:relatedLinks/maml:navigationLink/maml:uri");
             Assert.Equal(2, linkUri.Length);
             Assert.Equal("", linkUri[0]); // empty, because foo.md is not a valid URI and help system will be unhappy.
             Assert.Equal("bar://bar.md", linkUri[1]); // bar://bar.md is a valid URI
@@ -340,7 +340,7 @@ This example demonstrates the process of registering a snap-in on your system an
 [about_PSSnapins]()
 
 ");
-            string[] examples = GetXmlContent(maml, "/helpItems/command:command/command:examples/command:example/dev:code");
+            string[] examples = GetXmlContent(maml, "msh:helpItems/command:command/command:examples/command:example/dev:code");
             Assert.Equal(5 + 3, examples.Length);
         }
 
@@ -358,6 +358,7 @@ This example demonstrates the process of registering a snap-in on your system an
             xmlns.AddNamespace("maml", "http://schemas.microsoft.com/maml/2004/10");
             xmlns.AddNamespace("dev", "http://schemas.microsoft.com/maml/dev/2004/10");
             xmlns.AddNamespace("MSHelp", "http://msdn.microsoft.com/mshelp");
+            xmlns.AddNamespace("msh", "http://msh");
 
             XPathNodeIterator iterator = nav.Select(xpath, xmlns);
             foreach (var i in iterator)

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -66,11 +66,11 @@ namespace Markdown.MAML.Test.Renderer
 
             string maml = renderer.MamlModelToString(new [] {command});
 
-            string[] name = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:details/command:name");
+            string[] name = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:details/command:name");
             Assert.Equal(1, name.Length);
             Assert.Equal("Get-Foo", name[0]);
 
-            string[] synopsis = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:details/maml:description/maml:para");
+            string[] synopsis = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal("This is the synopsis", synopsis[0]);
         }
@@ -108,16 +108,16 @@ namespace Markdown.MAML.Test.Renderer
 
             string maml = renderer.MamlModelToString(new[] { command });
 
-            string[] syntaxItemName = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:syntax/command:syntaxItem/maml:name");
+            string[] syntaxItemName = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:syntax/command:syntaxItem/maml:name");
             Assert.Equal(1, syntaxItemName.Length);
             Assert.Equal("Get-Foo", syntaxItemName[0]);
 
-            string[] nameSyntax = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:syntax/command:syntaxItem/command:parameter/maml:name");
+            string[] nameSyntax = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:syntax/command:syntaxItem/command:parameter/maml:name");
             Assert.Equal(2, nameSyntax.Length);
             Assert.Equal("Param1", nameSyntax[0]);
             Assert.Equal("Param2", nameSyntax[1]);
 
-            string[] nameParam = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:parameters/command:parameter/maml:name");
+            string[] nameParam = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter/maml:name");
             Assert.Equal(2, nameParam.Length);
             Assert.Equal("Param1", nameParam[0]);
             Assert.Equal("Param2", nameParam[1]);
@@ -135,7 +135,7 @@ namespace Markdown.MAML.Test.Renderer
             
             string maml = renderer.MamlModelToString(new[] { command });
 
-            string[] synopsis = EndToEndTests.GetXmlContent(maml, "/helpItems/command:command/command:details/maml:description/maml:para");
+            string[] synopsis = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal(synopsis[0], command.Synopsis);
         }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -394,7 +394,7 @@ Describe 'New-ExternalHelp' {
         $Named
     }
 
-    It "generates right order for syntax" {
+    BeforeAll {
         $a = @{
             command = 'Test-OrderFunction'
             OutputFolder = 'TestDrive:\'
@@ -402,7 +402,10 @@ Describe 'New-ExternalHelp' {
         }
 
         $file = New-MarkdownHelp @a
-        $maml = $file | New-ExternalHelp -OutputPath "TestDrive:\" -Force
+        $maml = $file | New-ExternalHelp -OutputPath "TestDrive:\TestOrderFunction.xml" -Force
+    }
+
+    It "generates right order for syntax" {
         $help = Get-HelpPreview -Path $maml 
         ($help.Syntax.syntaxItem | measure).Count | Should Be 1
         $names = $help.Syntax.syntaxItem.parameter.Name
@@ -410,6 +413,11 @@ Describe 'New-ExternalHelp' {
         $names[0] | Should Be 'First'        
         $names[1] | Should Be 'Third'
         $names[2] | Should Be 'Named'
+    }
+
+    It "checks that xmlns 'http://msh' is present" {
+        $xml = [xml] (Get-Content (Join-Path $TestDrive 'TestOrderFunction.xml'))
+        $xml.helpItems.namespaceuri | Should Be 'http://msh'
     }
 }
 


### PR DESCRIPTION
The xmlns msh = 'http://msh' is required for xpath queries of provider
help to work. Added it to the XML_PREAMBULA

This fixes #246 