### PR TITLE
Update to maml rendered to pad example titles issue #119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 * Clean up trailing whitespace during markdown generation [#225](https://github.com/PowerShell/platyPS/issues/225)
 * Preserve line breaks after headers when Update-MarkdownHelp is used [#319](https://github.com/PowerShell/platyPS/issues/319)
+* MAML generation now pads example titles with dash (-) to improve readability [#119](https://github.com/PowerShell/platyPS/issues/119)
 
 ## 0.8.3
 

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -19,6 +19,9 @@ namespace Markdown.MAML.Renderer
         private static XNamespace devNS = XNamespace.Get("http://schemas.microsoft.com/maml/dev/2004/10");
         private static XNamespace msHelpNS = XNamespace.Get("http://msdn.microsoft.com/mshelp");
 
+        private static char examplePadChar = '-';
+        private static char space = ' ';
+
         /// <summary>
         /// 
         /// </summary>
@@ -161,7 +164,7 @@ namespace Markdown.MAML.Renderer
         private static XElement CreateExample(MamlExample example)
         {
             return new XElement(commandNS + "example",
-                    new XElement(mamlNS + "title", example.Title),
+                    new XElement(mamlNS + "title", PadExampleTitle(example.Title)),
                     new XElement(devNS + "code", example.Code),
                     new XElement(devNS + "remarks", GenerateParagraphs(example.Remarks)));
         }
@@ -187,6 +190,30 @@ namespace Markdown.MAML.Renderer
             return new XElement(mamlNS + "navigationLink",
                     new XElement(mamlNS + "linkText", link.LinkName),
                     new XElement(mamlNS + "uri", uriValue));
+        }
+
+        /// <summary>
+        /// Generate (-) padding for example title
+        /// </summary>
+        /// <param name="title">The title to pa.</param>
+        /// <returns>The title padded by dashes</returns>
+        private static string PadExampleTitle(string title)
+        {
+            // Filter out edge cases where title is too long or empty
+            if (string.IsNullOrWhiteSpace(title) || title.Length >= 62)
+            {
+                return title;
+            }
+
+            // Pad example title with dash (-) to increase readability up to 64 characters
+
+            int padLength = (64 - title.Length - 2) / 2;
+
+            return title
+                .PadLeft(title.Length + 1, space)
+                .PadRight(title.Length + 2, space)
+                .PadLeft(title.Length + 2 + padLength, examplePadChar)
+                .PadRight(title.Length + 2 + 2 * padLength, examplePadChar);
         }
 
         private static string ConvertPSTypeToMamlType(MamlParameter parameter)

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -269,7 +269,6 @@ namespace Markdown.MAML.Renderer
 
         private bool ShouldBreak(SectionFormatOption formatOption)
         {
-            // If the line break flag is set return true.
             return formatOption.HasFlag(SectionFormatOption.LineBreakAfterHeader);
         }
 

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -344,7 +344,7 @@ namespace Markdown.MAML.Renderer
             {
                 var extraNewLine = ShouldBreak(example.FormatOption);
 
-                AddHeader(ModelTransformerBase.EXAMPLE_HEADING_LEVEL, example.Title, extraNewLine: extraNewLine);
+                AddHeader(ModelTransformerBase.EXAMPLE_HEADING_LEVEL, GetExampleTitle(example.Title), extraNewLine: extraNewLine);
 
                 if (!string.IsNullOrEmpty(example.Introduction))
                 {
@@ -363,11 +363,22 @@ namespace Markdown.MAML.Renderer
             }
         }
 
+        private static string GetExampleTitle(string title)
+        {
+            var match = Regex.Match(title, @"^(-| ){0,}(?<title>([^\f\n\r\t\v\x85\p{Z}-][^\f\n\r\t\v\x85]+[^\f\n\r\t\v\x85\p{Z}-]))(-| ){0,}$");
+            
+            if (match.Success)
+            {
+                return match.Groups["title"].Value;
+            }
+
+            return title;
+        }
+
         public static string GetSyntaxString(MamlCommand command, MamlSyntax syntax)
         {
             return GetSyntaxString(command, syntax, DEFAULT_SYNTAX_WIDTH);
         }
-
 
         public static string GetSyntaxString(MamlCommand command, MamlSyntax syntax, int maxSyntaxWidth)
         {

--- a/src/Markdown.MAML/Transformer/MamlModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlModelMerger.cs
@@ -214,7 +214,6 @@ namespace Markdown.MAML.Transformer
                             _cmdletUpdated = true;
                         }
 
-                        // Update the parameter with the merged in FormatOption
                         param.FormatOption = strParam.FormatOption;
                     }
 

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -12,12 +12,28 @@ namespace Markdown.MAML.Test.EndToEnd
     public class EndToEndTests
     {
         [Fact]
-        public void ProduceNameAndSynopsis()
+        public void ProduceMamlFromMarkdown()
         {
             string maml = MarkdownStringToMamlString(@"
 # Get-Foo
 ## Synopsis
 This is Synopsis
+## Examples
+### Example 1
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 1 remark.
+
+### Example 2: With a long title
+This is an example description.
+
+```
+PS C:\> Update-MarkdownHelp
+```
+
+This is example 2 remark.
 ");
             string[] name = GetXmlContent(maml, "/msh:helpItems/command:command/command:details/command:name");
             Assert.Equal(1, name.Length);
@@ -26,6 +42,13 @@ This is Synopsis
             string[] synopsis = GetXmlContent(maml, "/msh:helpItems/command:command/command:details/maml:description/maml:para");
             Assert.Equal(1, synopsis.Length);
             Assert.Equal("This is Synopsis", synopsis[0]);
+
+            // Check that example title is reproduced with dash (-) padding
+            string[] example = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:examples/command:example/maml:title");
+            Assert.Equal(63, example[0].Length);
+            Assert.Equal(64, example[1].Length);
+            Assert.Matches($"^-+ Example 1 -+$", example[0]);
+            Assert.Matches($"^-+ Example 2: With a long title -+$", example[1]);
         }
 
         [Fact]
@@ -457,14 +480,12 @@ This example demonstrates the process of registering a snap-in on your system an
             Assert.Equal(5 + 3, examples.Length);
         }
 
-
         public static string[] GetXmlContent(string xml, string xpath)
         {
             List<string> result = new List<string>(); 
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(xml);
             var nav = xmlDoc.CreateNavigator();
-
 
             XmlNamespaceManager xmlns = new XmlNamespaceManager(nav.NameTable);
             xmlns.AddNamespace("command", "http://schemas.microsoft.com/maml/dev/command/2004/10");

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -126,7 +126,7 @@ namespace Markdown.MAML.Test.Renderer
         }
 
         [Fact]
-        public void RendererLineBreakAfterExample()
+        public void RendersExamplesFromMaml()
         {
             var renderer = new MarkdownV2Renderer(ParserMode.Full);
 
@@ -165,10 +165,34 @@ namespace Markdown.MAML.Test.Renderer
                 Introduction = "Intro"
             };
 
+            var example5 = new MamlExample()
+            {
+                Title = "---Example 5---",
+                Code = "PS C:\\> Get-Help -Full",
+                Introduction = "With some dashes and no spaces"
+            };
+
+            var example6 = new MamlExample()
+            {
+                Title = "------------------ Example 6: With extra info ------------------",
+                Code = "PS C:\\> Get-Help -Full",
+                Introduction = "Padded to 64 characters and spaces"
+            };
+
+            var example7 = new MamlExample()
+            {
+                Title = "Example 7: ".PadRight(66, 'A'),
+                Code = "PS C:\\> Get-Help -Full",
+                Introduction = "Greater then 64 characters"
+            };
+
             command.Examples.Add(example1);
             command.Examples.Add(example2);
             command.Examples.Add(example3);
             command.Examples.Add(example4);
+            command.Examples.Add(example5);
+            command.Examples.Add(example6);
+            command.Examples.Add(example7);
 
             string markdown = renderer.MamlModelToString(command, null);
 
@@ -179,6 +203,11 @@ namespace Markdown.MAML.Test.Renderer
             // Uses line break and should be preserved
             Assert.Contains("### Example 3\r\n\r\n```", markdown);
             Assert.Contains("### Example 4\r\n\r\nIntro\r\n\r\n```", markdown);
+
+            // Includes title padding that should be removed
+            Assert.Contains("### Example 5\r\n", markdown);
+            Assert.Contains("### Example 6: With extra info\r\n", markdown);
+            Assert.Contains($"### {example7.Title}\r\n", markdown);
         }
 
         [Fact]

