### PR TITLE
Set parameter default value to false when type is System.Management.Automation.SwitchParameter(full name)

### DIFF
--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -104,7 +104,7 @@ namespace Markdown.MAML.Renderer
         private static XElement CreateParameter(MamlParameter param, bool isSyntax = false) 
         {
             string mamlType = ConvertPSTypeToMamlType(param);
-            bool isSwitchParameter = mamlType == "SwitchParameter";
+            bool isSwitchParameter = mamlType == "SwitchParameter" || mamlType == "System.Management.Automation.SwitchParameter";
 
             return new XElement(commandNS + "parameter",
                     new XAttribute("required", param.Required),


### PR DESCRIPTION
After enable full type name, need to set parameter default value to false when type is System.Management.Automation.SwitchParameter(full name) when generate MAML use New-ExternalHelp.