### PR TITLE
Added functionality to have multiple locales and help versions

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -31,6 +31,7 @@ $script:MODULE_PAGE_GUID = "Module Guid"
 $script:MODULE_PAGE_LOCALE = "Locale"
 $script:MODULE_PAGE_FW_LINK = "Download Help Link"
 $script:MODULE_PAGE_HELP_VERSION = "Help Version"
+$script:MODULE_PAGE_ADDITIONAL_LOCALE = "Additional Locale"
 
 $script:MAML_ONLINE_LINK_DEFAULT_MONIKER = 'Online Version:'
 
@@ -914,6 +915,7 @@ function New-ExternalHelpCab
     $Locale = $Metadata[$script:MODULE_PAGE_LOCALE]
     $FwLink = $Metadata[$script:MODULE_PAGE_FW_LINK]
     $OldHelpVersion = $Metadata[$script:MODULE_PAGE_HELP_VERSION]
+    $AdditionalLocale = $Metadata[$script:MODULE_PAGE_ADDITIONAL_LOCALE]
     
     if($IncrementHelpVersion)
     {
@@ -976,6 +978,26 @@ function New-ExternalHelpCab
 
         #Create the HelpInfo Xml 
         MakeHelpInfoXml -ModuleName $ModuleName -GUID $Guid -HelpCulture $Locale -HelpVersion $HelpVersion -URI $FwLink -OutputFolder $OutputFolder
+
+        if($AdditionalLocale)
+        {
+            $allLocales = $AdditionalLocale -split ','
+
+            foreach($loc in $allLocales)
+            {
+                #Create the HelpInfo Xml for each locale
+                $locVersion = $Metadata["$loc Version"]
+
+                if([String]::IsNullOrEmpty($locVersion))
+                {
+                    Write-Warning ("No version found for Locale: {0}" -f $loc)
+                }
+                else
+                {
+                    MakeHelpInfoXml -ModuleName $ModuleName -GUID $Guid -HelpCulture $loc -HelpVersion $locVersion -URI $FwLink -OutputFolder $OutputFolder
+                }
+            }
+        }
     }
 }
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -563,13 +563,13 @@ Describe 'New-ExternalHelpCab' {
 
         It 'Adds another help locale'{
         
-            Set-Content -Path (Join-Path $OutputPath "\Source\ModuleMd\Module.md") -Value "---`r`nModule Name: PlatyPs`r`nModule Guid: 00000000-0000-0000-0000-000000000000`r`nDownload Help Link: Somesite.com`r`nHelp Version: 5.0.0.1`r`nLocale: fr-FR`r`n---" | Out-Null
+            Set-Content -Path (Join-Path $OutputPath "\Source\ModuleMd\Module.md") -Value "---`r`nModule Name: PlatyPs`r`nModule Guid: 00000000-0000-0000-0000-000000000000`r`nDownload Help Link: Somesite.com`r`nHelp Version: 5.0.0.1`r`nLocale: en-US`r`nAdditional Locale: fr-FR,ja-JP`r`nfr-FR Version: 1.2.3.4`r`nja-JP Version: 2.3.4.5`r`n---" | Out-Null
             New-ExternalHelpCab -CabFilesFolder $CmdletContentFolder -OutputFolder $OutputPath -LandingPagePath $ModuleMdPageFullPath
             [xml] $PlatyPSHelpInfo = Get-Content  (Join-Path $OutputPath "PlatyPs_00000000-0000-0000-0000-000000000000_helpinfo.xml")
             $Count = 0
             $PlatyPSHelpInfo.HelpInfo.SupportedUICultures.UICulture | % {$Count++}
             
-            $Count | Should Be 2
+            $Count | Should Be 3
         }
     }
 }


### PR DESCRIPTION
HelpInfoXML files can have multiple locales and have their own versions
per locale. This fix adds the functionality by expecting 'Additional
Locale' in the module.md page. Each locale version can be specified like
fr-FR Version: 1.2.3.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/271)
<!-- Reviewable:end -->