--- a/test/Pester/FullLoop.Tests.ps1
+++ b/test/Pester/FullLoop.Tests.ps1
@@ -73,9 +73,19 @@ Describe 'Full loop for Add-Member cmdlet' {
         # this '-' before force could be screwed up
         0..($generatedHelpObject.examples.example.Count - 1) | ForEach-Object {
             It ('generate correct example ' + ($generatedHelpObject.examples.example[$_].title)) -Skip:($_ -eq 5) {
-                ($generatedHelpObject.examples.example[$_] | Out-String).TrimEnd() | Should Be ($originalHelpObject.examples.example[$_] | Out-String).TrimEnd()
+                
+                $exampleExtractionRegex = '^(-| ){0,}(?<title>([^\f\n\r\t\v\x85\p{Z}-][^\f\n\r\t\v\x85]+[^\f\n\r\t\v\x85\p{Z}-]))(-| ){0,}(\r|\n){1,}(?<body>(\S|\s)+)';
+                $generatedMatches = [Regex]::Match(($generatedHelpObject.examples.example[$_] | Out-String).Trim(), $exampleExtractionRegex)
+                $originalMatches = [Regex]::Match(($originalHelpObject.examples.example[$_] | Out-String).Trim(), $exampleExtractionRegex)
+                
+                # Confirm match completed successfully
+                $generatedMatches.Success | Should Be $True
+                $originalMatches.Success | Should Be $True
+
+                # Match clean title and clean body seperately
+                $generatedMatches.Groups['title'].Value | Should Be $originalMatches.Groups['title'].Value
+                $generatedMatches.Groups['body'].Value | Should Be $originalMatches.Groups['body'].Value
             }
-            #($generatedHelpObject.examples | Out-String) | Should Be ($originalHelpObject.examples | Out-String)
         }
     }
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -884,7 +884,7 @@ It has mutlilines. And hyper (http://link.com).
     It 'has a placeholder for example' {
         ($Help.examples.example | Measure-Object).Count | Should Be 1
         $e = $Help.examples.example
-        $e.Title | Should Be 'Example 1'
+        $e.Title | Should Match '-+ Example 1 -+'
         $e.Code | Should Match 'PS C:\>*'
     }
     


### PR DESCRIPTION
* MAML generation now pads example titles with dash (-) to improve readability #119

Fix #119