### PR TITLE
Fix to preserve line break after headers issue #319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Not released
 
 * Clean up trailing whitespace during markdown generation [#225](https://github.com/PowerShell/platyPS/issues/225)
+* Preserve line breaks after headers when Update-MarkdownHelp is used [#319](https://github.com/PowerShell/platyPS/issues/319)
 
 ## 0.8.3
 

--- a/src/Markdown.MAML/Markdown.MAML.csproj
+++ b/src/Markdown.MAML/Markdown.MAML.csproj
@@ -61,6 +61,8 @@
     <Compile Include="Model\Markdown\MarkdownNode.cs" />
     <Compile Include="Model\Markdown\MarkdownNodeType.cs" />
     <Compile Include="Model\Markdown\ParagraphNode.cs" />
+    <Compile Include="Model\Markdown\SectionBody.cs" />
+    <Compile Include="Model\Markdown\SectionFormatOption.cs" />
     <Compile Include="Model\Markdown\SourceExtent.cs" />
     <Compile Include="Model\Markdown\TextNode.cs" />
     <Compile Include="Model\Markdown\HyperlinkSpan.cs" />

--- a/src/Markdown.MAML/Model/MAML/MamlCommand.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlCommand.cs
@@ -6,9 +6,12 @@ namespace Markdown.MAML.Model.MAML
     public class MamlCommand
     {
         public SourceExtent Extent { get; set; }
+
         public string Name { get; set; }
-        public string Synopsis { get; set; }
-        public string Description { get; set; }
+
+        public SectionBody Synopsis { get; set; }
+
+        public SectionBody Description { get; set; }
 
         public List<MamlInputOutput> Inputs 
         {
@@ -25,7 +28,7 @@ namespace Markdown.MAML.Model.MAML
             get { return _parameters; } 
         }
 
-        public string Notes { get; set; }
+        public SectionBody Notes { get; set; }
 
         public bool IsWorkflow { get; set; }
 

--- a/src/Markdown.MAML/Model/MAML/MamlExample.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlExample.cs
@@ -13,6 +13,10 @@ namespace Markdown.MAML.Model.MAML
         public string Code { get; set; }
         public string Remarks { get; set; }
         public string Introduction { get; set; }
+
+        /// <summary>
+        /// Additional options that determine how the section will be formated when rendering markdown.
+        /// </summary>
         public SectionFormatOption FormatOption { get; set; }
     }
 }

--- a/src/Markdown.MAML/Model/MAML/MamlExample.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlExample.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Markdown.MAML.Model.Markdown;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,5 +13,6 @@ namespace Markdown.MAML.Model.MAML
         public string Code { get; set; }
         public string Remarks { get; set; }
         public string Introduction { get; set; }
+        public SectionFormatOption FormatOption { get; set; }
     }
 }

--- a/src/Markdown.MAML/Model/MAML/MamlInputOutput.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlInputOutput.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Markdown.MAML.Model.Markdown;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,6 +14,11 @@ namespace Markdown.MAML.Model.MAML
     {
         public string TypeName { get; set; }
         public string Description { get; set; }
+
+        /// <summary>
+        /// Additional options that determine how the section will be formated when rendering markdown.
+        /// </summary>
+        public SectionFormatOption FormatOption { get; set; }
 
         bool IEquatable<MamlInputOutput>.Equals(MamlInputOutput other)
         {

--- a/src/Markdown.MAML/Model/MAML/MamlParameter.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlParameter.cs
@@ -9,6 +9,8 @@ namespace Markdown.MAML.Model.MAML
     {
         public SourceExtent Extent { get; set; }
 
+        public SectionFormatOption FormatOption { get; set; }
+
         public string Type { get; set; }
 
         public string FullType { get; set; }

--- a/src/Markdown.MAML/Model/MAML/MamlParameter.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlParameter.cs
@@ -9,6 +9,9 @@ namespace Markdown.MAML.Model.MAML
     {
         public SourceExtent Extent { get; set; }
 
+        /// <summary>
+        /// Additional options that determine how the section will be formated when rendering markdown.
+        /// </summary>
         public SectionFormatOption FormatOption { get; set; }
 
         public string Type { get; set; }

--- a/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
+++ b/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
@@ -10,7 +10,7 @@
         public int HeadingLevel { get; private set; }
 
         /// <summary>
-        /// Format options that control markdown generation.
+        /// Additional options that determine how the section will be formated when rendering markdown. This options will be passed on to MAML models when they are generated.
         /// </summary>
         public SectionFormatOption FormatOption { get; private set; }
 

--- a/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
+++ b/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
@@ -9,10 +9,13 @@
 
         public int HeadingLevel { get; private set; }
 
-        public HeadingNode(string headingText, int headingLevel, SourceExtent sourceExtent) 
+        public bool BreakAfterHeader { get; private set; }
+
+        public HeadingNode(string headingText, int headingLevel, SourceExtent sourceExtent, bool breakAfterHeader) 
             : base(headingText, sourceExtent)
         {
             this.HeadingLevel = headingLevel;
+            this.BreakAfterHeader = breakAfterHeader;
         }
     }
 }

--- a/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
+++ b/src/Markdown.MAML/Model/Markdown/HeadingNode.cs
@@ -9,13 +9,16 @@
 
         public int HeadingLevel { get; private set; }
 
-        public bool BreakAfterHeader { get; private set; }
+        /// <summary>
+        /// Format options that control markdown generation.
+        /// </summary>
+        public SectionFormatOption FormatOption { get; private set; }
 
-        public HeadingNode(string headingText, int headingLevel, SourceExtent sourceExtent, bool breakAfterHeader) 
+        public HeadingNode(string headingText, int headingLevel, SourceExtent sourceExtent, SectionFormatOption formatOption) 
             : base(headingText, sourceExtent)
         {
             this.HeadingLevel = headingLevel;
-            this.BreakAfterHeader = breakAfterHeader;
+            this.FormatOption = formatOption;
         }
     }
 }

--- a/src/Markdown.MAML/Model/Markdown/SectionBody.cs
+++ b/src/Markdown.MAML/Model/Markdown/SectionBody.cs
@@ -11,11 +11,6 @@ namespace Markdown.MAML.Model.Markdown
     /// </summary>
     public sealed class SectionBody
     {
-        public SectionBody()
-        {
-            FormatOption = SectionFormatOption.None;
-        }
-
         public SectionBody(string text, SectionFormatOption formatOption)
         {
             Text = text;
@@ -28,7 +23,7 @@ namespace Markdown.MAML.Model.Markdown
         public string Text { get; private set; }
 
         /// <summary>
-        /// Format options that control markdown generation.
+        /// Additional options that determine how the section will be formated when rendering markdown.
         /// </summary>
         public SectionFormatOption FormatOption { get; private set; }
 

--- a/src/Markdown.MAML/Model/Markdown/SectionBody.cs
+++ b/src/Markdown.MAML/Model/Markdown/SectionBody.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Markdown.MAML.Model.Markdown
+{
+    /// <summary>
+    /// A section of text with formatting options.
+    /// </summary>
+    public sealed class SectionBody
+    {
+        public SectionBody()
+        {
+            FormatOption = SectionFormatOption.None;
+        }
+
+        public SectionBody(string text, SectionFormatOption formatOption)
+        {
+            Text = text;
+            FormatOption = formatOption;
+        }
+
+        /// <summary>
+        /// The text of the section body.
+        /// </summary>
+        public string Text { get; private set; }
+
+        /// <summary>
+        /// Format options that control markdown generation.
+        /// </summary>
+        public SectionFormatOption FormatOption { get; private set; }
+
+        public override string ToString()
+        {
+            return Text;
+        }
+
+        public static SectionBody New(string text, SectionFormatOption formatOption = SectionFormatOption.None)
+        {
+            return new SectionBody(text, formatOption);
+        }
+
+        public static implicit operator SectionBody(string text)
+        {
+            return new SectionBody(text, SectionFormatOption.None);
+        }
+    }
+}

--- a/src/Markdown.MAML/Model/Markdown/SectionBody.cs
+++ b/src/Markdown.MAML/Model/Markdown/SectionBody.cs
@@ -17,6 +17,10 @@ namespace Markdown.MAML.Model.Markdown
             FormatOption = formatOption;
         }
 
+        public SectionBody(string text)
+            : this(text, SectionFormatOption.None)
+        { }
+
         /// <summary>
         /// The text of the section body.
         /// </summary>
@@ -30,16 +34,6 @@ namespace Markdown.MAML.Model.Markdown
         public override string ToString()
         {
             return Text;
-        }
-
-        public static SectionBody New(string text, SectionFormatOption formatOption = SectionFormatOption.None)
-        {
-            return new SectionBody(text, formatOption);
-        }
-
-        public static implicit operator SectionBody(string text)
-        {
-            return new SectionBody(text, SectionFormatOption.None);
         }
     }
 }

--- a/src/Markdown.MAML/Model/Markdown/SectionFormatOption.cs
+++ b/src/Markdown.MAML/Model/Markdown/SectionFormatOption.cs
@@ -6,11 +6,17 @@ using System.Threading.Tasks;
 
 namespace Markdown.MAML.Model.Markdown
 {
+    /// <summary>
+    /// Define options that determine how sections will be formated when rendering markdown.
+    /// </summary>
+    [Flags()]
     public enum SectionFormatOption : byte
     {
         None = 0,
 
-        // A line break should be added after the section header
+        /// <summary>
+        /// A line break should be added after the section header.
+        /// </summary>
         LineBreakAfterHeader = 1
     }
 }

--- a/src/Markdown.MAML/Model/Markdown/SectionFormatOption.cs
+++ b/src/Markdown.MAML/Model/Markdown/SectionFormatOption.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Markdown.MAML.Model.Markdown
+{
+    public enum SectionFormatOption : byte
+    {
+        None = 0,
+
+        // A line break should be added after the section header
+        LineBreakAfterHeader = 1
+    }
+}

--- a/src/Markdown.MAML/Parser/MarkdownParser.cs
+++ b/src/Markdown.MAML/Parser/MarkdownParser.cs
@@ -308,6 +308,8 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[2].Value,
                     regexMatch.Groups[1].Value.Length,
                     sourceExtent,
