### PR TITLE
fix full type name in syntax

### DIFF
--- a/src/Markdown.MAML/Model/MAML/MamlParameter.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlParameter.cs
@@ -11,6 +11,8 @@ namespace Markdown.MAML.Model.MAML
 
         public string Type { get; set; }
 
+        public string FullType { get; set; }
+
         public string Name { get; set; }
 
         public bool Required { get; set; }

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2249,14 +2249,9 @@ function ConvertPsObjectsToMamlModel
                 $ParameterObject.Required = $Parameter.IsMandatory
                 $ParameterObject.PipelineInput = getPipelineValue $Parameter
                 $ParameterType = $Parameter.ParameterType
-                $ParameterObject.Type = if ($UseFullTypeName)
-                {
-                    $ParameterType.FullName
-                }
-                else
-                {
-                    getTypeString -typeObject $ParameterType
-                }
+                $ParameterObject.Type = getTypeString -typeObject $ParameterType
+                $ParameterObject.FullType = $ParameterType.FullName
+
                 $ParameterObject.ValueRequired = -not ($Parameter.Type -eq "SwitchParameter") # thisDefinition is a heuristic
 
                 foreach($Alias in $Parameter.Aliases)
@@ -2507,6 +2502,11 @@ function ConvertPsObjectsToMamlModel
         $Parameter = Get-ParameterByName $ParameterName
         if ($Parameter)
         {
+            if ($UseFullTypeName)
+            {
+                $Parameter = $Parameter.Clone()
+                $Parameter.Type = $Parameter.FullType
+            }
             $MamlCommandObject.Parameters.Add($Parameter)
         }
         else 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -406,7 +406,7 @@ Type: System.Management.Automation.SwitchParameter
 
 '@ 
             $expectedSyntax = normalizeEnds @'
-Get-Alpha [[-WhatIf] <System.Management.Automation.SwitchParameter>] [[-CCC] <System.String>]
+Get-Alpha [-WhatIf] [[-CCC] <String>]
 
 '@
 
@@ -887,7 +887,7 @@ Type: System.String
 
 '@ 
         $expectedSyntax = normalizeEnds @'
-Get-MyCoolStuff [[-Foo] <System.String>] [[-Bar] <System.String>] [<CommonParameters>]
+Get-MyCoolStuff [[-Foo] <String>] [[-Bar] <String>] [<CommonParameters>]
 
 '@
         $v3markdown | Where-Object {$_.StartsWith('Type: ')} | Out-String | Should Be $expectedParameters


### PR DESCRIPTION
1. Change the parameter type in syntax. The type name should not be the full type name.
2. Change the related test cases.