### PR TITLE
Reverted module version change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,7 @@ Under the hood, the following tranformations happen:
 1. Make sure that `CHANGELOG.md` is up-to-date, move section from `UNRELEASED` to new section `<release name>`.
 1. Make sure platyPS help itself (content in .\docs folder) is up to date. 
    `Update-MarkdownHelp -Path .\docs` should result in no changes.
+1. Do not change the version in platyps.psd1. Git tag will update this version for release.
 1. From master, tag the release.
 1. Push tag to GitHub.
 1. Find the corresponding build on AppVeyor.

--- a/src/platyPS/platyPS.psd1
+++ b/src/platyPS/platyPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'platyPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.6'
+ModuleVersion = '0.0.1'
 
 # ID used to uniquely identify this module
 GUID = '0bdcabef-a4b7-4a6d-bf7e-d879817ebbff'


### PR DESCRIPTION
The module version needs to be generated by the git tag during the release. Reverted the change done for last release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/platyps/274)
<!-- Reviewable:end -->