+
+                    // Detect if a line break after the header exists. Mutiple line breaks will be reduced to one.
                     (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 
@@ -320,7 +322,9 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[3].Value,
                     regexMatch.Groups[2].Value.Length,
                     sourceExtent,
-                    (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
+
+                    // Detect if a line break after the header exists. Mutiple line breaks will be reduced to one.
+                    (regexMatch.Groups[4].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 
         private void CreateUnderlineHeader(Match regexMatch, SourceExtent sourceExtent)

--- a/src/Markdown.MAML/Parser/MarkdownParser.cs
+++ b/src/Markdown.MAML/Parser/MarkdownParser.cs
@@ -307,7 +307,8 @@ namespace Markdown.MAML.Parser
                 new HeadingNode(
                     regexMatch.Groups[2].Value,
                     regexMatch.Groups[1].Value.Length,
-                    sourceExtent));
+                    sourceExtent,
+                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
         }
 
         private void CreateHashHeader2(Match regexMatch, SourceExtent sourceExtent)
@@ -318,7 +319,8 @@ namespace Markdown.MAML.Parser
                 new HeadingNode(
                     regexMatch.Groups[3].Value,
                     regexMatch.Groups[2].Value.Length,
-                    sourceExtent));
+                    sourceExtent,
+                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
         }
 
         private void CreateUnderlineHeader(Match regexMatch, SourceExtent sourceExtent)
@@ -333,7 +335,8 @@ namespace Markdown.MAML.Parser
                 new HeadingNode(
                     regexMatch.Groups[1].Value,
                     headerLevel,
-                    sourceExtent));
+                    sourceExtent,
+                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
         }
 
         private void CreateTickCodeBlock(Match regexMatch, SourceExtent sourceExtent)

--- a/src/Markdown.MAML/Parser/MarkdownParser.cs
+++ b/src/Markdown.MAML/Parser/MarkdownParser.cs
@@ -340,6 +340,8 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[1].Value,
                     headerLevel,
                     sourceExtent,
+
+                    // Detect if a line break after the header exists. Mutiple line breaks will be reduced to one. 
                     (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 

--- a/src/Markdown.MAML/Parser/MarkdownParser.cs
+++ b/src/Markdown.MAML/Parser/MarkdownParser.cs
@@ -308,7 +308,7 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[2].Value,
                     regexMatch.Groups[1].Value.Length,
                     sourceExtent,
-                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
+                    (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 
         private void CreateHashHeader2(Match regexMatch, SourceExtent sourceExtent)
@@ -320,7 +320,7 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[3].Value,
                     regexMatch.Groups[2].Value.Length,
                     sourceExtent,
-                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
+                    (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 
         private void CreateUnderlineHeader(Match regexMatch, SourceExtent sourceExtent)
@@ -336,7 +336,7 @@ namespace Markdown.MAML.Parser
                     regexMatch.Groups[1].Value,
                     headerLevel,
                     sourceExtent,
-                    (regexMatch.Groups[3].Captures.Count > 1) ? true : false));
+                    (regexMatch.Groups[3].Captures.Count > 1) ? SectionFormatOption.LineBreakAfterHeader : SectionFormatOption.None));
         }
 
         private void CreateTickCodeBlock(Match regexMatch, SourceExtent sourceExtent)

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -64,14 +64,14 @@ namespace Markdown.MAML.Renderer
                         new XElement(commandNS + "name", command.Name),
                         new XElement(commandNS + "verb", verb),
                         new XElement(commandNS + "noun", noun),
-                        new XElement(mamlNS + "description", GenerateParagraphs(command.Synopsis))),
-                    new XElement(mamlNS + "description", GenerateParagraphs(command.Description)),
+                        new XElement(mamlNS + "description", GenerateParagraphs(command.Synopsis?.Text))),
+                    new XElement(mamlNS + "description", GenerateParagraphs(command.Description?.Text)),
                     new XElement(commandNS + "syntax", command.Syntax.Select(syn => CreateSyntaxItem(syn, command))),
                     new XElement(commandNS + "parameters", command.Parameters.Select(param => CreateParameter(param))),
                     new XElement(commandNS + "inputTypes", command.Inputs.Select(input => CreateInput(input))),
                     new XElement(commandNS + "returnValues", command.Outputs.Select(output => CreateOutput(output))),
                     new XElement(mamlNS + "alertSet", 
-                        new XElement(mamlNS + "alert", GenerateParagraphs(command.Notes))),
+                        new XElement(mamlNS + "alert", GenerateParagraphs(command.Notes?.Text))),
                     new XElement(commandNS + "examples", command.Examples.Select(example => CreateExample(example))),
                     new XElement(commandNS + "relatedLinks", command.Links.Select(link => CreateLink(link))));
         }
@@ -81,17 +81,6 @@ namespace Markdown.MAML.Renderer
             if (text != null)
             {
                 return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
-                    .Select(para => new XElement(mamlNS + "para", para));
-            }
-
-            return Enumerable.Empty<XElement>();
-        }
-
-        private static IEnumerable<XElement> GenerateParagraphs(Markdown.MAML.Model.Markdown.SectionBody body)
-        {
-            if (body != null && !string.IsNullOrEmpty(body.Text))
-            {
-                return body.Text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
                     .Select(para => new XElement(mamlNS + "para", para));
             }
 

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -80,7 +80,7 @@ namespace Markdown.MAML.Renderer
         {
             if (text != null)
             {
-                return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
+                return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(para => new XElement(mamlNS + "para", para));
             }
 

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -80,7 +80,18 @@ namespace Markdown.MAML.Renderer
         {
             if (text != null)
             {
-                return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+                return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
+                    .Select(para => new XElement(mamlNS + "para", para));
+            }
+
+            return Enumerable.Empty<XElement>();
+        }
+
+        private static IEnumerable<XElement> GenerateParagraphs(Markdown.MAML.Model.Markdown.SectionBody body)
+        {
+            if (body != null && !string.IsNullOrEmpty(body.Text))
+            {
+                return body.Text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
                     .Select(para => new XElement(mamlNS + "para", para));
             }
 

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -269,7 +269,8 @@ namespace Markdown.MAML.Renderer
 
         private bool ShouldBreak(SectionFormatOption formatOption)
         {
-            return ((formatOption & SectionFormatOption.LineBreakAfterHeader) == SectionFormatOption.LineBreakAfterHeader);
+            // If the line break flag is set return true.
+            return formatOption.HasFlag(SectionFormatOption.LineBreakAfterHeader);
         }
 
         private void AddParameter(MamlParameter parameter, MamlCommand command)
@@ -536,6 +537,12 @@ namespace Markdown.MAML.Renderer
             {
                 string[] paragraphs = body.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
                 body = GetAutoWrappingForMarkdown(paragraphs.Select(para => GetEscapedMarkdownText(para.Trim())).ToArray());
+            }
+
+            // The the body already ended in a line break don't add extra lines on to the end
+            if (body.EndsWith("\r\n\r\n"))
+            {
+                noNewLines = true;
             }
 
             _stringBuilder.AppendFormat("{0}{1}{1}", body, noNewLines ? null : Environment.NewLine);

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -432,17 +432,24 @@ namespace Markdown.MAML.Renderer
             }
         }
 
-        private void AddEntryHeaderWithText(string header, string text)
+        private void AddEntryHeaderWithText(string header, SectionBody body)
         {
+            // Add header
             AddHeader(ModelTransformerBase.COMMAND_ENTRIES_HEADING_LEVEL, header, extraNewLine: false);
+
             // to correctly handle empty text case, we are adding new-line here
-            if (string.IsNullOrEmpty(text))
+            if (body == null || string.IsNullOrEmpty(body.Text))
             {
                 _stringBuilder.Append(Environment.NewLine);
             }
             else
             {
-                AddParagraphs(text);
+                if (body.FormatOption == SectionFormatOption.LineBreakAfterHeader)
+                {
+                    _stringBuilder.Append(Environment.NewLine);
+                }
+
+                AddParagraphs(body.Text);
             }
         }
 

--- a/src/Markdown.MAML/Renderer/YamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/YamlRenderer.cs
@@ -22,9 +22,9 @@ namespace Markdown.MAML.Renderer
             var model = new YamlCommand
             {
                 Name = mamlCommand.Name,
-                Notes = mamlCommand.Notes,
-                Remarks = mamlCommand.Description,
-                Summary = mamlCommand.Synopsis,
+                Notes = mamlCommand.Notes.Text,
+                Remarks = mamlCommand.Description.Text,
+                Summary = mamlCommand.Synopsis.Text,
                 Examples = mamlCommand.Examples.Select(CreateExample).ToList(),
                 Inputs = mamlCommand.Inputs.Select(CreateInputOutput).ToList(),
                 Links = mamlCommand.Links.Select(CreateLink).ToList(),

--- a/src/Markdown.MAML/Transformer/MamlModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlModelMerger.cs
@@ -1,4 +1,5 @@
 ﻿using Markdown.MAML.Model.MAML;
+using Markdown.MAML.Model.Markdown;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,18 +37,9 @@ namespace Markdown.MAML.Transformer
                 result = new MamlCommand()
                 {
                     Name = metadataModel.Name,
-                    Synopsis = metadataStringCompare(metadataModel.Synopsis,
-                        stringModel.Synopsis,
-                        metadataModel.Name,
-                        "synopsis"),
-                    Description = metadataStringCompare(metadataModel.Description,
-                        stringModel.Description,
-                        metadataModel.Name,
-                        "description"),
-                    Notes = metadataStringCompare(metadataModel.Notes,
-                        stringModel.Notes,
-                        metadataModel.Name,
-                        "notes"),
+                    Synopsis = stringModel.Synopsis,
+                    Description = stringModel.Description,
+                    Notes = stringModel.Notes,
                     Extent = stringModel.Extent
                 };
             }
@@ -192,11 +184,7 @@ namespace Markdown.MAML.Transformer
                     {
                         try
                         {
-                            param.Description = metadataStringCompare(param.Description,
-                                strParam.Description,
-                                metadataModel.Name,
-                                param.Name,
-                                "parameter description");
+                            param.Description = strParam.Description;
                         }
                         catch (Exception ex)
                         {
@@ -286,42 +274,6 @@ namespace Markdown.MAML.Transformer
                 Report($"    Exception parameter merge: \r\n{ex.Message}\r\n");
                 _cmdletUpdated = true;
             }
-
-
-        }
-
-        /// <summary>
-        /// Compares parameters
-        /// </summary>
-        private string metadataStringCompare(string metadataContent, string stringContent, string moduleName, string paramName, string contentItemName)
-        {
-            var pretifiedStringContent = stringContent == null ? "" : Pretify(stringContent).TrimEnd(' ');
-            var pretifiedMetadataContent = metadataContent == null ? "" : Pretify(metadataContent).TrimEnd(' ');
-
-            return stringContent;
-        }
-
-        /// <summary>
-        /// Cleans the extra \r\n and inserts a tab at the beginning of new lines, mid paragraphs
-        /// </summary>
-        private static string Pretify(string multiLineText)
-        {
-            if(string.IsNullOrEmpty(multiLineText))
-            {
-                multiLineText = "";
-            }
-            return Regex.Replace(multiLineText, "(\r\n)+", "\r\n    ");
-        }
-
-        /// <summary>
-        /// Compares Cmdlet values: Synopsis, Description, and Notes. Preserves the content from the string model (old) or the metadata model (new).
-        /// </summary>
-        private string metadataStringCompare(string metadataContent, string stringContent, string moduleName, string contentItemName)
-        {
-            var metadataContentPretified = (metadataContent == null ? "" : Pretify(metadataContent).TrimEnd(' '));
-            var stringContentPretified = (stringContent == null ? "" : Pretify(stringContent).TrimEnd(' '));
-
-            return stringContent;
         }
 
         private void Report(string format, params object[] objects)

--- a/src/Markdown.MAML/Transformer/MamlModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlModelMerger.cs
@@ -87,8 +87,6 @@ namespace Markdown.MAML.Transformer
             //Result takes in the merged parameter results.
             MergeParameters(result, metadataModel, stringModel);
 
-
-
             if (!_cmdletUpdated)
             {
                 Report("\tNo updates done\r\n");
@@ -216,16 +214,8 @@ namespace Markdown.MAML.Transformer
                             _cmdletUpdated = true;
                         }
 
-                        try
-                        {
-                            param.FormatOption = strParam.FormatOption;
-                        }
-                        catch (Exception ex)
-                        {
-                            Report($"---- ERROR UPDATING Cmdlet : {metadataModel.Name}----\r\n");
-                            Report($"    Exception {param.Name} FormatOption merge: \r\n{ex.Message}\r\n");
-                            _cmdletUpdated = true;
-                        }
+                        // Update the parameter with the merged in FormatOption
+                        param.FormatOption = strParam.FormatOption;
                     }
 
                     result.Parameters.Add(param);

