### PR TITLE
Added Outputfile to New-ExternalHelp CmdLet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## Not released
 
+## 0.8.3
+
+* New-ExternalHelp can log warnings and errors as JSON to file using new -OutputFile parameter. The output file can be used by CI systems to report warnings and errors to the build summary.
+
 ## 0.8.2
 
 * Help content for Merge-MarkdownHelp is updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 
 ## 0.8.3
 
-* New-ExternalHelp can log warnings and errors as JSON to file using new -OutputFile parameter. The output file can be used by CI systems to report warnings and errors to the build summary.
+* New-ExternalHelp can log warnings and errors as JSON to file using new -ErrorLogFile parameter. The file can be used by CI systems to report warnings and errors to the build summary.
 
 ## 0.8.2
 

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -14,7 +14,7 @@ Creates external help file based on markdown supported by PlatyPS.
 
 ```
 New-ExternalHelp -Path <String[]> -OutputPath <String> [-ApplicableTag <String[]>] [-Encoding <Encoding>]
- [-Force] [<CommonParameters>]
+ -OutputFile <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,6 +56,22 @@ Mode                LastWriteTime         Length Name
 This command creates an external help file in the specified location.
 This command specifies the *Force* parameter, therefore, it overwrites an existing file.
 The command specifies Unicode encoding for the created file.
+
+### Example 3: Write warnings and errors to file
+```
+PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\platyPS\en-US" -OutputFile ".\WarningsAndErrors.json"
+
+    Directory: D:\Working\PlatyPS\out\platyPS\en-US
+
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        5/19/2016  12:32 PM          46776 platyPS-help.xml
+```
+
+This command creates an external help file in the specified location.
+This command uses the best practice that the folder name includes the locale.
+This command writes the warnings and errors to the WarningsAndErrors.json file.
 
 ## PARAMETERS
 
@@ -136,6 +152,27 @@ See [design issue](https://github.com/PowerShell/platyPS/issues/273) for more de
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFile
+The path where this cmdlet will save formatted results log file.
+
+The path must include the location and name of the folder and file name with
+the json extension. The JSON object contains three properties, Message, FilePath,
+and Severity (Warning or Error).
+
+If this path is not provided, no log will be generated.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases: 
 

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -14,7 +14,7 @@ Creates external help file based on markdown supported by PlatyPS.
 
 ```
 New-ExternalHelp -Path <String[]> -OutputPath <String> [-ApplicableTag <String[]>] [-Encoding <Encoding>]
- -OutputFile <String> [-Force] [<CommonParameters>]
+ -ErrorLogFile <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -59,7 +59,7 @@ The command specifies Unicode encoding for the created file.
 
 ### Example 3: Write warnings and errors to file
 ```
-PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\platyPS\en-US" -OutputFile ".\WarningsAndErrors.json"
+PS C:\> New-ExternalHelp -Path ".\docs" -OutputPath "out\platyPS\en-US" -ErrorLogFile ".\WarningsAndErrors.json"
 
     Directory: D:\Working\PlatyPS\out\platyPS\en-US
 
@@ -162,7 +162,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OutputFile
+### -ErrorLogFile
 The path where this cmdlet will save formatted results log file.
 
 The path must include the location and name of the folder and file name with

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -749,7 +749,7 @@ function New-ExternalHelp
 
         [System.Text.Encoding]$Encoding = [System.Text.Encoding]::UTF8,
 
-        [string]$OutputFile,
+        [string]$ErrorLogFile,
         
         [switch]$Force
     )
@@ -880,8 +880,8 @@ function New-ExternalHelp
          throw
        }
        finally {
-         if ($OutputFile) {
-            ConvertTo-Json $warningsAndErrors | Out-File $OutputFile
+         if ($ErrorLogFile) {
+            ConvertTo-Json $warningsAndErrors | Out-File $ErrorLogFile
          }
        }        
     }

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -3,14 +3,15 @@
 ## DEVELOPERS NOTES & CONVENTIONS
 ##
 ##  1. Non-exported functions (subroutines) should avoid using 
-##     PowerShell standart Verb-Noun naming convention.
-##     They should use camalCase or CamalCase instead.
+##     PowerShell standard Verb-Noun naming convention.
+##     They should use camalCase or PascalCase instead.
 ##  2. SMALL subroutines, used only from ONE function 
 ##     should be placed inside the parent function body.
 ##     They should use camalCase for the name.
 ##  3. LARGE subroutines and subroutines used from MORE THEN ONE function 
-##     should be placed after the IMPLEMENTATION text block in the midle of this module.
-##     They should use CamalCase for the name.
+##     should be placed after the IMPLEMENTATION text block in the middle 
+##     of this module.
+##     They should use PascalCase for the name.
 ##  4. Add comment "# yeild" on subroutine calls that write values to pipeline.
 ##     It would help keep code maintainable and simplify ramp up for others.
 ## 

--- a/test/Pester/FullLoop.Tests.ps1
+++ b/test/Pester/FullLoop.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Full loop for Add-Member cmdlet' {
     
     Context 'markdown metadata' {
         $h = Get-MarkdownMetadata $file
-        It 'online version is available in metadata and metadat is case-insensitive' {
+        It 'online version is available in metadata and metadata is case-insensitive' {
             $h['oNline vErsion'] | Should Be $originalHelpObject.relatedLinks.navigationLink[0].uri
         }
     }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -468,6 +468,38 @@ Describe 'New-ExternalHelp' {
     }
 }
 
+Describe 'New-ExternalHelp -ErrorLogFile' {
+   BeforeAll {
+      function global:Test-OrderFunction {
+         param ([Parameter(Position = 3)]$Third, [Parameter(Position = 1)]$First, [Parameter()]$Named) 
+         $First
+         $Third
+         $Named
+      }
+
+      try {
+         # Don't add metadata so the file has an error
+         $file = New-MarkdownHelp -Command 'Test-OrderFunction' -OutputFolder $TestDrive -Force -NoMetadata
+         $maml = $file | New-ExternalHelp -OutputPath "$TestDrive\TestOrderFunction.xml" -ErrorLogFile "$TestDrive\warningsAndErrors.json" -Force      
+      }
+      catch {
+         # Ignore the error. I just needed an error to write to the log file.
+         # If I don't catch this the test will fail.
+      }
+   }
+  
+   It "generates error log file" {
+      Test-Path  "$TestDrive\warningsAndErrors.json" | Should Be $true
+   }
+
+   It "error log file is valid JSON" {
+      $r = (Get-Content "$TestDrive\warningsAndErrors.json" | ConvertFrom-Json)
+      $r[0].Message | Should Be "PlatyPS schema version 1.0.0 is deprecated and not supported anymore. Please install platyPS 0.7.6 and migrate to the supported version..Exception.Message" 
+      $r[0].Severity | Should Be "Error" 
+      $r[0].FilePath | Should Be "" 
+   }
+}
+
 Describe 'New-ExternalHelp -ApplicableTag for cmdlet level' {
     BeforeAll {
         function global:Test-Applicable12 {}


### PR DESCRIPTION
I needed a format of warning and errors I could parse to show in a build summary.  I added the OutputFile parameter to use to store all warnings and errors as JSON written to the provided location.

I updated the changelog and the help files to match changes in cmdlet.

I am not clear on how to turn this into a release as I don't have the apikey.