### PR TITLE
Fix first build experience

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,33 @@ param(
 # msbuild is part of .NET Framework, we can try to get it from well-known location.
 if (-not (Get-Command -Name msbuild -ErrorAction Ignore)) {
     Write-Warning "Appending probable msbuild path"
-    $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
+    $env:path += ";${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin"
+}
+
+if (-not (Get-Command -Name msbuild -ErrorAction Ignore)) {
+    throw "The msbuild command is not available."
+}
+
+if (-not (Get-ChildItem "$PSScriptRoot\packages\*" -ErrorAction Ignore)) {
+    # No packages... better restore or things won't go well.
+
+    $nugetCmd = 'nuget'
+    if (-not (Get-Command -Name $nugetCmd -ErrorAction Ignore)) {
+        $nugetCmd = "$PSScriptRoot\.nuget\NuGet.exe"
+    }
+
+    Write-Host -Foreground Cyan 'Attempting nuget package restore'
+
+    try
+    {
+        Push-Location $PSScriptRoot
+
+        & $nugetCmd restore
+    }
+    finally
+    {
+        Pop-Location
+    }
 }
 
 msbuild Markdown.MAML.sln /p:Configuration=$Configuration


### PR DESCRIPTION
(let's try this PR again... hopefully newlines aren't messed up this time)

For a first-time user who clones the repo and runs `build.ps1` in a vanilla PowerShell window, the experience is disappointing. This PR adds a `nuget restore` if the root `packages` directory does not exist, and also searches for a proper VS2017 msbuild that can handle the new C# 7 features now in use.