--- a/src/Markdown.MAML/Transformer/MamlModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlModelMerger.cs
@@ -216,6 +216,16 @@ namespace Markdown.MAML.Transformer
                             _cmdletUpdated = true;
                         }
 
+                        try
+                        {
+                            param.FormatOption = strParam.FormatOption;
+                        }
+                        catch (Exception ex)
+                        {
+                            Report($"---- ERROR UPDATING Cmdlet : {metadataModel.Name}----\r\n");
+                            Report($"    Exception {param.Name} FormatOption merge: \r\n{ex.Message}\r\n");
+                            _cmdletUpdated = true;
+                        }
                     }
 
                     result.Parameters.Add(param);

--- a/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
@@ -49,9 +49,9 @@ namespace Markdown.MAML.Transformer
             result = new MamlCommand()
             {
                 Name = referenceModel.Name,
-                Synopsis = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Synopsis.Text))),
-                Description = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Description.Text))),
-                Notes = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Notes.Text))),
+                Synopsis = new SectionBody(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Synopsis.Text))),
+                Description = new SectionBody(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Description.Text))),
+                Notes = new SectionBody(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Notes.Text))),
                 Extent = referenceModel.Extent
             };
 

--- a/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlMultiModelMerger.cs
@@ -1,4 +1,5 @@
 ﻿using Markdown.MAML.Model.MAML;
+using Markdown.MAML.Model.Markdown;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -48,9 +49,9 @@ namespace Markdown.MAML.Transformer
             result = new MamlCommand()
             {
                 Name = referenceModel.Name,
-                Synopsis = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Synopsis)),
-                Description = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Description)),
-                Notes = MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Notes)),
+                Synopsis = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Synopsis.Text))),
+                Description = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Description.Text))),
+                Notes = SectionBody.New(MergeText(tagsModel.ToDictionary(pair => pair.Key, pair => pair.Value.Notes.Text))),
                 Extent = referenceModel.Extent
             };
 

--- a/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
@@ -118,10 +118,15 @@ namespace Markdown.MAML.Transformer
             _ungotNode = node;
         }
 
-        protected string SimpleTextSectionRule()
+        protected string SimpleTextSectionRule(bool breakBeforeSection)
         {
             // grammar:
             // Simple paragraph Text
+            if (breakBeforeSection)
+            {
+                return string.Concat("\r\n", GetTextFromParagraphNode(ParagraphNodeRule()));
+            }
+
             return GetTextFromParagraphNode(ParagraphNodeRule());
         }
         
@@ -255,7 +260,7 @@ namespace Markdown.MAML.Transformer
                 TypeName = headingNode.Text
             };
 
-            typeEntity.Description = SimpleTextSectionRule();
+            typeEntity.Description = SimpleTextSectionRule(false);
 
             return typeEntity;
         }

--- a/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
@@ -118,15 +118,10 @@ namespace Markdown.MAML.Transformer
             _ungotNode = node;
         }
 
-        protected string SimpleTextSectionRule(bool breakBeforeSection)
+        protected string SimpleTextSectionRule()
         {
             // grammar:
             // Simple paragraph Text
-            if (breakBeforeSection)
-            {
-                return string.Concat("\r\n", GetTextFromParagraphNode(ParagraphNodeRule()));
-            }
-
             return GetTextFromParagraphNode(ParagraphNodeRule());
         }
         
@@ -181,6 +176,7 @@ namespace Markdown.MAML.Transformer
                     Title = headingNode.Text
                 };
                 example.Introduction = GetTextFromParagraphNode(ParagraphNodeRule());
+                example.FormatOption = headingNode.FormatOption;
                 CodeBlockNode codeBlock;
                 while ((codeBlock = CodeBlockRule()) != null)
                 {
@@ -260,7 +256,7 @@ namespace Markdown.MAML.Transformer
                 TypeName = headingNode.Text
             };
 
-            typeEntity.Description = SimpleTextSectionRule(false);
+            typeEntity.Description = SimpleTextSectionRule();
 
             return typeEntity;
         }

--- a/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
@@ -253,10 +253,10 @@ namespace Markdown.MAML.Transformer
 
             MamlInputOutput typeEntity = new MamlInputOutput()
             {
-                TypeName = headingNode.Text
+                TypeName = headingNode.Text,
+                Description = SimpleTextSectionRule(),
+                FormatOption = headingNode.FormatOption
             };
-
-            typeEntity.Description = SimpleTextSectionRule();
 
             return typeEntity;
         }

--- a/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
@@ -47,12 +47,12 @@ namespace Markdown.MAML.Transformer
             {
                 case "DESCRIPTION":
                     {
-                        command.Description = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
+                        command.Description = new SectionBody(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "SYNOPSIS":
                     {
-                        command.Synopsis = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
+                        command.Synopsis = new SectionBody(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "SYNTAX":
@@ -82,7 +82,7 @@ namespace Markdown.MAML.Transformer
                     }
                 case "NOTES":
                     {
-                        command.Notes = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
+                        command.Notes = new SectionBody(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "RELATED LINKS":

--- a/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
@@ -47,12 +47,12 @@ namespace Markdown.MAML.Transformer
             {
                 case "DESCRIPTION":
                     {
-                        command.Description = SimpleTextSectionRule();
+                        command.Description = SimpleTextSectionRule(headingNode.BreakAfterHeader);
                         break;
                     }
                 case "SYNOPSIS":
                     {
-                        command.Synopsis = SimpleTextSectionRule();
+                        command.Synopsis = SimpleTextSectionRule(headingNode.BreakAfterHeader);
                         break;
                     }
                 case "SYNTAX":
@@ -82,7 +82,7 @@ namespace Markdown.MAML.Transformer
                     }
                 case "NOTES":
                     {
-                        command.Notes = SimpleTextSectionRule();
+                        command.Notes = SimpleTextSectionRule(headingNode.BreakAfterHeader);
                         break;
                     }
                 case "RELATED LINKS":

--- a/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
@@ -47,12 +47,12 @@ namespace Markdown.MAML.Transformer
             {
                 case "DESCRIPTION":
                     {
-                        command.Description = SimpleTextSectionRule(headingNode.BreakAfterHeader);
+                        command.Description = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "SYNOPSIS":
                     {
-                        command.Synopsis = SimpleTextSectionRule(headingNode.BreakAfterHeader);
+                        command.Synopsis = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "SYNTAX":
@@ -82,7 +82,7 @@ namespace Markdown.MAML.Transformer
                     }
                 case "NOTES":
                     {
-                        command.Notes = SimpleTextSectionRule(headingNode.BreakAfterHeader);
+                        command.Notes = SectionBody.New(SimpleTextSectionRule(), headingNode.FormatOption);
                         break;
                     }
                 case "RELATED LINKS":
@@ -378,6 +378,7 @@ namespace Markdown.MAML.Transformer
             };
 
             parameter.Description = ParagraphOrCodeBlockNodeRule("yaml");
+            parameter.FormatOption = headingNode.FormatOption;
 
             if (StringComparer.OrdinalIgnoreCase.Equals(parameter.Name, MarkdownStrings.CommonParametersToken))
             {

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -427,7 +427,7 @@ function Update-MarkdownHelp
             }
 
             $md = ConvertMamlModelToMarkdown -mamlCommand $newModel -metadata $metadata -PreserveFormatting
-            MySetContent -path $file.FullName -value $md -Encoding $Encoding -Force # yeild
+            MySetContent -path $file.FullName -value $md -Encoding $Encoding -Force # yield
         }
     }
 }
@@ -2276,7 +2276,7 @@ function ConvertPsObjectsToMamlModel
     
     #Get Description
     #Not provided by the command object.
-    $MamlCommandObject.Description = "{{Fill in the Description}}"
+    $MamlCommandObject.Description = New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ("{{Fill in the Description}}")
 
     #endregion 
 
@@ -2457,24 +2457,24 @@ function ConvertPsObjectsToMamlModel
         # Help object ALWAYS contains SYNOPSIS.
         # If it's not available, it's auto-generated.
         # We don't want to include auto-generated SYNOPSIS (see https://github.com/PowerShell/platyPS/issues/110)
-        $MamlCommandObject.Synopsis = "{{Fill in the Synopsis}}"
+        $MamlCommandObject.Synopsis = New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ("{{Fill in the Synopsis}}")
     }
     else 
     {
-        $MamlCommandObject.Synopsis = $Help.Synopsis.Trim()    
+        $MamlCommandObject.Synopsis = New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ($Help.Synopsis.Trim())
     }
 
     #Get Description
     if($Help.description -ne $null)
     {
-        $MamlCommandObject.Description = $Help.description.Text | AddLineBreaksForParagraphs
+        $MamlCommandObject.Description =  New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ($Help.description.Text | AddLineBreaksForParagraphs)
     }
 
     #Add to Notes
     #From the Help AlertSet data
     if($help.alertSet)
     {
-        $MamlCommandObject.Notes = $help.alertSet.alert.Text | AddLineBreaksForParagraphs
+        $MamlCommandObject.Notes =  New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ($help.alertSet.alert.Text | AddLineBreaksForParagraphs)
     }
     
     # Not provided by the command object. Using the Command Type to create a note declaring it's type.

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -64,21 +64,18 @@ Update-MarkdownHelp [-Name] <String> [-Path <String>]
 ```
 
 ## DESCRIPTION
-
 When calling Update-MarkdownHelp line breaks should be preserved.
 
 ## EXAMPLES
 
-### Example 1: Update all files in a folder
-
+### Example 1: With no line break or description
 ```
 PS C:\> Update-MarkdownHelp
 ```
 
 This is example 1 remark.
 
-### Example 2: Update one file and capture log
-
+### Example 2: With no line break
 This is an example description.
 
 ```
@@ -87,11 +84,29 @@ PS C:\> Update-MarkdownHelp
 
 This is example 2 remark.
 
+### Example 3: With line break and no description
+
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 3 remark.
+
+### Example 4: With line break and description
+
+This is an example description.
+
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 4 remark.
+
 ## PARAMETERS
 
 ### -Name
 
-Parameter name description.
+Parameter name description with line break.
 
 ```yaml
 Type: String
@@ -106,8 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-
-Parameter path description.
+Parameter path description with no line break.
 
 ```yaml
 Type: String
@@ -137,14 +151,13 @@ This is an output description.
 
 ## RELATED LINKS
 ";
-            var parser = new MarkdownParser();
-            var transformer = new ModelTransformerVersion2();
-            var renderer = new MarkdownV2Renderer(ParserMode.Full);
-            var markdownModel = parser.ParseString(new string[] { expected });
-            var mamlModel = transformer.NodeModelToMamlModel(markdownModel).FirstOrDefault();
-            var actual = renderer.MamlModelToString(mamlModel, true);
+            
+            // Parse markdown and convert back to markdown to make sure there are no changes
+            var actualFull = MarkdownStringToMarkdownString(expected, ParserMode.Full);
+            var actualFormattingPreserve = MarkdownStringToMarkdownString(expected, ParserMode.FormattingPreserve);
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expected, actualFull);
+            Assert.Equal(expected, actualFormattingPreserve);
         }
 
         [Fact]
@@ -485,6 +498,21 @@ This example demonstrates the process of registering a snap-in on your system an
             string maml = renderer.MamlModelToString(mamlModel);
 
             return maml;
+        }
+
+        private string MarkdownStringToMarkdownString(string markdown, ParserMode parserMode)
+        {
+            // Parse
+            var parser = new MarkdownParser();
+            var markdownModel = parser.ParseString(new string[] { markdown }, ParserMode.FormattingPreserve, null);
+
+            // Convert model to Maml
+            var transformer = new ModelTransformerVersion2();
+            var mamlModel = transformer.NodeModelToMamlModel(markdownModel).FirstOrDefault();
+
+            // Render as markdown
+            var renderer = new MarkdownV2Renderer(parserMode);
+            return renderer.MamlModelToString(mamlModel, true);
         }
     }
 }

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -5,6 +5,7 @@ using Markdown.MAML.Renderer;
 using Xunit;
 using Markdown.MAML.Parser;
 using Markdown.MAML.Transformer;
