### PR TITLE
Fix first build experience

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,33 @@ param(
 # msbuild is part of .NET Framework, we can try to get it from well-known location.
 if (-not (Get-Command -Name msbuild -ErrorAction Ignore)) {
     Write-Warning "Appending probable msbuild path"
-    $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
+    $env:path += ";${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin"
+}
+
+if (-not (Get-Command -Name msbuild -ErrorAction Ignore)) {
+    throw "The msbuild command is not available."
+}
+
+if (-not (Get-ChildItem "$PSScriptRoot\packages\*" -ErrorAction Ignore)) {
+    # No packages... better restore or things won't go well.
+
+    $nugetCmd = 'nuget'
+    if (-not (Get-Command -Name $nugetCmd -ErrorAction Ignore)) {
+        $nugetCmd = "$PSScriptRoot\.nuget\NuGet.exe"
+    }
+
+    Write-Host -Foreground Cyan 'Attempting nuget package restore'
+
+    try
+    {
+        Push-Location $PSScriptRoot
+
+        & $nugetCmd restore
+    }
+    finally
+    {
+        Pop-Location
+    }
 }
 
 msbuild Markdown.MAML.sln /p:Configuration=$Configuration


### PR DESCRIPTION
1. If msbuild isn't on the path, we need to guess at a path to a newer
   msbuild--the old one won't compile C# 7 code now in use.

2. If there are no packages, do a package restore. Perhaps something
   should be done to restore packages on any build, but at least this is
   a step in the right direction.