### PR TITLE
Removing the auto increment of help version

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -880,7 +880,10 @@ function New-ExternalHelpCab
             })]
         [string] $LandingPagePath,
         [parameter(Mandatory=$true)]
-        [string] $OutputFolder
+        [string] $OutputFolder,
+
+        [parameter()]
+        [switch] $IncrementHelpVersion
     )
     begin
     {
@@ -910,8 +913,21 @@ function New-ExternalHelpCab
     $Guid = $Metadata[$script:MODULE_PAGE_GUID]
     $Locale = $Metadata[$script:MODULE_PAGE_LOCALE]
     $FwLink = $Metadata[$script:MODULE_PAGE_FW_LINK]
-    $HelpVersion = $Metadata[$script:MODULE_PAGE_HELP_VERSION]
+    $OldHelpVersion = $Metadata[$script:MODULE_PAGE_HELP_VERSION]
     
+    if($IncrementHelpVersion)
+    {
+        #IncrementHelpVersion
+        $HelpVersion = IncrementHelpVersion -HelpVersionString $OldHelpVersion
+        $MdContent = Get-Content -raw $LandingPagePath
+        $MdContent = $MdContent.Replace($OldHelpVersion,$HelpVersion)
+        Set-Content -path $LandingPagePath -value $MdContent
+    }
+    else
+    {
+        $HelpVersion = $OldHelpVersion
+    }
+
     #Create HelpInfo File
     
         #Testing the destination directories, creating if none exists.

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -910,14 +910,8 @@ function New-ExternalHelpCab
     $Guid = $Metadata[$script:MODULE_PAGE_GUID]
     $Locale = $Metadata[$script:MODULE_PAGE_LOCALE]
     $FwLink = $Metadata[$script:MODULE_PAGE_FW_LINK]
-    $OldHelpVersion = $Metadata[$script:MODULE_PAGE_HELP_VERSION]
-
-    #IncrementHelpVersion
-    $HelpVersion = IncrementHelpVersion -HelpVersionString $OldHelpVersion
-    $MdContent = Get-Content -raw $LandingPagePath
-    $MdContent = $MdContent.Replace($OldHelpVersion,$HelpVersion)
-    Set-Content -path $LandingPagePath -value $MdContent
-
+    $HelpVersion = $Metadata[$script:MODULE_PAGE_HELP_VERSION]
+    
     #Create HelpInfo File
     
         #Testing the destination directories, creating if none exists.

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -553,6 +553,14 @@ Describe 'New-ExternalHelpCab' {
             $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureVersion | Should Be "5.0.0.1"
         }
 
+        It 'validates the version is incremented when the switch is used' {
+            New-ExternalHelpCab -CabFilesFolder $CmdletContentFolder -OutputFolder $OutputPath -LandingPagePath $ModuleMdPageFullPath -IncrementHelpVersion
+            [xml] $PlatyPSHelpInfo = Get-Content  (Join-Path $OutputPath "PlatyPs_00000000-0000-0000-0000-000000000000_helpinfo.xml")
+            $PlatyPSHelpInfo | Should Not Be $null
+            $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureName | Should Be "en-US"
+            $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureVersion | Should Be "5.0.0.2"
+        }
+
         It 'Adds another help locale'{
         
             Set-Content -Path (Join-Path $OutputPath "\Source\ModuleMd\Module.md") -Value "---`r`nModule Name: PlatyPs`r`nModule Guid: 00000000-0000-0000-0000-000000000000`r`nDownload Help Link: Somesite.com`r`nHelp Version: 5.0.0.1`r`nLocale: fr-FR`r`n---" | Out-Null

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -550,7 +550,7 @@ Describe 'New-ExternalHelpCab' {
 
             $PlatyPSHelpInfo | Should Not Be $null
             $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureName | Should Be "en-US"
-            $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureVersion | Should Be "5.0.0.2"
+            $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture.UICultureVersion | Should Be "5.0.0.1"
         }
 
         It 'Adds another help locale'{


### PR DESCRIPTION
The help version is auto incremented when PlatyPS is run. This is done for
creating the cab files, so they have a higher version. The issue with this
approach is that the changed module.md file is not checked in, hence the
next time we run PlatyPS it will generate the same version as previous
run.

Fixed test that verfied auto increment of version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/269)
<!-- Reviewable:end -->