+using System.Linq;
 
 namespace Markdown.MAML.Test.EndToEnd
 {
@@ -45,6 +46,105 @@ And this is my last line.
 
             string[] description = GetXmlContent(maml, "/msh:helpItems/command:command/maml:description/maml:para");
             Assert.Equal(3, description.Length);
+        }
+
+        [Fact]
+        public void PreserveMarkdownWhenUpdatingMarkdownHelp()
+        {
+            var expected = @"# Update-MarkdownHelp
+
+## SYNOPSIS
+
+Example markdown to test that markdown is preserved.
+
+## SYNTAX
+
+```
+Update-MarkdownHelp [-Name] <String> [-Path <String>]
+```
+
+## DESCRIPTION
+
+When calling Update-MarkdownHelp line breaks should be preserved.
+
+## EXAMPLES
+
+### Example 1: Update all files in a folder
+
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 1 remark.
+
+### Example 2: Update one file and capture log
+
+This is an example description.
+
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 2 remark.
+
+## PARAMETERS
+
+### -Name
+
+Parameter name description.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+Parameter path description.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### String[]
+
+This is an input description.
+
+## OUTPUTS
+
+### System.Object
+
+This is an output description.
+
+## NOTES
+
+## RELATED LINKS
+";
+            var parser = new MarkdownParser();
+            var transformer = new ModelTransformerVersion2();
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+            var markdownModel = parser.ParseString(new string[] { expected });
+            var mamlModel = transformer.NodeModelToMamlModel(markdownModel).FirstOrDefault();
+            var actual = renderer.MamlModelToString(mamlModel, true);
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/test/Markdown.MAML.Test/Parser/ParserTests.cs
+++ b/test/Markdown.MAML.Test/Parser/ParserTests.cs
@@ -589,6 +589,58 @@ Deletes commands with the specified text strings. If you enter more than one str
             Assert.Equal(descriptionText, paragraphNode.Spans.First().Text);
         }
 
+        [Fact]
+        public void PreservesLineBreakAfterHeaderWithHashPrefix()
+        {
+            var expected = "This is the description text.";
+            var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n\r\n{expected}");
+
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(true, hasLineBreak);
+        }
+
+        [Fact]
+        public void PreservesNoLineBreakAfterHeaderWithHashPrefix()
+        {
+            var expected = "This is the description text.";
+            var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n{expected}");
+
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(false, hasLineBreak);
+        }
+
+        [Fact]
+        public void PreservesLineBreakAfterHeaderWithUnderlines()
+        {
+            var expected = "This is the description text.";
+            var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n\r\n{expected}");
+
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(true, hasLineBreak);
+        }
+
+        [Fact]
+        public void PreservesNoLineBreakAfterHeaderWithUnderlines()
+        {
+            var expected = "This is the description text.";
+            var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n{expected}");
+
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(false, hasLineBreak);
+        }
+
         private TNode ParseAndGetExpectedChild<TNode>(
             string markdownString, 
             MarkdownNodeType expectedNodeType)

--- a/test/Markdown.MAML.Test/Parser/ParserTests.cs
+++ b/test/Markdown.MAML.Test/Parser/ParserTests.cs
@@ -4,6 +4,7 @@ using Markdown.MAML.Model;
 using Markdown.MAML.Model.Markdown;
 using Markdown.MAML.Parser;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Markdown.MAML.Test.Parser
 {
@@ -592,82 +593,78 @@ Deletes commands with the specified text strings. If you enter more than one str
         [Fact]
         public void PreservesLineBreakAfterHeaderWithHashPrefix()
         {
-            var expected = "This is the description text.";
-            var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n\r\n{expected}");
+            var expectedSynopsis = "This is the synopsis text.";
+            var expectedDescription = "This is the description text.";
 
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            // Parse markdown
+            var documentNode = MarkdownStringToDocumentNode($"## SYNOPSIS\r\n{expectedSynopsis}\r\n\r\n## DESCRIPTION\r\n\r\n{expectedDescription}");
 
-            Assert.Equal(expected, actual);
-            Assert.Equal(true, hasLineBreak);
-        }
+            // Get results
+            var actualSynopsis = GetParagraph(documentNode, "SYNOPSIS").Spans.FirstOrDefault().Text;
+            var actualDescription = GetParagraph(documentNode, "DESCRIPTION").Spans.FirstOrDefault().Text;
+            var synopsisHasLineBreak = GetHeading(documentNode, "SYNOPSIS").FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            var descriptionHasLineBreak = GetHeading(documentNode, "DESCRIPTION").FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
-        [Fact]
-        public void PreservesNoLineBreakAfterHeaderWithHashPrefix()
-        {
-            var expected = "This is the description text.";
-            var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n{expected}");
+            // Check that text matches and line breaks haven't been captured as text
+            Assert.Equal(expectedSynopsis, actualSynopsis);
+            Assert.Equal(expectedDescription, actualDescription);
 
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            // Does not use line break and should not be added
+            Assert.Equal(false, synopsisHasLineBreak);
 
-            Assert.Equal(expected, actual);
-            Assert.Equal(false, hasLineBreak);
+            // Uses line break and should be preserved
+            Assert.Equal(true, descriptionHasLineBreak);
         }
 
         [Fact]
         public void PreservesLineBreakAfterParameter()
         {
-            var p1 = "Name parameter description.";
-            var p2 = "Path parameter description.";
-            var documentNode = MarkdownStringToDocumentNode($"## PARAMETERS\r\n\r\n### -Name\r\n\r\n{p1}\r\n\r\n```yaml\r\n```\r\n\r\n### -Path\r\n\r\n{p2}");
+            var expectedP1 = "Name parameter description.";
+            var expectedP2 = "Path parameter description.";
 
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreakP1 = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Name") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
-            var hasLineBreakP2 = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Path") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            // Parse markdown
+            var documentNode = MarkdownStringToDocumentNode($"## PARAMETERS\r\n\r\n### -Name\r\n{expectedP1}\r\n\r\n```yaml\r\n```\r\n\r\n### -Path\r\n\r\n{expectedP2}");
 
-            Assert.Equal(p1, actual);
-            Assert.Equal(true, hasLineBreakP1);
+            var actualP1 = GetParagraph(documentNode, "-Name").Spans.FirstOrDefault().Text;
+            var actualP2 = GetParagraph(documentNode, "-Path").Spans.FirstOrDefault().Text;
+            var hasLineBreakP1 = GetHeading(documentNode, "-Name").FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            var hasLineBreakP2 = GetHeading(documentNode, "-Path").FormatOption == SectionFormatOption.LineBreakAfterHeader;
+
+            // Check that text matches and line breaks haven't been captured as text
+            Assert.Equal(expectedP1, actualP1);
+            Assert.Equal(expectedP2, actualP2);
+
+            // Does not use line break and should not be added
+            Assert.Equal(false, hasLineBreakP1);
+
+            // Uses line break and should be preserved
             Assert.Equal(true, hasLineBreakP2);
-        }
-
-        [Fact]
-        public void PreservesNoLineBreakAfterParameter()
-        {
-            var expected = "This is the parameter description text.";
-            var documentNode = MarkdownStringToDocumentNode($"## PARAMETERS\r\n\r\n### -Name\r\n{expected}");
-
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Name") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
-
-            Assert.Equal(expected, actual);
-            Assert.Equal(false, hasLineBreak);
         }
 
         [Fact]
         public void PreservesLineBreakAfterHeaderWithUnderlines()
         {
-            var expected = "This is the description text.";
-            var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n\r\n{expected}");
+            var expectedSynopsis = "This is the synopsis text.";
+            var expectedDescription = "This is the description text.";
 
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            // Parse markdown
+            var documentNode = MarkdownStringToDocumentNode($"SYNOPSIS\r\n---\r\n{expectedSynopsis}\r\n\r\nDESCRIPTION\r\n---\r\n\r\n{expectedDescription}");
 
-            Assert.Equal(expected, actual);
-            Assert.Equal(true, hasLineBreak);
-        }
+            // Get results
+            var actualSynopsis = GetParagraph(documentNode, "SYNOPSIS").Spans.FirstOrDefault().Text;
+            var actualDescription = GetParagraph(documentNode, "DESCRIPTION").Spans.FirstOrDefault().Text;
+            var synopsisHasLineBreak = GetHeading(documentNode, "SYNOPSIS").FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            var descriptionHasLineBreak = GetHeading(documentNode, "DESCRIPTION").FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
-        [Fact]
-        public void PreservesNoLineBreakAfterHeaderWithUnderlines()
-        {
-            var expected = "This is the description text.";
-            var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n{expected}");
+            // Check that text matches and line breaks haven't been captured as text
+            Assert.Equal(expectedSynopsis, actualSynopsis);
+            Assert.Equal(expectedDescription, actualDescription);
 
-            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            // Does not use line break and should not be added
+            Assert.Equal(false, synopsisHasLineBreak);
 
-            Assert.Equal(expected, actual);
-            Assert.Equal(false, hasLineBreak);
+            // Uses line break and should be preserved
+            Assert.Equal(true, descriptionHasLineBreak);
         }
 
         private TNode ParseAndGetExpectedChild<TNode>(
@@ -688,6 +685,30 @@ Deletes commands with the specified text strings. If you enter more than one str
             Assert.NotNull(markdownNode);
             Assert.Equal(expectedNodeType, markdownNode.NodeType);
             return Assert.IsType<TNode>(markdownNode);
+        }
+
+        private ParagraphNode GetParagraph(DocumentNode documentNode, string heading)
+        {
+            return documentNode
+                .Children
+
+                // Skip until we reach the heading
+                .SkipWhile(node => node.NodeType != MarkdownNodeType.Heading || (node as HeadingNode).Text != heading)
+
+                // Get the next paragraph after the heading
+                .Skip(1)
+                .OfType<ParagraphNode>()
+                .FirstOrDefault();
+        }
+
+        private HeadingNode GetHeading(DocumentNode documentNode, string text = null)
+        {
+            return documentNode
+                .Children
+                .OfType<HeadingNode>()
+
+                // If heading was specified, get the specific heading
+                .FirstOrDefault(node => string.IsNullOrEmpty(text) || node.Text == text);
         }
 
         private DocumentNode MarkdownStringToDocumentNode(string markdown)

--- a/test/Markdown.MAML.Test/Parser/ParserTests.cs
+++ b/test/Markdown.MAML.Test/Parser/ParserTests.cs
@@ -596,7 +596,7 @@ Deletes commands with the specified text strings. If you enter more than one str
             var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n\r\n{expected}");
 
             var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
             Assert.Equal(expected, actual);
             Assert.Equal(true, hasLineBreak);
@@ -608,8 +608,8 @@ Deletes commands with the specified text strings. If you enter more than one str
             var expected = "This is the description text.";
             var documentNode = MarkdownStringToDocumentNode($"## DESCRIPTION\r\n{expected}");
 
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
             var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
             Assert.Equal(expected, actual);
             Assert.Equal(false, hasLineBreak);
@@ -622,7 +622,7 @@ Deletes commands with the specified text strings. If you enter more than one str
             var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n\r\n{expected}");
 
             var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
             Assert.Equal(expected, actual);
             Assert.Equal(true, hasLineBreak);
@@ -634,8 +634,8 @@ Deletes commands with the specified text strings. If you enter more than one str
             var expected = "This is the description text.";
             var documentNode = MarkdownStringToDocumentNode($"DESCRIPTION\r\n---\r\n{expected}");
 
-            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).BreakAfterHeader;
             var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading) as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
 
             Assert.Equal(expected, actual);
             Assert.Equal(false, hasLineBreak);

