### PR TITLE
Fix for trailing whitespace issue #225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## Not released
 
+* Clean up trailing whitespace during markdown generation [#225](https://github.com/PowerShell/platyPS/issues/225)
 
 ## 0.8.3
 

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -76,7 +76,7 @@ namespace Markdown.MAML.Renderer
             return RenderCleaner.NormalizeLineBreaks(
                 RenderCleaner.NormalizeWhitespaces(
                     RenderCleaner.NormalizeQuotesAndDashes(
-                        _stringBuilder.ToString())));
+                        _stringBuilder.ToString())), true);
         }
         
         private void AddYamlHeader(Hashtable yamlHeader)

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -76,7 +76,7 @@ namespace Markdown.MAML.Renderer
             return RenderCleaner.NormalizeLineBreaks(
                 RenderCleaner.NormalizeWhitespaces(
                     RenderCleaner.NormalizeQuotesAndDashes(
-                        _stringBuilder.ToString())), true);
+                        _stringBuilder.ToString())));
         }
         
         private void AddYamlHeader(Hashtable yamlHeader)
@@ -92,7 +92,7 @@ namespace Markdown.MAML.Renderer
             
             foreach (var pair in sortedHeader)
             {
-                _stringBuilder.AppendFormat("{0}: {1}{2}", pair.Key, pair.Value, Environment.NewLine);
+                AppendYamlKeyValue(pair.Key, pair.Value);
             }
 
             _stringBuilder.AppendFormat("---{0}{0}", Environment.NewLine);
@@ -276,7 +276,7 @@ namespace Markdown.MAML.Renderer
             {
                 _stringBuilder.AppendFormat("```yaml{0}", Environment.NewLine);
 
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Type, parameter.Type, Environment.NewLine);
+                AppendYamlKeyValue(MarkdownStrings.Type, parameter.Type);
 
                 string parameterSetsString;
                 if (command.Syntax.Count == 1 || set.Item1.Count == command.Syntax.Count)
@@ -290,29 +290,41 @@ namespace Markdown.MAML.Renderer
                     parameterSetsString = JoinWithComma(set.Item1);
                 }
 
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Parameter_Sets, parameterSetsString, Environment.NewLine);
+                AppendYamlKeyValue(MarkdownStrings.Parameter_Sets, parameterSetsString);
 
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Aliases, JoinWithComma(parameter.Aliases), Environment.NewLine);
+                AppendYamlKeyValue(MarkdownStrings.Aliases, JoinWithComma(parameter.Aliases));
                 if (parameter.ParameterValueGroup.Count > 0)
                 {
-                    _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Accepted_values, JoinWithComma(parameter.ParameterValueGroup), Environment.NewLine);
+                    AppendYamlKeyValue(MarkdownStrings.Accepted_values, JoinWithComma(parameter.ParameterValueGroup));
                 }
 
                 if (parameter.Applicable != null)
                 {
-                    _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Applicable, JoinWithComma(parameter.Applicable), Environment.NewLine);
+                    AppendYamlKeyValue(MarkdownStrings.Applicable, JoinWithComma(parameter.Applicable));
                 }
 
                 _stringBuilder.AppendLine();
 
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Required, set.Item2.Required, Environment.NewLine);
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Position, set.Item2.IsNamed() ? "Named" : set.Item2.Position, Environment.NewLine);
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Default_value, string.IsNullOrWhiteSpace(parameter.DefaultValue) ? "None" : parameter.DefaultValue, Environment.NewLine);
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Accept_pipeline_input, parameter.PipelineInput, Environment.NewLine);
-                _stringBuilder.AppendFormat("{0}: {1}{2}", MarkdownStrings.Accept_wildcard_characters, parameter.Globbing, Environment.NewLine);
+                AppendYamlKeyValue(MarkdownStrings.Required, set.Item2.Required.ToString());
+                AppendYamlKeyValue(MarkdownStrings.Position, set.Item2.IsNamed() ? "Named" : set.Item2.Position);
+                AppendYamlKeyValue(MarkdownStrings.Default_value, string.IsNullOrWhiteSpace(parameter.DefaultValue) ? "None" : parameter.DefaultValue);
+                AppendYamlKeyValue(MarkdownStrings.Accept_pipeline_input, parameter.PipelineInput);
+                AppendYamlKeyValue(MarkdownStrings.Accept_wildcard_characters, parameter.Globbing.ToString());
 
                 _stringBuilder.AppendFormat("```{0}{0}", Environment.NewLine);
             }
+        }
+
+        private void AppendYamlKeyValue(string key, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                _stringBuilder.AppendFormat("{0}:{1}", key, Environment.NewLine);
+
+                return;
+            }
+
+            _stringBuilder.AppendFormat("{0}: {1}{2}", key, value, Environment.NewLine);
         }
 
         private void AddExamples(MamlCommand command)

--- a/src/Markdown.MAML/Renderer/RenderCleaner.cs
+++ b/src/Markdown.MAML/Renderer/RenderCleaner.cs
@@ -60,8 +60,13 @@ namespace Markdown.MAML.Renderer
             return text;
         }
 
-        public static string NormalizeLineBreaks(string text)
+        public static string NormalizeLineBreaks(string text, bool trimSpaces = false)
         {
+            if (trimSpaces)
+            {
+                return Regex.Replace(text, " *(\r\n?|\n)", "\r\n");
+            }
+
             return Regex.Replace(text, "\r\n?|\n", "\r\n");
         }
     }

--- a/src/Markdown.MAML/Renderer/RenderCleaner.cs
+++ b/src/Markdown.MAML/Renderer/RenderCleaner.cs
@@ -60,13 +60,8 @@ namespace Markdown.MAML.Renderer
             return text;
         }
 
-        public static string NormalizeLineBreaks(string text, bool trimSpaces = false)
+        public static string NormalizeLineBreaks(string text)
         {
-            if (trimSpaces)
-            {
-                return Regex.Replace(text, " *(\r\n?|\n)", "\r\n");
-            }
-
             return Regex.Replace(text, "\r\n?|\n", "\r\n");
         }
     }

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -253,7 +253,7 @@ Get-Foo [-Name] <String> [<CommonParameters>]
 ## DESCRIPTION
 This is a long description.
 
-With two paragraphs.
+With two paragraphs. 
 And the second one contains of few line!
 They should be auto-wrapped.
 Because, why not?

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -235,7 +235,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             string markdown = renderer.MamlModelToString(command, metadata);
             Assert.Equal(@"---
 foo: bar
-null: 
+null:
 schema: 2.0.0
 ---
 
@@ -253,7 +253,7 @@ Get-Foo [-Name] <String> [<CommonParameters>]
 ## DESCRIPTION
 This is a long description.
 
-With two paragraphs. 
+With two paragraphs.
 And the second one contains of few line!
 They should be auto-wrapped.
 Because, why not?
@@ -414,7 +414,7 @@ Get-Foo -Common <String> -Second <String> [<CommonParameters>]
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -427,7 +427,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: FirstSyntax
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -440,7 +440,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: SecondSyntax
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named


### PR DESCRIPTION
PR is in response to PowerShell/platyPS#225

- Updated test cases to remove trailing whitespace in expected output, which is now not expected.
- Updated yaml generation to check for null or empty values.
- xUnit and Pester tests passing.