### PR TITLE
Updated relatedLinks tag to correct namespace

### DIFF
--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -139,7 +139,7 @@ namespace Markdown.MAML.Renderer
 
         private void AddLinks(MamlCommand command)
         {
-            PushTag("command:relatedLinks");
+            PushTag("maml:relatedLinks");
             foreach (MamlLink Link in command.Links)
             {
                 if (Link.IsSimplifiedTextLink)


### PR DESCRIPTION
The official document from Microsoft says the relatedLinks tag is in the maml namespace as opposed to the command namespace (https://msdn.microsoft.com/en-us/library/bb736334(v=vs.85).aspx).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/260)
<!-- Reviewable:end -->