--- a/test/Markdown.MAML.Test/Parser/ParserTests.cs
+++ b/test/Markdown.MAML.Test/Parser/ParserTests.cs
@@ -616,6 +616,35 @@ Deletes commands with the specified text strings. If you enter more than one str
         }
 
         [Fact]
+        public void PreservesLineBreakAfterParameter()
+        {
+            var p1 = "Name parameter description.";
+            var p2 = "Path parameter description.";
+            var documentNode = MarkdownStringToDocumentNode($"## PARAMETERS\r\n\r\n### -Name\r\n\r\n{p1}\r\n\r\n```yaml\r\n```\r\n\r\n### -Path\r\n\r\n{p2}");
+
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreakP1 = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Name") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+            var hasLineBreakP2 = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Path") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+
+            Assert.Equal(p1, actual);
+            Assert.Equal(true, hasLineBreakP1);
+            Assert.Equal(true, hasLineBreakP2);
+        }
+
+        [Fact]
+        public void PreservesNoLineBreakAfterParameter()
+        {
+            var expected = "This is the parameter description text.";
+            var documentNode = MarkdownStringToDocumentNode($"## PARAMETERS\r\n\r\n### -Name\r\n{expected}");
+
+            var actual = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Paragraph) as ParagraphNode).Spans.FirstOrDefault().Text;
+            var hasLineBreak = (documentNode.Children.FirstOrDefault(node => node.NodeType == MarkdownNodeType.Heading && (node as HeadingNode).Text == "-Name") as HeadingNode).FormatOption == SectionFormatOption.LineBreakAfterHeader;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(false, hasLineBreak);
+        }
+
+        [Fact]
         public void PreservesLineBreakAfterHeaderWithUnderlines()
         {
             var expected = "This is the description text.";

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -20,7 +20,7 @@ namespace Markdown.MAML.Test.Renderer
             {
                 Name = "Get-Foo",
                 Synopsis = "This is the synopsis",
-                Description = "\r\nThis is a long description."
+                Description = "This is a long description."
             };
 
             command.Parameters.Add(new MamlParameter()
@@ -28,12 +28,25 @@ namespace Markdown.MAML.Test.Renderer
                 Type = "String",
                 Name = "Name",
                 Required = true,
-                Description = "Parameter Description.",
+                Description = "This is the name parameter description.",
                 VariableLength = true,
                 Globbing = true,
                 PipelineInput = "True (ByValue)",
                 Position = "1",
                 Aliases = new string []{"GF","Foos","Do"},
+            }
+            );
+            command.Parameters.Add(new MamlParameter()
+            {
+                Type = "String",
+                Name = "Path",
+                Required = true,
+                Description = "This is the path parameter description.",
+                VariableLength = true,
+                Globbing = true,
+                PipelineInput = "True (ByValue)",
+                Position = "2",
+                Aliases = new string[] {  },
             }
             );
             command.Inputs.Add(new MamlInputOutput()
@@ -77,6 +90,18 @@ namespace Markdown.MAML.Test.Renderer
             string[] description = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/maml:description/maml:para");
             Assert.Equal(1, description.Length);
             Assert.Equal("This is a long description.", description[0]);
+
+            string[] parameter1 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Name']/maml:Description/maml:para");
+            Assert.Equal(1, parameter1.Length);
+            Assert.Equal("This is the name parameter description.", parameter1[0]);
+
+            string[] parameter2 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Path']/maml:Description/maml:para");
+            Assert.Equal(1, parameter2.Length);
+            Assert.Equal("This is the path parameter description.", parameter2[0]);
+
+            string[] example1 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:examples/command:example[maml:title='Example 1']/dev:code");
+            Assert.Equal(1, example1.Length);
+            Assert.Equal("PS:> Get-Help -YouNeedIt", example1[0]);
         }
 
         [Fact]
@@ -141,7 +166,7 @@ namespace Markdown.MAML.Test.Renderer
 
             string[] synopsis = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
-            Assert.Equal(synopsis[0], command.Synopsis);
+            Assert.Equal(synopsis[0], command.Synopsis.Text);
         }
 
     }

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -20,7 +20,7 @@ namespace Markdown.MAML.Test.Renderer
             {
                 Name = "Get-Foo",
                 Synopsis = "This is the synopsis",
-                Description = "This is a long description."
+                Description = "\r\nThis is a long description."
             };
 
             command.Parameters.Add(new MamlParameter()
@@ -73,6 +73,10 @@ namespace Markdown.MAML.Test.Renderer
             string[] synopsis = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal("This is the synopsis", synopsis[0]);
+
+            string[] description = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/maml:description/maml:para");
+            Assert.Equal(1, description.Length);
+            Assert.Equal("This is a long description.", description[0]);
         }
 
         [Fact]

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -7,6 +7,7 @@ using Markdown.MAML.Transformer;
 using Xunit;
 using Markdown.MAML.Test.EndToEnd;
 using Markdown.MAML.Model.MAML;
+using Markdown.MAML.Model.Markdown;
 
 namespace Markdown.MAML.Test.Renderer
 {
@@ -19,8 +20,8 @@ namespace Markdown.MAML.Test.Renderer
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description."
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.")
             };
 
             command.Parameters.Add(new MamlParameter()
@@ -159,7 +160,7 @@ namespace Markdown.MAML.Test.Renderer
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "<port&number>" // < and > should be properly escaped
+                Synopsis = new SectionBody("<port&number>") // < and > should be properly escaped
             };
             
             string maml = renderer.MamlModelToString(new[] { command });

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -73,6 +73,152 @@ namespace Markdown.MAML.Test.Renderer
         }
 
         [Fact]
+        public void RendererAddLineBreakAfterParameter()
+        {
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Test-LineBreak",
+                Synopsis = SectionBody.New("This is the synopsis"),
+                Description = SectionBody.New("This is a long description"),
+                Notes = SectionBody.New("This is a note")
+            };
+
+            var parameter1 = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Name",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Required = true,
+                Description = "Name description.",
+                Globbing = true
+            };
+
+            var parameter2 = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Path",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Required = true,
+                Description = "Path description.",
+                Globbing = true
+            };
+
+            command.Parameters.Add(parameter1);
+            command.Parameters.Add(parameter2);
+
+            var syntax1 = new MamlSyntax()
+            {
+                ParameterSetName = "ByName"
+            };
+
+            syntax1.Parameters.Add(parameter1);
+            syntax1.Parameters.Add(parameter2);
+            command.Syntax.Add(syntax1);
+
+            string markdown = renderer.MamlModelToString(command, null);
+
+            Assert.Contains("### -Name\r\n\r\nName description.", markdown);
+            Assert.Contains("### -Path\r\n\r\nPath description.", markdown);
+        }
+
+        [Fact]
+        public void RendererIgnoredLineBreakAfterParameter()
+        {
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Test-LineBreak",
+                Synopsis = SectionBody.New("This is the synopsis"),
+                Description = SectionBody.New("This is a long description"),
+                Notes = SectionBody.New("This is a note")
+            };
+
+            var parameter = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Name",
+                Required = true,
+                Description = "Parameter description.",
+                Globbing = true
+            };
+
+            command.Parameters.Add(parameter);
+
+            var syntax1 = new MamlSyntax()
+            {
+                ParameterSetName = "ByName"
+            };
+
+            syntax1.Parameters.Add(parameter);
+            command.Syntax.Add(syntax1);
+
+            string markdown = renderer.MamlModelToString(command, null);
+
+            Assert.Contains("### -Name\r\nParameter description.", markdown);
+        }
+
+        [Fact]
+        public void RendererAddLineBreakAfterExample()
+        {
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Test-LineBreak",
+            };
+
+            var example1 = new MamlExample()
+            {
+                Title = "Example 1",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Code = "PS C:\\> Get-Help",
+                Remarks = "This is an example to get help."
+            };
+
+            var example2 = new MamlExample()
+            {
+                Title = "Example 2",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Code = "PS C:\\> Get-Help -Full",
+                Introduction = "Intro"
+            };
+
+            command.Examples.Add(example1);
+            command.Examples.Add(example2);
+
+            string markdown = renderer.MamlModelToString(command, null);
+
+            Assert.Contains("### Example 1\r\n\r\n```", markdown);
+            Assert.Contains("### Example 2\r\n\r\nIntro\r\n\r\n```", markdown);
+        }
+
+        [Fact]
+        public void RendererIgnoredLineBreakAfterExample()
+        {
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Test-LineBreak",
+
+            };
+
+            var example1 = new MamlExample()
+            {
+                Title = "Example 1",
+                Code = "PS C:\\> Get-Help"
+            };
+
+            command.Examples.Add(example1);
+
+            string markdown = renderer.MamlModelToString(command, null);
+
+            Assert.Contains("### Example 1\r\n```", markdown);
+        }
+
+        [Fact]
         public void RendererCreatesWorkflowParametersEntry()
         {
             var renderer = new MarkdownV2Renderer(ParserMode.Full);
@@ -120,7 +266,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-
 ", markdown);
         }
 
