### PR TITLE
applicable tags and Merge-MarkdownHelp

### DIFF
--- a/docs/Merge-MarkdownHelp.md
+++ b/docs/Merge-MarkdownHelp.md
@@ -1,0 +1,164 @@
+---
+external help file: platyPS-help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Merge-MarkdownHelp
+
+## SYNOPSIS
+Merge multiply markdown version of the same cmdlets into a single markdown file.
+
+## SYNTAX
+
+```
+Merge-MarkdownHelp [-Path] <String[]> [-OutputPath] <String> [[-Encoding] <Encoding>]
+ [-ExplicitApplicableIfAll] [-Force] [[-MergeMarker] <String>]
+```
+
+## DESCRIPTION
+
+If we have similar modules, or different version of the same module,
+we are likely to have a lot of duplicated markdown in them.
+
+Merge-MarkdownHelp allows you to keep all of them into a single markdown files.
+It uses `applicable:` yaml metadata field to identify what versions or tags are applicable.
+It acts on two levels: for the whole cmlets and for individual parameters.
+
+Besides the inserted `applicable:` tags, the result markdown will have all the content from 
+the individual versions.
+Duplicated content would be simple ignored, and different content would be merged using **merge markers**,
+followed by a comma-separated list of applicable tags.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> Merge-MarkdownHelp -Path @('Lync server 2010\Test-CsPhoneBootstrap.md', 'Lync server 2013
+\Test-CsPhoneBootstrap.md') -OutputPath lync
+```
+
+The result file will be located at lync\Test-CsPhoneBootstrap.md
+
+### Example 1
+```
+PS C:\> Merge-MarkdownHelp -Path @('Lync server 2010\Test-CsPhoneBootstrap.md', 'Lync server 2013
+\Test-CsPhoneBootstrap.md') -OutputPath lync
+```
+
+The result file will be located at lync\Test-CsPhoneBootstrap.md
+
+## PARAMETERS
+
+### -Encoding
+Specifies the character encoding for your external help file.
+Specify a **System.Text.Encoding** object.
+For more information, see [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx) in the Microsoft Developer Network.
+For example, you can control Byte Order Mark (BOM) preferences.
+For more information, see [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom) at the Stack Overflow community.
+
+
+```yaml
+Type: Encoding
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: UTF8 without BOM
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExplicitApplicableIfAll
+Always write out full list of applicable tags.
+By default cmdlets and parameters that are present in all variations don't get an application tag.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Indicates that this cmdlet overwrites an existing file that has the same name.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MergeMarker
+String to be used as a merge text indicator.
+Applicable tag list would be included after the marker
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 3
+Default value: '!!! '
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+Specifies the path of the folder where this cmdlet creates the combined markdown help files.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Specifies an array of paths of markdown files or folders.
+This cmdlet creates combined markdown help based on these files and folders.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: True
+```
+
+## INPUTS
+
+### System.String[]
+
+
+## OUTPUTS
+
+### System.IO.FileInfo[]
+
+
+## NOTES
+
+## RELATED LINKS
+

--- a/src/Markdown.MAML/Markdown.MAML.csproj
+++ b/src/Markdown.MAML/Markdown.MAML.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Transformer\IModelTransformer.cs" />
     <Compile Include="Transformer\MamlModelMerger.cs" />
     <Compile Include="Transformer\MamlComparer.cs" />
+    <Compile Include="Transformer\MamlMultiModelMerger.cs" />
     <Compile Include="Transformer\ModelTransformerBase.cs" />
     <Compile Include="Transformer\ModelTransformerVersion2.cs" />
   </ItemGroup>

--- a/src/Markdown.MAML/Model/MAML/MamlInputOutput.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlInputOutput.cs
@@ -9,9 +9,24 @@ namespace Markdown.MAML.Model.MAML
     /// <summary>
     /// This class represent Input and Output properties for MAML.
     /// </summary>
-    public class MamlInputOutput
+    public class MamlInputOutput : IEquatable<MamlInputOutput>
     {
         public string TypeName { get; set; }
         public string Description { get; set; }
+
+        bool IEquatable<MamlInputOutput>.Equals(MamlInputOutput other)
+        {
+            if (!StringComparer.OrdinalIgnoreCase.Equals(other.TypeName, this.TypeName))
+            {
+                return false;
+            }
+
+            if (!StringComparer.OrdinalIgnoreCase.Equals(other.Description, this.Description))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Markdown.MAML/Model/MAML/MamlLink.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlLink.cs
@@ -9,7 +9,7 @@ namespace Markdown.MAML.Model.MAML
     /// <summary>
     /// This class represents the related links properties for MAML
     /// </summary>
-    public class MamlLink
+    public class MamlLink : IEquatable<MamlLink>
     {
         /// <summary>
         /// This is a workaround for PreserveFormatting
@@ -26,6 +26,21 @@ namespace Markdown.MAML.Model.MAML
         public MamlLink(bool isSimplifiedTextLink)
         {
             this.IsSimplifiedTextLink = isSimplifiedTextLink;
+        }
+
+        bool IEquatable<MamlLink>.Equals(MamlLink other)
+        {
+            if (!StringComparer.OrdinalIgnoreCase.Equals(other.LinkName, this.LinkName))
+            {
+                return false;
+            }
+
+            if (!StringComparer.OrdinalIgnoreCase.Equals(other.LinkUri, this.LinkUri))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Markdown.MAML/Model/MAML/MamlSyntax.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlSyntax.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Markdown.MAML.Model.MAML
 {
-    public class MamlSyntax
+    public class MamlSyntax : IEquatable<MamlSyntax>
     {
         public MamlSyntax()
         {
@@ -22,5 +22,29 @@ namespace Markdown.MAML.Model.MAML
         public List<MamlParameter> Parameters { get { return _parameters; } }
 
         private List<MamlParameter> _parameters = new List<MamlParameter>();
+
+        bool IEquatable<MamlSyntax>.Equals(MamlSyntax other)
+        {
+            if (!StringComparer.OrdinalIgnoreCase.Equals(other.ParameterSetName, this.ParameterSetName))
+            {
+                return false;
+            }
+
+            // This is not 100% accurate, we just compare parameter names here
+            var names1 = this.Parameters.Select(p => p.Name).ToList();
+            var names2 = other.Parameters.Select(p => p.Name).ToList();
+
+            if (names1.Count != names2.Count)
+            {
+                return false;
+            }
+
+            if (names1.Except(names2).Any())
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Markdown.MAML/Model/MAML/MamlSyntax.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlSyntax.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Markdown.MAML.Model.MAML
 {
-    public class MamlSyntax : IEquatable<MamlSyntax>
+    public class MamlSyntax
     {
         public MamlSyntax()
         {
@@ -22,29 +22,5 @@ namespace Markdown.MAML.Model.MAML
         public List<MamlParameter> Parameters { get { return _parameters; } }
 
         private List<MamlParameter> _parameters = new List<MamlParameter>();
-
-        bool IEquatable<MamlSyntax>.Equals(MamlSyntax other)
-        {
-            if (!StringComparer.OrdinalIgnoreCase.Equals(other.ParameterSetName, this.ParameterSetName))
-            {
-                return false;
-            }
-
-            // This is not 100% accurate, we just compare parameter names here
-            var names1 = this.Parameters.Select(p => p.Name).ToList();
-            var names2 = other.Parameters.Select(p => p.Name).ToList();
-
-            if (names1.Count != names2.Count)
-            {
-                return false;
-            }
-
-            if (names1.Except(names2).Any())
-            {
-                return false;
-            }
-
-            return true;
-        }
     }
 }

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -206,7 +206,16 @@ namespace Markdown.MAML.Renderer
                 {
                     if (StringComparer.OrdinalIgnoreCase.Equals(parameterName, param.Name))
                     {
-                        result[syntax.ParameterSetName] = param;
+                        if (string.IsNullOrEmpty(syntax.ParameterSetName))
+                        {
+                            // Note (vors) : I guess that means it's applicable to all parameter sets,
+                            // but it's hard to tell anymore...
+                            result[ModelTransformerVersion2.ALL_PARAM_SETS_MONIKER] = param;
+                        }
+                        else
+                        {
+                            result[syntax.ParameterSetName] = param;
+                        }
                         // there could be only one parameter in the param set with the same name
                         break;
                     }

--- a/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
@@ -1,0 +1,207 @@
+﻿using Markdown.MAML.Model.MAML;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Markdown.MAML.Transformer
+{
+    /// <summary>
+    /// Model merger that's capable of combining few models at once.
+    /// It's useful for scenarios, when you want to assign applicable tags to parameters.
+    /// </summary>
+    public class MamlMultiModelMerger
+    {
+        private Action<string> _infoCallback;
+        private bool _ignoreTagsIfAllApplicable;
+        private string _mergeMarker;
+
+        public MamlMultiModelMerger() : this(null, true) { }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="infoCallback">Report string information to some channel</param>
+        /// <param name="ignoreTagsIfAllApplicable">if True merger will skip adding applicable tags if it's applicable to all</param>
+        public MamlMultiModelMerger(Action<string> infoCallback, bool ignoreTagsIfAllApplicable, string mergeMarker = "!!!!!! ")
+        {
+            _infoCallback = infoCallback;
+            _ignoreTagsIfAllApplicable = ignoreTagsIfAllApplicable;
+            _mergeMarker = mergeMarker;
+        }
+
+        public MamlCommand Merge(Dictionary<string, MamlCommand> applicableTag2Model)
+        {
+            if (applicableTag2Model.Count == 0)
+            {
+                throw new ArgumentException("applicableTag2Model");
+            }
+
+            var tagsModel = applicableTag2Model.ToList();
+
+            // just take one model to use name from it and such
+            var referenceModel = applicableTag2Model.First().Value;
+
+            MamlCommand result = null;
+            result = new MamlCommand()
+            {
+                Name = referenceModel.Name,
+                Synopsis = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Synopsis)),
+                Description = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Description)),
+                Notes = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Notes)),
+                Extent = referenceModel.Extent
+            };
+
+            // post all links, exclude dups
+            result.Links.AddRange(MergeEntityList(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Links)));
+
+            MergeExamples(result, applicableTag2Model);
+
+            result.Inputs.AddRange(MergeEntityList(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Inputs)));
+            result.Outputs.AddRange(MergeEntityList(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Outputs)));
+
+            MergeParameters(result, applicableTag2Model);
+            return result;
+        }
+
+        /// <summary>
+        /// Merge entities, exclude duplicates and preserve the order.
+        /// </summary>
+        /// <param name="links"></param>
+        /// <returns></returns>
+        private List<TEntity> MergeEntityList<TEntity>(Dictionary<string, List<TEntity>> applicableTag2Model) 
+            where TEntity : IEquatable<TEntity>
+        {
+            List<TEntity> result = new List<TEntity>();
+            foreach(var pair in applicableTag2Model)
+            {
+                foreach (var candidate in pair.Value)
+                {
+                    // this cycle can be optimized but that's fine
+                    bool found = false; 
+                    foreach (var added in result)
+                    {
+                        if (added.Equals(candidate))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        result.Add(candidate);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Combine examples together. Don't perform any reduction, but group the examples after each other and add tag name to the title.
+        /// TODO can we combine examples better perhaps?
+        /// </summary>
+        /// <param name="result"></param>
+        /// <param name="applicableTag2Model"></param>
+        private void MergeExamples(MamlCommand result, Dictionary<string, MamlCommand> applicableTag2Model)
+        {
+            int max = applicableTag2Model.Select(pair => pair.Value.Examples.Count).Max();
+            for (int i = 0; i < max; i++)
+            {
+                foreach (var pair in applicableTag2Model)
+                {
+                    if (pair.Value.Examples.Count > i)
+                    {
+                        var example = pair.Value.Examples.ElementAt(i);
+                        example.Title += string.Format(" ({0})", pair.Key);
+                        result.Examples.Add(example);
+                    }
+                }
+            }
+        }
+
+        private MamlParameter FindParameterByName(string name, IEnumerable<MamlParameter> list)
+        {
+            return list.FirstOrDefault(x => StringComparer.OrdinalIgnoreCase.Equals(name, x.Name));
+        }
+
+        private void MergeParameters(MamlCommand result, Dictionary<string, MamlCommand> applicableTag2Model)
+        {
+            // First handle syntax.
+            // TODO: we can do it better probably
+            var tagsModel = applicableTag2Model.ToList();
+            result.Syntax.AddRange(MergeEntityList(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Syntax)));
+
+            // Then merge individual parameters
+
+            var allNames = tagsModel.SelectMany(pair => pair.Value.Parameters).Select(p => p.Name).Distinct().ToList();
+            foreach (string name in allNames)
+            {
+                Dictionary<string, MamlParameter> paramsToMerge = new Dictionary<string, MamlParameter>();
+                foreach (var pair in tagsModel)
+                {
+                    MamlParameter candidate = FindParameterByName(name, pair.Value.Parameters);
+                    if (candidate != null)
+                    {
+                        paramsToMerge[pair.Key] = candidate;
+                    }
+                }
+
+                string newDescription = MergeText(paramsToMerge.ToDictionary(pair => pair.Key, pair => pair.Value.Description));
+                var newParameter = paramsToMerge.First().Value.Clone();
+                newParameter.Description = newDescription;
+                if (paramsToMerge.Count != applicableTag2Model.Count || !this._ignoreTagsIfAllApplicable)
+                {
+                    // we should not update applicable tags, if it's applicable to everything and not explicitly specified
+                    newParameter.Applicable = paramsToMerge.Select(p => p.Key).ToArray();
+                }
+
+                result.Parameters.Add(newParameter);
+            }
+        }
+
+        /// <summary>
+        /// Merges text attributed with tags into a single representation
+        /// </summary>
+        private string MergeText(Dictionary<string, string> applicableTag2Text)
+        {
+            var reverseMap = new Dictionary<string, List<string>>();
+            foreach (var pair in applicableTag2Text)
+            {
+                string pretty = pair.Value != null ? pair.Value.Trim() : "";
+                List<string> tags;
+                if (!reverseMap.TryGetValue(pretty, out tags))
+                {
+                    tags = new List<string>();
+                    reverseMap[pretty] = tags;
+                }
+                tags.Add(pair.Key);
+            }
+
+            if (reverseMap.Count == 1)
+            {
+                return reverseMap.Keys.First();
+            }
+
+            var result = new StringBuilder();
+            foreach (var pair in reverseMap)
+            {
+                var tagsString = string.Join(", ", pair.Value);
+                result.AppendFormat("{0}{1}{2}{2}{3}{2}{2}", _mergeMarker, tagsString, Environment.NewLine, pair.Key);
+            }
+
+            return result.ToString().Trim();
+        }
+
+        private void Report(string format, params object[] objects)
+        {
+            if (_infoCallback != null)
+            {
+                _infoCallback.Invoke(string.Format(format, objects));
+            }
+        }
+    }
+
+
+}

--- a/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
@@ -1,7 +1,9 @@
 ﻿using Markdown.MAML.Model.MAML;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Management.Automation;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -28,6 +30,37 @@ namespace Markdown.MAML.Transformer
             _infoCallback = infoCallback;
             _ignoreTagsIfAllApplicable = ignoreTagsIfAllApplicable;
             _mergeMarker = mergeMarker;
+        }
+
+        /// <summary>
+        /// Facade for Merge method that's easier to call from PowerShell
+        /// </summary>
+        /// <param name="applicableTag2Model"></param>
+        /// <returns></returns>
+        public MamlCommand MergePS(Hashtable applicableTag2Model)
+        {
+            Dictionary<string, MamlCommand> dict = new Dictionary<string, MamlCommand>();
+            foreach (DictionaryEntry pair in applicableTag2Model)
+            {
+                MamlCommand value;
+                if (pair.Value is PSObject)
+                {
+                    value = (pair.Value as PSObject).BaseObject as MamlCommand;
+                }
+                else
+                {
+                    value = pair.Value as MamlCommand;
+                }
+
+                if (value == null)
+                {
+                    throw new ArgumentException("Value of hashtable cannot be casted to MamlCommand");
+                }
+
+                dict[pair.Key.ToString()] = pair.Value as MamlCommand;
+            }
+
+            return this.Merge(dict);
         }
 
         public MamlCommand Merge(Dictionary<string, MamlCommand> applicableTag2Model)

--- a/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
@@ -263,7 +263,7 @@ namespace Markdown.MAML.Transformer
             var reverseMap = new Dictionary<string, List<string>>();
             foreach (var pair in applicableTag2Text)
             {
-                string pretty = pair.Value != null ? pair.Value.Trim() : "";
+                string pretty = pair.Value != null ? pair.Value : "";
                 List<string> tags;
                 if (!reverseMap.TryGetValue(pretty, out tags))
                 {

--- a/src/platyPS/platyPS.psd1
+++ b/src/platyPS/platyPS.psd1
@@ -73,9 +73,9 @@ FunctionsToExport = @(
     'Get-HelpPreview',
     'New-ExternalHelpCab',
     'Update-MarkdownHelp',
-    'Update-MarkdownHelpSchema',
     'Update-MarkdownHelpModule',
-    'New-MarkdownAboutHelp'
+    'New-MarkdownAboutHelp',
+    'Merge-MarkdownHelp'
 )
 
 # Cmdlets to export from this module

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -438,7 +438,9 @@ function Merge-MarkdownHelp
 
         [Switch]$IgnoreTagIfAllApplicable,
 
-        [Switch]$Force
+        [Switch]$Force,
+
+        [string]$MergeMarker = "!!! "
     )
 
     begin
@@ -515,7 +517,7 @@ function Merge-MarkdownHelp
                 $newMetadata = @{}
             }
 
-            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, $IgnoreTagIfAllApplicable
+            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, $IgnoreTagIfAllApplicable, $MergeMarker
             $newModel = $merger.MergePS($dict)
 
             $md = ConvertMamlModelToMarkdown -mamlCommand $newModel -metadata $newMetadata -PreserveFormatting

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -436,7 +436,7 @@ function Merge-MarkdownHelp
 
         [System.Text.Encoding]$Encoding = $script:UTF8_NO_BOM,
 
-        [Switch]$IgnoreTagIfAllApplicable,
+        [Switch]$ExplicitApplicableIfAll,
 
         [Switch]$Force,
 
@@ -508,16 +508,16 @@ function Merge-MarkdownHelp
             }
 
             $tags = $dict.Keys
-            if (($allTags | measure-object).Count -gt ($tags | measure-object).Count -or $IgnoreTagIfAllApplicable)
+            if (($allTags | measure-object).Count -gt ($tags | measure-object).Count -or $ExplicitApplicableIfAll)
             {
-                $newMetadata = @{ $script:APPLICABLE_YAML_HEADER = [string]::Join(", ", $tags) }
+                $newMetadata = @{ $script:APPLICABLE_YAML_HEADER = $tags -join ', ' }
             }
             else
             {
                 $newMetadata = @{}
             }
 
-            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, $IgnoreTagIfAllApplicable, $MergeMarker
+            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, $ExplicitApplicableIfAll, $MergeMarker
             $newModel = $merger.MergePS($dict)
 
             $md = ConvertMamlModelToMarkdown -mamlCommand $newModel -metadata $newMetadata -PreserveFormatting

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -517,7 +517,7 @@ function Merge-MarkdownHelp
                 $newMetadata = @{}
             }
 
-            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, $ExplicitApplicableIfAll, $MergeMarker
+            $merger = New-Object Markdown.MAML.Transformer.MamlMultiModelMerger -ArgumentList $null, !$ExplicitApplicableIfAll, $MergeMarker
             $newModel = $merger.MergePS($dict)
 
             $md = ConvertMamlModelToMarkdown -mamlCommand $newModel -metadata $newMetadata -PreserveFormatting

--- a/test/Markdown.MAML.Test/Markdown.MAML.Test.csproj
+++ b/test/Markdown.MAML.Test/Markdown.MAML.Test.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Transformer\MamlModelMergerTests.cs" />
     <Compile Include="Parser\ParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Transformer\MamlMultiModelMergerTests.cs" />
     <Compile Include="Transformer\ParserAndTransformerTestsV2.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
@@ -1,0 +1,299 @@
+﻿using Markdown.MAML.Model.MAML;
+using Markdown.MAML.Transformer;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Markdown.MAML.Test.Transformer
+{
+    public class MamlMultiModelMergerTests
+    {
+        [Fact]
+        public void Merge3SimpleModels()
+        {
+            var merger = new MamlMultiModelMerger(null, false, "! ");
+            var input = new Dictionary<string, MamlCommand>();
+            input["First"] = GetModel1();
+            input["Second"] = GetModel2();
+            input["Third"] = GetModel3();
+
+            var result = merger.Merge(input);
+
+            Assert.Equal(result.Synopsis, @"! First, Second
+
+This is the synopsis
+
+! Third
+
+This is the synopsis 3");
+
+            Assert.Equal(result.Description, "This is a long description.\r\nWith two paragraphs.");
+
+            Assert.Equal(result.Notes, @"! First
+
+This is a multiline note.
+Second line.
+First Command
+
+! Second
+
+This is a multiline note.
+Second line.
+Second Command
+
+! Third
+
+This is a multiline note.
+Second line.
+Third Command");
+
+            // Links
+            Assert.Equal(2, result.Links.Count);
+            Assert.Equal("", result.Links.ElementAt(0).LinkName);
+            Assert.Equal("foo", result.Links.ElementAt(1).LinkName);
+
+            // Examples
+            Assert.Equal(2, result.Examples.Count);
+            Assert.Equal("Example 1 (Second)", result.Examples.ElementAt(0).Title);
+            Assert.Equal("Example 1 (Third)", result.Examples.ElementAt(1).Title);
+
+            // Inputs
+            Assert.Equal(2, result.Inputs.Count);
+            Assert.Equal("String", result.Inputs.ElementAt(0).TypeName);
+            Assert.Equal("Foo", result.Inputs.ElementAt(0).Description);
+            Assert.Equal("String", result.Inputs.ElementAt(1).TypeName);
+            Assert.Equal("Foo 2", result.Inputs.ElementAt(1).Description);
+
+            // Output
+            Assert.Equal(1, result.Outputs.Count);
+            Assert.Equal("String", result.Outputs.ElementAt(0).TypeName);
+            Assert.Equal(null, result.Outputs.ElementAt(0).Description);
+
+            // Syntax
+            Assert.Equal(3, result.Syntax.Count);
+            Assert.Equal("ByName", result.Syntax.ElementAt(0).ParameterSetName);
+            Assert.Equal("ByName", result.Syntax.ElementAt(1).ParameterSetName);
+            Assert.Equal("BySomethingElse", result.Syntax.ElementAt(2).ParameterSetName);
+
+            // Parameters
+            Assert.Equal(2, result.Parameters.Count);
+
+            Assert.Equal("Name", result.Parameters[0].Name);
+            Assert.Equal(new string[] { "First", "Second", "Third" }, result.Parameters[0].Applicable);
+
+            Assert.Equal("Remove", result.Parameters[1].Name);
+            Assert.Equal(new string[] { "Third" }, result.Parameters[1].Applicable);
+        }
+
+
+        private MamlCommand GetModel1()
+        {
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Get-Foo",
+                Synopsis = "This is the synopsis",
+                Description = "This is a long description.\r\nWith two paragraphs.",
+                Notes = "This is a multiline note.\r\nSecond line.\r\nFirst Command"
+            };
+
+            command.Links.Add(new MamlLink()
+            {
+                LinkName = "", // if name is empty, it would be populated with uri
+                LinkUri = "http://foo.com"
+            });
+
+            command.Inputs.Add(new MamlInputOutput()
+            {
+                TypeName = "String",
+                Description = "Foo"
+
+            }
+            );
+
+            command.Outputs.Add(new MamlInputOutput()
+            {
+                TypeName = "String",
+                Description = null
+            }
+            );
+
+            var parameterName = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Name",
+                Required = true,
+                Description = "Parameter Description.",
+                VariableLength = true,
+                Globbing = true,
+                PipelineInput = "True (ByValue)",
+                Position = "1",
+                DefaultValue = "trololo",
+                Aliases = new string[] { "GF", "Foos", "Do" },
+            };
+
+            command.Parameters.Add(parameterName);
+
+            var syntax1 = new MamlSyntax()
+            {
+                ParameterSetName = "ByName",
+            };
+            syntax1.Parameters.Add(parameterName);
+            command.Syntax.Add(syntax1);
+
+            return command;
+        }
+
+        private MamlCommand GetModel2()
+        {
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Get-Foo",
+                Synopsis = "This is the synopsis",
+                Description = "This is a long description.\r\nWith two paragraphs.",
+                Notes = "This is a multiline note.\r\nSecond line.\r\nSecond Command"
+            };
+
+            command.Links.Add(new MamlLink()
+            {
+                LinkName = "", // if name is empty, it would be populated with uri
+                LinkUri = "http://foo.com"
+            });
+
+            command.Links.Add(new MamlLink()
+            {
+                LinkName = "foo",
+                LinkUri = ""
+            });
+
+            command.Examples.Add(new MamlExample()
+            {
+                Title = "Example 1",
+                Code = "PS:> Get-Help -YouNeedIt",
+                Remarks = "This does stuff!"
+            }
+            );
+
+            command.Inputs.Add(new MamlInputOutput()
+            {
+                TypeName = "String",
+                Description = "Foo"
+
+            }
+            );
+
+            var parameterName = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Name",
+                Required = true,
+                Description = "Parameter Description.",
+                VariableLength = true,
+                Globbing = true,
+                PipelineInput = "True (ByValue)",
+                Position = "1",
+                DefaultValue = "trololo",
+                Aliases = new string[] { "GF", "Foos", "Do" },
+            };
+
+            command.Parameters.Add(parameterName);
+
+            var syntax1 = new MamlSyntax()
+            {
+                ParameterSetName = "ByName",
+            };
+            syntax1.Parameters.Add(parameterName);
+            command.Syntax.Add(syntax1);
+
+            return command;
+        }
+
+        private MamlCommand GetModel3()
+        {
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Get-Foo",
+                Synopsis = "This is the synopsis 3",
+                Description = "This is a long description.\r\nWith two paragraphs.",
+                Notes = "This is a multiline note.\r\nSecond line.\r\nThird Command"
+            };
+
+            command.Links.Add(new MamlLink()
+            {
+                LinkName = "foo",
+                LinkUri = ""
+            });
+
+            command.Examples.Add(new MamlExample()
+            {
+                Title = "Example 1",
+                Code = "PS:> Get-Help -YouNeedIt",
+                Remarks = "This does stuff too!"
+            }
+            );
+
+            command.Inputs.Add(new MamlInputOutput()
+            {
+                TypeName = "String",
+                Description = "Foo 2"
+
+            }
+            );
+
+            command.Outputs.Add(new MamlInputOutput()
+            {
+                TypeName = "String",
+                Description = null
+            }
+            );
+
+            var parameterName = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Name",
+                Required = true,
+                Description = "Parameter Description.",
+                VariableLength = true,
+                Globbing = true,
+                PipelineInput = "True (ByValue)",
+                Position = "1",
+                DefaultValue = "trololo",
+                Aliases = new string[] { "GF", "Foos", "Do" },
+            };
+
+            var parameterRemoved = new MamlParameter()
+            {
+                Type = "int",
+                Name = "Remove",
+                Required = true,
+                Description = "Parameter Description 2.",
+                VariableLength = true,
+                Globbing = true,
+                PipelineInput = "True (ByValue)",
+                Position = "2",
+                DefaultValue = "dodododo",
+                Aliases = new string[] { "Pa1", "RemovedParam", "Gone" },
+            };
+
+            command.Parameters.Add(parameterName);
+            command.Parameters.Add(parameterRemoved);
+
+            var syntax1 = new MamlSyntax()
+            {
+                ParameterSetName = "ByName",
+            };
+            syntax1.Parameters.Add(parameterName);
+            syntax1.Parameters.Add(parameterRemoved);
+            command.Syntax.Add(syntax1);
+
+            var syntax2 = new MamlSyntax()
+            {
+                ParameterSetName = "BySomethingElse",
+                IsDefault = true
+            };
+            syntax2.Parameters.Add(parameterName);
+            command.Syntax.Add(syntax2);
+
+            return command;
+        }
+    }
+}

--- a/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
@@ -336,6 +336,10 @@ Third Command
 
             var renderer = new MarkdownV2Renderer(MAML.Parser.ParserMode.FormattingPreserve);
             string markdown = renderer.MamlModelToString(result, true);
+
+            int yamlLinesCount = markdown.Split('\n').Select(s => s.Trim()).Where(s => s.Equals("```yaml")).Count();
+            // verify that ```yaml are all on a separate line
+            Assert.Equal(2, yamlLinesCount);
         }
 
         private MamlCommand GetModel1()
@@ -353,7 +357,7 @@ Third Command
                 Type = "String",
                 Name = "Name1",
                 Required = true,
-                Description = "Parameter Description.",
+                Description = "Parameter Description.\r\n",
                 VariableLength = true,
                 Globbing = true,
                 PipelineInput = "True (ByValue)",
@@ -386,7 +390,7 @@ Third Command
                 Type = "String",
                 Name = "Name2",
                 Required = true,
-                Description = "Parameter Description.",
+                Description = "Parameter Description.\r\n",
                 VariableLength = true,
                 Globbing = true,
                 PipelineInput = "True (ByValue)",

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -1100,4 +1100,33 @@ Describe 'Merge-MarkdownHelp' {
             ($helpNew2 | Out-String) | Should Be ($help2 | Out-String)
         }
     }
