### PR TITLE
use tostring instead of FullName when get full type name

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2352,7 +2352,7 @@ function ConvertPsObjectsToMamlModel
                 $ParameterObject.PipelineInput = getPipelineValue $Parameter
                 $ParameterType = $Parameter.ParameterType
                 $ParameterObject.Type = getTypeString -typeObject $ParameterType
-                $ParameterObject.FullType = $ParameterType.FullName
+                $ParameterObject.FullType = $ParameterType.ToString()
 
                 $ParameterObject.ValueRequired = -not ($Parameter.Type -eq "SwitchParameter") # thisDefinition is a heuristic
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -395,18 +395,22 @@ Describe 'New-MarkdownHelp' {
                 $WhatIf,
                 [string]
                 [Parameter(Position=2)]
-                $CCC
+                $CCC,
+                [System.Nullable`1[System.Int32]]
+                [Parameter(Position=3)]
+                $ddd
             )
         }
 
         It 'use full type name when specified' {
             $expectedParameters = normalizeEnds @'
 Type: System.String
+Type: System.Nullable`1[System.Int32]
 Type: System.Management.Automation.SwitchParameter
 
 '@ 
             $expectedSyntax = normalizeEnds @'
-Get-Alpha [-WhatIf] [[-CCC] <String>]
+Get-Alpha [-WhatIf] [[-CCC] <String>] [[-ddd] <Int32>]
 
 '@
 
@@ -419,11 +423,12 @@ Get-Alpha [-WhatIf] [[-CCC] <String>]
         It 'not use full type name when specified' {
             $expectedParameters = normalizeEnds @'
 Type: String
+Type: Int32
 Type: SwitchParameter
 
 '@ 
             $expectedSyntax = normalizeEnds @'
-Get-Alpha [-WhatIf] [[-CCC] <String>]
+Get-Alpha [-WhatIf] [[-CCC] <String>] [[-ddd] <Int32>]
 
 '@
 


### PR DESCRIPTION
Fix issue: The full type name of parameter type `Int32` is not correct.

use tostring instead of FullName when get full type name.