@@ -163,7 +308,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-
 ", markdown);
         }
 
@@ -476,7 +620,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-
 ", markdown);
         }
 

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -64,7 +64,7 @@ namespace Markdown.MAML.Test.Renderer
             MamlCommand command = new MamlCommand()
             {
                 Name = "Test-LineBreak",
-                Notes = SectionBody.New("", SectionFormatOption.LineBreakAfterHeader)
+                Notes = new SectionBody("", SectionFormatOption.LineBreakAfterHeader)
             };
 
             string markdown = renderer.MamlModelToString(command, null);
@@ -73,23 +73,22 @@ namespace Markdown.MAML.Test.Renderer
         }
 
         [Fact]
-        public void RendererAddLineBreakAfterParameter()
+        public void RendererLineBreakAfterParameter()
         {
             var renderer = new MarkdownV2Renderer(ParserMode.Full);
 
             MamlCommand command = new MamlCommand()
             {
                 Name = "Test-LineBreak",
-                Synopsis = SectionBody.New("This is the synopsis"),
-                Description = SectionBody.New("This is a long description"),
-                Notes = SectionBody.New("This is a note")
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description"),
+                Notes = new SectionBody("This is a note")
             };
 
             var parameter1 = new MamlParameter()
             {
                 Type = "String",
                 Name = "Name",
-                FormatOption = SectionFormatOption.LineBreakAfterHeader,
                 Required = true,
                 Description = "Name description.",
                 Globbing = true
@@ -119,49 +118,15 @@ namespace Markdown.MAML.Test.Renderer
 
             string markdown = renderer.MamlModelToString(command, null);
 
-            Assert.Contains("### -Name\r\n\r\nName description.", markdown);
+            // Does not use line break and should not be added
+            Assert.Contains("### -Name\r\nName description.", markdown);
+
+            // Uses line break and should be preserved
             Assert.Contains("### -Path\r\n\r\nPath description.", markdown);
         }
 
         [Fact]
-        public void RendererIgnoredLineBreakAfterParameter()
-        {
-            var renderer = new MarkdownV2Renderer(ParserMode.Full);
-
-            MamlCommand command = new MamlCommand()
-            {
-                Name = "Test-LineBreak",
-                Synopsis = SectionBody.New("This is the synopsis"),
-                Description = SectionBody.New("This is a long description"),
-                Notes = SectionBody.New("This is a note")
-            };
-
-            var parameter = new MamlParameter()
-            {
-                Type = "String",
-                Name = "Name",
-                Required = true,
-                Description = "Parameter description.",
-                Globbing = true
-            };
-
-            command.Parameters.Add(parameter);
-
-            var syntax1 = new MamlSyntax()
-            {
-                ParameterSetName = "ByName"
-            };
-
-            syntax1.Parameters.Add(parameter);
-            command.Syntax.Add(syntax1);
-
-            string markdown = renderer.MamlModelToString(command, null);
-
-            Assert.Contains("### -Name\r\nParameter description.", markdown);
-        }
-
-        [Fact]
-        public void RendererAddLineBreakAfterExample()
+        public void RendererLineBreakAfterExample()
         {
             var renderer = new MarkdownV2Renderer(ParserMode.Full);
 
@@ -173,7 +138,6 @@ namespace Markdown.MAML.Test.Renderer
             var example1 = new MamlExample()
             {
                 Title = "Example 1",
-                FormatOption = SectionFormatOption.LineBreakAfterHeader,
                 Code = "PS C:\\> Get-Help",
                 Remarks = "This is an example to get help."
             };
@@ -181,6 +145,21 @@ namespace Markdown.MAML.Test.Renderer
             var example2 = new MamlExample()
             {
                 Title = "Example 2",
+                Code = "PS C:\\> Get-Help -Full",
+                Introduction = "Intro"
+            };
+
+            var example3 = new MamlExample()
+            {
+                Title = "Example 3",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Code = "PS C:\\> Get-Help",
+                Remarks = "This is an example to get help."
+            };
+
+            var example4 = new MamlExample()
+            {
+                Title = "Example 4",
                 FormatOption = SectionFormatOption.LineBreakAfterHeader,
                 Code = "PS C:\\> Get-Help -Full",
                 Introduction = "Intro"
@@ -188,34 +167,18 @@ namespace Markdown.MAML.Test.Renderer
 
             command.Examples.Add(example1);
             command.Examples.Add(example2);
+            command.Examples.Add(example3);
+            command.Examples.Add(example4);
 
             string markdown = renderer.MamlModelToString(command, null);
 
-            Assert.Contains("### Example 1\r\n\r\n```", markdown);
-            Assert.Contains("### Example 2\r\n\r\nIntro\r\n\r\n```", markdown);
-        }
-
-        [Fact]
-        public void RendererIgnoredLineBreakAfterExample()
-        {
-            var renderer = new MarkdownV2Renderer(ParserMode.Full);
-            MamlCommand command = new MamlCommand()
-            {
-                Name = "Test-LineBreak",
-
-            };
-
-            var example1 = new MamlExample()
-            {
-                Title = "Example 1",
-                Code = "PS C:\\> Get-Help"
-            };
-
-            command.Examples.Add(example1);
-
-            string markdown = renderer.MamlModelToString(command, null);
-
+            // Does not use line break and should not be added
             Assert.Contains("### Example 1\r\n```", markdown);
+            Assert.Contains("### Example 2\r\nIntro\r\n\r\n```", markdown);
+
+            // Uses line break and should be preserved
+            Assert.Contains("### Example 3\r\n\r\n```", markdown);
+            Assert.Contains("### Example 4\r\n\r\nIntro\r\n\r\n```", markdown);
         }
 
         [Fact]
@@ -276,7 +239,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             MamlCommand command = new MamlCommand()
             {
                 Name = "Test-Quotes",
-                Description = SectionBody.New(@"”“‘’––-")
+                Description = new SectionBody(@"”“‘’––-")
             };
 
             string markdown = renderer.MamlModelToString(command, null);
@@ -318,9 +281,9 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = SectionBody.New("This is the synopsis"),
-                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs.  And the second one contains of few line! They should be auto-wrapped. Because, why not? We can do that kind of the things, no problem.\r\n\r\n-- Foo. Bar.\r\n-- Don't break. The list.\r\n-- Into. Pieces"),
-                Notes = SectionBody.New("This is a multiline note.\r\nSecond line.")
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs.  And the second one contains of few line! They should be auto-wrapped. Because, why not? We can do that kind of the things, no problem.\r\n\r\n-- Foo. Bar.\r\n-- Don't break. The list.\r\n-- Into. Pieces"),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.")
             };
 
             var parameter = new MamlParameter()
@@ -631,7 +594,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             {
                 Name = "Get-Foo",
                 SupportCommonParameters = false,
-                Description = @"Hello
+                Description = new SectionBody(@"Hello
 This \<description \> should be preserved by renderer
 With all [hyper](https://links.com) and yada
   -- yada
@@ -642,7 +605,7 @@ weired
 * [ ] But
 
 * [ ] It should be left"
-            };
+            )};
 
             command.Links.Add(
                 new MamlLink(isSimplifiedTextLink: true)

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Collections;
 using Markdown.MAML.Parser;
+using Markdown.MAML.Model.Markdown;
 
 namespace Markdown.MAML.Test.Renderer
 {
@@ -54,6 +55,21 @@ namespace Markdown.MAML.Test.Renderer
 
             string syntaxString = MarkdownV2Renderer.GetSyntaxString(command, syntax);
             Assert.Equal("Get-Foo [-Bar <BarObject>] [<CommonParameters>]", syntaxString);
+        }
+
+        [Fact]
+        public void RendererIgnoresLineBreakWhenBodyIsEmpty()
+        {
+            var renderer = new MarkdownV2Renderer(ParserMode.Full);
+            MamlCommand command = new MamlCommand()
+            {
+                Name = "Test-LineBreak",
+                Notes = SectionBody.New("", SectionFormatOption.LineBreakAfterHeader)
+            };
+
+            string markdown = renderer.MamlModelToString(command, null);
+
+            Assert.DoesNotContain("\r\n\r\n\r\n", markdown);
         }
 
         [Fact]
@@ -115,7 +131,7 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             MamlCommand command = new MamlCommand()
             {
                 Name = "Test-Quotes",
-                Description = @"”“‘’––-"
+                Description = SectionBody.New(@"”“‘’––-")
             };
 
             string markdown = renderer.MamlModelToString(command, null);
@@ -158,9 +174,9 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.  And the second one contains of few line! They should be auto-wrapped. Because, why not? We can do that kind of the things, no problem.\r\n\r\n-- Foo. Bar.\r\n-- Don't break. The list.\r\n-- Into. Pieces",
-                Notes = "This is a multiline note.\r\nSecond line."
+                Synopsis = SectionBody.New("This is the synopsis"),
+                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs.  And the second one contains of few line! They should be auto-wrapped. Because, why not? We can do that kind of the things, no problem.\r\n\r\n-- Foo. Bar.\r\n-- Don't break. The list.\r\n-- Into. Pieces"),
+                Notes = SectionBody.New("This is a multiline note.\r\nSecond line.")
             };
 
             var parameter = new MamlParameter()

--- a/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
@@ -207,9 +207,9 @@ namespace Markdown.MAML.Test.Renderer
             var command = new MamlCommand
             {
                 Name = "Test-Unit",
-                Description = SectionBody.New("A test cmdlet"),
-                Synopsis = SectionBody.New("A cmdlet to test"),
-                Notes = SectionBody.New("This is just a test"),
+                Description = new SectionBody("A test cmdlet"),
+                Synopsis = new SectionBody("A cmdlet to test"),
+                Notes = new SectionBody("This is just a test"),
                 ModuleName = "TestModule"
             };
 

--- a/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
@@ -9,6 +9,7 @@ using Markdown.MAML.Renderer;
 using Xunit;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using Markdown.MAML.Model.Markdown;
 
 namespace Markdown.MAML.Test.Renderer
 {
@@ -27,9 +28,9 @@ namespace Markdown.MAML.Test.Renderer
 
             Assert.NotNull(writtenModel);
             Assert.Equal(model.Name, writtenModel.Name);
-            Assert.Equal(model.Description, writtenModel.Remarks);
-            Assert.Equal(model.Synopsis, writtenModel.Summary);
-            Assert.Equal(model.Notes, writtenModel.Notes);
+            Assert.Equal(model.Description.Text, writtenModel.Remarks);
+            Assert.Equal(model.Synopsis.Text, writtenModel.Summary);
+            Assert.Equal(model.Notes.Text, writtenModel.Notes);
         }
 
         [Fact]
@@ -206,9 +207,9 @@ namespace Markdown.MAML.Test.Renderer
             var command = new MamlCommand
             {
                 Name = "Test-Unit",
-                Description = "A test cmdlet",
-                Synopsis = "A cmdlet to test",
-                Notes = "This is just a test",
+                Description = SectionBody.New("A test cmdlet"),
+                Synopsis = SectionBody.New("A cmdlet to test"),
+                Notes = SectionBody.New("This is just a test"),
                 ModuleName = "TestModule"
             };
 

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Markdown.MAML.Model.MAML;
+using Markdown.MAML.Model.Markdown;
 using Markdown.MAML.Transformer;
 using System;
 using System.Collections.Generic;
@@ -36,9 +37,9 @@ namespace Markdown.MAML.Test.Transformer
             Assert.Contains("---- UPDATING Cmdlet : Get-Foo ----", _reportStream);
             Assert.Contains("---- COMPLETED UPDATING Cmdlet : Get-Foo ----\r\n\r\n", _reportStream);
 
-            Assert.Equal(originalCommand.Synopsis, result.Synopsis);
-            Assert.Equal(originalCommand.Description, result.Description);
-            Assert.Equal(originalCommand.Notes, result.Notes);
+            Assert.Equal(originalCommand.Synopsis.Text, result.Synopsis.Text);
+            Assert.Equal(originalCommand.Description.Text, result.Description.Text);
+            Assert.Equal(originalCommand.Notes.Text, result.Notes.Text);
             Assert.Equal(originalCommand.Parameters[0].Description, result.Parameters[0].Description);
 
             Assert.Equal(originalCommand.Links.Count, result.Links.Count);
@@ -56,9 +57,9 @@ namespace Markdown.MAML.Test.Transformer
             MamlCommand originalCommand = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line."
+                Synopsis = SectionBody.New("This is the synopsis"),
+                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs."),
+                Notes = SectionBody.New("This is a multiline note.\r\nSecond line.")
             };
 
             var parameterName = new MamlParameter()