+
+    Context 'two file' {
+        function global:Test-PlatyPSMergeFunction1() {}
+        function global:Test-PlatyPSMergeFunction2() {}
+        
+        $files = @()
+        $files += New-MarkdownHelp -Command Test-PlatyPSMergeFunction1 -OutputFolder TestDrive:\mergePath1 -Force
+        $files += New-MarkdownHelp -Command Test-PlatyPSMergeFunction1, Test-PlatyPSMergeFunction2 -OutputFolder TestDrive:\mergePath2 -Force
+
+        It 'generates merged markdown with applicable tags' {
+            $fileNew = Merge-MarkdownHelp -Path $files -OutputPath TestDrive:\mergePathOut -Force
+
+            $mamlNew1 = $fileNew | New-ExternalHelp -OutputPath TestDrive:\1new.xml -Force -ApplicableTag('mergePath1')
+            $helpNew1 = Get-HelpPreview -Path $mamlNew1
+
+            $mamlNew2 = $fileNew | New-ExternalHelp -OutputPath TestDrive:\2new.xml -Force -ApplicableTag('mergePath2')
+            $helpNew2 = Get-HelpPreview -Path $mamlNew2
+
+            $names1 = $helpNew1.Name 
+            $names2 = $helpNew2.Name
+
+            ($names1 | measure).Count | Should Be 1
+            $names1 | Should Be 'Test-PlatyPSMergeFunction1'
+
+            ($names2 | measure).Count | Should Be 2
+            $names2[0] | Should Be 'Test-PlatyPSMergeFunction1'
+            $names2[1] | Should Be 'Test-PlatyPSMergeFunction2'
+        }
+    }
 }


### PR DESCRIPTION
Currently, platyPS doesn't have a way to re-use content between different version or flaivors of the module. I.e. https://github.com/PowerShell/PowerShell-Docs/tree/staging/reference has different top-level folders with a bunch of duplicated content.

The same thing is applicable for different flavors of the same module, i.e. Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, and Skype for Business Online. 

There is a significant overlap, so it's desirable to re-use the documentation.

This changes closes this gap and implements design described in #273