@@ -150,9 +151,9 @@ namespace Markdown.MAML.Test.Transformer
             MamlCommand metadataCommand = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Synopsis = "This is a old synopsis.", // DIFF!!
-                Notes = "These are old notes" // DIFF!!
+                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs."),
+                Synopsis = SectionBody.New("This is a old synopsis."), // DIFF!!
+                Notes = SectionBody.New("These are old notes") // DIFF!!
             };
 
             var parameterName1 = new MamlParameter()

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -60,9 +60,9 @@ namespace Markdown.MAML.Test.Transformer
             MamlCommand originalCommand = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = SectionBody.New("This is the synopsis"),
-                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs."),
-                Notes = SectionBody.New("This is a multiline note.\r\nSecond line.")
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.")
             };
 
             var parameterName = new MamlParameter()
@@ -164,9 +164,9 @@ namespace Markdown.MAML.Test.Transformer
             MamlCommand metadataCommand = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Description = SectionBody.New("This is a long description.\r\nWith two paragraphs."),
-                Synopsis = SectionBody.New("This is a old synopsis."), // DIFF!!
-                Notes = SectionBody.New("These are old notes") // DIFF!!
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Synopsis = new SectionBody("This is a old synopsis."), // DIFF!!
+                Notes = new SectionBody("These are old notes") // DIFF!!
             };
 
             var parameterName1 = new MamlParameter()

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -23,8 +23,8 @@ namespace Markdown.MAML.Test.Transformer
 
             var result = merger.Merge(metadataCommand, originalCommand);
 
-            Assert.Equal(2, result.Parameters.Count);
-            Assert.Equal(2, originalCommand.Parameters.Count);
+            Assert.Equal(3, result.Parameters.Count);
+            Assert.Equal(3, originalCommand.Parameters.Count);
             Assert.Equal("Name", result.Parameters[0].Name);
             Assert.Equal("NewParam", result.Parameters[1].Name);
             Assert.Contains("Parameter Updated: Name", _reportStream);
@@ -41,6 +41,9 @@ namespace Markdown.MAML.Test.Transformer
             Assert.Equal(originalCommand.Description.Text, result.Description.Text);
             Assert.Equal(originalCommand.Notes.Text, result.Notes.Text);
             Assert.Equal(originalCommand.Parameters[0].Description, result.Parameters[0].Description);
+            Assert.Equal(originalCommand.Parameters[0].FormatOption, result.Parameters[0].FormatOption);
+            Assert.Equal(originalCommand.Parameters[2].Description, result.Parameters[2].Description);
+            Assert.Equal(originalCommand.Parameters[2].FormatOption, result.Parameters[2].FormatOption);
 
             Assert.Equal(originalCommand.Links.Count, result.Links.Count);
             Assert.Equal(originalCommand.Links[0].LinkName, result.Links[0].LinkName);
@@ -88,9 +91,19 @@ namespace Markdown.MAML.Test.Transformer
                 DefaultValue = "dodododo",
                 Aliases = new string[] { "Pa1", "RemovedParam", "Gone" },
             };
+            var parameterPath = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Path",
+                Required = true,
+                Description = "Parameter path description.",
+                FormatOption = SectionFormatOption.LineBreakAfterHeader,
+                Globbing = true
+            };
 
             originalCommand.Parameters.Add(parameterName);
             originalCommand.Parameters.Add(removedParameterName);
+            originalCommand.Parameters.Add(parameterPath);
 
             var syntax1 = new MamlSyntax()
             {
@@ -98,6 +111,7 @@ namespace Markdown.MAML.Test.Transformer
             };
             syntax1.Parameters.Add(parameterName);
             syntax1.Parameters.Add(removedParameterName);
+            syntax1.Parameters.Add(parameterPath);
             originalCommand.Syntax.Add(syntax1);
 
             var syntax2 = new MamlSyntax()
@@ -106,9 +120,8 @@ namespace Markdown.MAML.Test.Transformer
                 IsDefault = true
             };
             syntax2.Parameters.Add(parameterName);
+            syntax2.Parameters.Add(parameterPath);
             originalCommand.Syntax.Add(syntax2);
-
-
 
             originalCommand.Inputs.Add(new MamlInputOutput()
             {
@@ -176,8 +189,18 @@ namespace Markdown.MAML.Test.Transformer
                 Description = "Old Param Description" 
             };
 
+            var parameterPath = new MamlParameter()
+            {
+                Type = "String",
+                Name = "Path",
+                Required = true,
+                Description = "Parameter path description.",
+                Globbing = true
+            };
+
             metadataCommand.Parameters.Add(parameterName1);
             metadataCommand.Parameters.Add(parameterNew);
+            metadataCommand.Parameters.Add(parameterPath);
 
             var syntax3 = new MamlSyntax()
             {
@@ -186,6 +209,7 @@ namespace Markdown.MAML.Test.Transformer
 
             syntax3.Parameters.Add(parameterName1);
             syntax3.Parameters.Add(parameterNew);
+            syntax3.Parameters.Add(parameterPath);
             metadataCommand.Syntax.Add(syntax3);
 
             var syntax4 = new MamlSyntax()
@@ -195,6 +219,7 @@ namespace Markdown.MAML.Test.Transformer
             };
 
             syntax4.Parameters.Add(parameterName1);
+            syntax4.Parameters.Add(parameterPath);
             metadataCommand.Syntax.Add(syntax4);
 
             return metadataCommand;

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -35,15 +35,15 @@ namespace Markdown.MAML.Test.Transformer
             Assert.Contains("Parameter Deleted: Remove", _reportStream);
             Assert.Contains("---- UPDATING Cmdlet : Get-Foo ----", _reportStream);
             Assert.Contains("---- COMPLETED UPDATING Cmdlet : Get-Foo ----\r\n\r\n", _reportStream);
-            
 
+            Assert.Equal(originalCommand.Synopsis, result.Synopsis);
+            Assert.Equal(originalCommand.Description, result.Description);
+            Assert.Equal(originalCommand.Notes, result.Notes);
             Assert.Equal(originalCommand.Parameters[0].Description, result.Parameters[0].Description);
 
             Assert.Equal(originalCommand.Links.Count, result.Links.Count);
             Assert.Equal(originalCommand.Links[0].LinkName, result.Links[0].LinkName);
             Assert.Equal(originalCommand.Links[0].LinkUri, result.Links[0].LinkUri);
-
-            
         }
 
         private void WriteMessage(string message)
@@ -151,8 +151,8 @@ namespace Markdown.MAML.Test.Transformer
             {
                 Name = "Get-Foo",
                 Description = "This is a long description.\r\nWith two paragraphs.",
-                Synopsis = "This is a old synopsis.",
-                Notes = "These are old notes"
+                Synopsis = "This is a old synopsis.", // DIFF!!
+                Notes = "These are old notes" // DIFF!!
             };
 
             var parameterName1 = new MamlParameter()

--- a/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
@@ -4,6 +4,7 @@ using Markdown.MAML.Renderer;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using Markdown.MAML.Model.Markdown;
 
 namespace Markdown.MAML.Test.Transformer
 {
@@ -98,9 +99,9 @@ Third Command
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line.\r\nFirst Command"
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.\r\nFirst Command")
             };
 
             command.Links.Add(new MamlLink(true)
@@ -154,9 +155,9 @@ Third Command
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line.\r\nSecond Command"
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.\r\nSecond Command")
             };
 
             command.Links.Add(new MamlLink(true)
@@ -211,9 +212,9 @@ Third Command
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis 3",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line.\r\nThird Command"
+                Synopsis = new SectionBody("This is the synopsis 3"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.\r\nThird Command")
             };
 
             command.Links.Add(new MamlLink(true)
@@ -338,9 +339,9 @@ Third Command
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line.\r\nFirst Command"
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.\r\nFirst Command")
             };
 
             var parameterName = new MamlParameter()
@@ -371,9 +372,9 @@ Third Command
             MamlCommand command = new MamlCommand()
             {
                 Name = "Get-Foo",
-                Synopsis = "This is the synopsis",
-                Description = "This is a long description.\r\nWith two paragraphs.",
-                Notes = "This is a multiline note.\r\nSecond line.\r\nSecond Command"
+                Synopsis = new SectionBody("This is the synopsis"),
+                Description = new SectionBody("This is a long description.\r\nWith two paragraphs."),
+                Notes = new SectionBody("This is a multiline note.\r\nSecond line.\r\nSecond Command")
             };
 
             var parameterName = new MamlParameter()

--- a/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
@@ -20,7 +20,7 @@ namespace Markdown.MAML.Test.Transformer
 
              var result = merger.Merge(input);
 
-            Assert.Equal(result.Synopsis, @"! First, Second
+            Assert.Equal(result.Synopsis.Text, @"! First, Second
 
 This is the synopsis
 
@@ -30,9 +30,9 @@ This is the synopsis 3
 
 ");
 
-            Assert.Equal(result.Description, "This is a long description.\r\nWith two paragraphs.");
+            Assert.Equal(result.Description.Text, "This is a long description.\r\nWith two paragraphs.");
 
-            Assert.Equal(result.Notes, @"! First
+            Assert.Equal(result.Notes.Text, @"! First
 
 This is a multiline note.
 Second line.

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -61,7 +61,7 @@ This is Synopsis
         [Fact]
         public void TransformCommandWithExtraLine()
         {
-            
+
             var doc = ParseString(@"
 #Add-Member
 
@@ -72,6 +72,20 @@ Adds custom properties and methods to an instance of a Windows PowerShell object
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
             Assert.Equal(mamlCommand.Name, "Add-Member");
             Assert.Equal(mamlCommand.Synopsis, "Adds custom properties and methods to an instance of a Windows PowerShell object.");
+        }
+
+        [Fact]
+        public void TransformCommandWithHeaderLineBreak()
+        {
+            var doc = ParseString(@"
+#Add-Member
+
+##SYNOPSIS
+
+Adds custom properties and methods to an instance of a Windows PowerShell object.");
+            MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
+            Assert.Equal(mamlCommand.Name, "Add-Member");
+            Assert.Equal(mamlCommand.Synopsis, "\r\nAdds custom properties and methods to an instance of a Windows PowerShell object.");
         }
 
         [Fact]
@@ -358,49 +372,43 @@ Remarks
         [Fact]
         public void HandlesHyperLinksInsideText()
         {
-            
             var doc = ParseString(@"
 # Get-Foo
 ## SYNOPSIS
-
 Runs the [Set-WSManQuickConfig]() cmdlet
 
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal(mamlCommand[0].Synopsis, "Runs the Set-WSManQuickConfig cmdlet");
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
         }
 
         [Fact]
         public void HandlesItalicInsideText()
         {
-
             var doc = ParseString(@"
 # Get-Foo
 ## SYNOPSIS
-
 Runs the *Set-WSManQuickConfig* cmdlet
 
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal(mamlCommand[0].Synopsis, "Runs the Set-WSManQuickConfig cmdlet");
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
         }
 
         [Fact]
         public void HandlesBoldInsideText()
         {
-
             var doc = ParseString(@"
 # Get-Foo
 ## SYNOPSIS
-
 Runs the **Set-WSManQuickConfig** cmdlet
 
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal(mamlCommand[0].Synopsis, "Runs the Set-WSManQuickConfig cmdlet");
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
         }
 
         [Fact]

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -20,8 +20,8 @@ namespace Markdown.MAML.Test.Transformer
 This is Synopsis
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            Assert.Equal(mamlCommand.Name, "Get-Foo");
-            Assert.Equal(mamlCommand.Synopsis, "This is Synopsis");
+            Assert.Equal("Get-Foo", mamlCommand.Name);
+            Assert.Equal("This is Synopsis", mamlCommand.Synopsis.Text);
         }
 
         [Fact]
@@ -34,8 +34,8 @@ This is Synopsis
 Here is a [hyperlink](http://non-existing-uri).
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            Assert.Equal(mamlCommand.Name, "Get-Foo");
-            Assert.Equal(mamlCommand.Synopsis, "Here is a hyperlink (http://non-existing-uri).");
+            Assert.Equal("Get-Foo", mamlCommand.Name);
+            Assert.Equal("Here is a hyperlink (http://non-existing-uri).", mamlCommand.Synopsis.Text);
         }
 
         [Fact]
@@ -54,14 +54,13 @@ schema: 2.0.0
 This is Synopsis
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            Assert.Equal(mamlCommand.Name, "Get-Foo");
-            Assert.Equal(mamlCommand.Synopsis, "This is Synopsis");
+            Assert.Equal("Get-Foo", mamlCommand.Name);
+            Assert.Equal("This is Synopsis", mamlCommand.Synopsis.Text);
         }
 
         [Fact]
         public void TransformCommandWithExtraLine()
         {
-
             var doc = ParseString(@"
 #Add-Member
 
@@ -70,8 +69,8 @@ Adds custom properties and methods to an instance of a Windows PowerShell object
 
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            Assert.Equal(mamlCommand.Name, "Add-Member");
-            Assert.Equal(mamlCommand.Synopsis, "Adds custom properties and methods to an instance of a Windows PowerShell object.");
+            Assert.Equal("Add-Member", mamlCommand.Name);
+            Assert.Equal("Adds custom properties and methods to an instance of a Windows PowerShell object.", mamlCommand.Synopsis.Text);
         }
 
         [Fact]
@@ -84,8 +83,59 @@ Adds custom properties and methods to an instance of a Windows PowerShell object
 
 Adds custom properties and methods to an instance of a Windows PowerShell object.");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            Assert.Equal(mamlCommand.Name, "Add-Member");
-            Assert.Equal(mamlCommand.Synopsis, "\r\nAdds custom properties and methods to an instance of a Windows PowerShell object.");
+            Assert.Equal("Add-Member", mamlCommand.Name);
+            Assert.Equal("Adds custom properties and methods to an instance of a Windows PowerShell object.", mamlCommand.Synopsis.Text);
+            Assert.Equal(SectionFormatOption.LineBreakAfterHeader, mamlCommand.Synopsis.FormatOption);
+        }
+
+        [Fact]
+        public void TransformCommandWithParameterHeaderLineBreak()
+        {
+            var doc = ParseString(@"
+# Add-Member
+
+## PARAMETERS
+
+### -Name
+
+This is the name parameter.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+");
+            MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
+            Assert.Equal("This is the name parameter.", mamlCommand.Parameters[0].Description);
+            Assert.Equal(SectionFormatOption.LineBreakAfterHeader, mamlCommand.Parameters[0].FormatOption);
+        }
+
+        [Fact]
+        public void TransformCommandWithExampleHeaderLineBreak()
+        {
+            var doc = ParseString(@"
+# Add-Member
+
+## EXAMPLES
+
+### Example 1
+
+This is an example.
+
+```powershell
+PS C:\> Get-PSDocumentHeader -Path '.\build\Default\Server1.md';
+```
+");
+            MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
+            Assert.Equal("This is an example.", mamlCommand.Examples[0].Introduction);
+            Assert.Equal(SectionFormatOption.LineBreakAfterHeader, mamlCommand.Examples[0].FormatOption);
         }
 
         [Fact]
@@ -105,7 +155,7 @@ I'm a multiline description.
 And this is my last line.
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
-            string[] description = mamlCommand.Description.Split('\n').Select(x => x.Trim()).ToArray();
+            string[] description = mamlCommand.Description.Text.Split('\n').Select(x => x.Trim()).ToArray();
             Assert.Equal(3, description.Length);
             Assert.Equal("Hello,", description[0]);
             Assert.Equal("I'm a multiline description.", description[1]);
@@ -380,7 +430,7 @@ Runs the [Set-WSManQuickConfig]() cmdlet
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis.Text);
         }
 
         [Fact]
@@ -394,7 +444,7 @@ Runs the *Set-WSManQuickConfig* cmdlet
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis.Text);
         }
 
         [Fact]
@@ -408,7 +458,7 @@ Runs the **Set-WSManQuickConfig** cmdlet
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
             Assert.Equal(mamlCommand.Count(), 1);
-            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis);
+            Assert.Equal("Runs the Set-WSManQuickConfig cmdlet", mamlCommand[0].Synopsis.Text);
         }
 
         [Fact]
@@ -512,7 +562,6 @@ Accept wildcard characters: false
 ## PARAMETERS
 
 ### NonExistingTypeParam
-
 This is NonExistingTypeParam description.
 
 ```yaml
@@ -1022,7 +1071,7 @@ This description block test formatting preservance.
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
             Assert.Equal("Get-Foo", mamlCommand.Name);
 
-            Assert.Equal(description, mamlCommand.Description);
+            Assert.Equal(description, mamlCommand.Description.Text);
         }
 
         private DocumentNode ParseString(string markdown)

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -606,9 +606,9 @@ Describe 'Get-Help & Get-Command on Add-Computer to build MAML Model Object' {
         It 'Validates attributes by checking several sections of the single attributes for Add-Computer' {
             
             $mamlModelObject.Name | Should be "Add-Computer"
-            $mamlModelObject.Synopsis | Should be "Add the local computer to a domain or workgroup."
-            $mamlModelObject.Description.Substring(0,135) | Should be "The Add-Computer cmdlet adds the local computer or remote computers to a domain or workgroup, or moves them from one domain to another."
-            $mamlModelObject.Notes.Substring(0,31) | Should be "In Windows PowerShell 2.0, the "
+            $mamlModelObject.Synopsis.Text | Should be "Add the local computer to a domain or workgroup."
+            $mamlModelObject.Description.Text.Substring(0,135) | Should be "The Add-Computer cmdlet adds the local computer or remote computers to a domain or workgroup, or moves them from one domain to another."
+            $mamlModelObject.Notes.Text.Substring(0,31) | Should be "In Windows PowerShell 2.0, the "
         }
 
         It 'Validates the examples by checking Add-Computer Example 1' {


### PR DESCRIPTION
* Updates to markdown parser and renderer to preserve line breaks after headers. Multiple line breaks are ignored.
* Extra line break is removed when related links does not contain any links.
* Test cases updated to test for preserving line breaks and when line breaks are absent.

Fix #319 

