### PR TITLE
Help cleanup of trailing spaces and line breaks

### DIFF
--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -51,7 +51,7 @@ Specifies an array of paths of MAML external help files.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -67,7 +67,7 @@ This output follows TechNet formatting.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -84,7 +84,7 @@ Markdown accepts single-hyphens for lists.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -109,4 +109,3 @@ This cmdlet returns a **Help** object, which is the same output as **Get-Help**.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -96,7 +96,7 @@ Specifies an array of paths of markdown files or folders.
 ```yaml
 Type: String[]
 Parameter Sets: FromPath
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -112,7 +112,7 @@ Specifies a string that contains markdown formatted text.
 ```yaml
 Type: String
 Parameter Sets: FromMarkdownString
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -138,4 +138,3 @@ The dictionary contains key-value pairs found in the markdown metadata block.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docs/Merge-MarkdownHelp.md
+++ b/docs/Merge-MarkdownHelp.md
@@ -1,7 +1,7 @@
 ---
 external help file: platyPS-help.xml
 Module Name: platyPS
-online version: 
+online version:
 schema: 2.0.0
 ---
 
@@ -58,7 +58,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -74,7 +74,7 @@ By default cmdlets and parameters that are present in all variations don't get a
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -89,7 +89,7 @@ Indicates that this cmdlet overwrites an existing file that has the same name.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -105,7 +105,7 @@ Applicable tag list would be included after the marker
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 3
@@ -120,7 +120,7 @@ Specifies the path of the folder where this cmdlet creates the combined markdown
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -136,7 +136,7 @@ This cmdlet creates combined markdown help based on these files and folders.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -159,4 +159,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -82,7 +82,7 @@ The folder name should end with a locale folder, as in the following example: `.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -102,7 +102,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -117,7 +117,7 @@ Indicates that this cmdlet overwrites an existing file that has the same name.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -133,7 +133,7 @@ This cmdlet creates external help based on these files and folders.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -153,7 +153,7 @@ See [design issue](https://github.com/PowerShell/platyPS/issues/273) for more de
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -173,7 +173,7 @@ MaxAboutWidth parameter.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -194,7 +194,7 @@ If this path is not provided, no log will be generated.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -50,7 +50,7 @@ Specifies the folder that contains the help content that this cmdlet packages in
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -67,7 +67,7 @@ For the required metadata, run **New-MarkdownHelp** with the *WithLandingPage* p
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -83,7 +83,7 @@ Specifies the location of the .cab file and helpinfo.xml file that this cmdlet c
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -98,7 +98,7 @@ Automatically increment the help version in the module markdown file.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/New-MarkdownAboutHelp.md
+++ b/docs/New-MarkdownAboutHelp.md
@@ -65,7 +65,7 @@ The name of the about topic.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -80,7 +80,7 @@ The directory to create the about topic in.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -136,7 +136,7 @@ This can be any command supported by Windows PowerShell help, such as a cmdlet o
 ```yaml
 Type: String[]
 Parameter Sets: FromCommand
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -155,7 +155,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -170,7 +170,7 @@ Indicates that this cmdlet overwrites existing files that have the same names.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -187,7 +187,7 @@ This value is used as markdown header metadata in the module page.
 ```yaml
 Type: String
 Parameter Sets: FromModule, FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -204,7 +204,7 @@ This value is used as markdown header metadata in the module page.
 ```yaml
 Type: String
 Parameter Sets: FromModule, FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -221,7 +221,7 @@ This value is used as markdown header metadata in the module page.
 ```yaml
 Type: String
 Parameter Sets: FromModule, FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -236,7 +236,7 @@ Specifies an array of paths path of MAML .xml help files.
 ```yaml
 Type: String[]
 Parameter Sets: FromMaml
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -256,7 +256,7 @@ External tools can use this metadata.
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -271,7 +271,7 @@ Specifies an array of names of modules for which this cmdlet creates help in mar
 ```yaml
 Type: String[]
 Parameter Sets: FromModule
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -288,7 +288,7 @@ This value is used as markdown header metadata in the module page.
 ```yaml
 Type: String
 Parameter Sets: FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -305,7 +305,7 @@ This value is used as markdown header metadata in the module page.
 ```yaml
 Type: String
 Parameter Sets: FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -320,7 +320,7 @@ Indicates that this cmdlet does not write any metadata in the generated markdown
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -336,7 +336,7 @@ If you do not specify a value, the cmdlet uses an empty string.
 ```yaml
 Type: String
 Parameter Sets: FromCommand
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -351,7 +351,7 @@ Specifies the path of the folder where this cmdlet creates the markdown help fil
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -369,7 +369,7 @@ If you did not specify that parameter, the cmdlet supplies the default name Maml
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromModule, FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -385,7 +385,7 @@ This output follows TechNet formatting.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -402,7 +402,7 @@ Markdown accepts single-hyphens for lists.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromMaml
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -419,7 +419,7 @@ These parameters are common and hence have well-defined behavior.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -434,7 +434,7 @@ Indicates that the target document will use a full type name instead of a short 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/New-YamlHelp.md
+++ b/docs/New-YamlHelp.md
@@ -80,7 +80,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -95,7 +95,7 @@ Indicates that this cmdlet overwrites an existing file that has the same name.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -111,7 +111,7 @@ This cmdlet creates external help based on these files and folders.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -126,7 +126,7 @@ Specifies the folder to create the YAML files in
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -151,4 +151,3 @@ This cmdlet returns a **FileInfo[]** object for created files.
 ## NOTES
 
 ## RELATED LINKS
-

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -82,7 +82,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -98,7 +98,7 @@ Indicates that this cmdlet appends information to the log instead overwriting it
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -116,7 +116,7 @@ If you specify the *Verbose* parameter, this cmdlet also writes that information
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
@@ -132,7 +132,7 @@ Specifies an array of paths of markdown files and folders to update.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -149,7 +149,7 @@ These parameters are common and hence have well-defined behavior.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -164,7 +164,7 @@ Indicates that the target document will use a full type name instead of a short 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -58,7 +58,7 @@ For more information, see [Using PowerShell to write a file in UTF-8 without the
 ```yaml
 Type: Encoding
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -74,7 +74,7 @@ Indicates that this cmdlet appends information to the log instead overwriting it
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -92,7 +92,7 @@ If you specify the *Verbose* parameter, this cmdlet also writes that information
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
@@ -109,7 +109,7 @@ The folder must contain a module page from which this cmdlet can get the module 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -124,7 +124,7 @@ Update module page when updating the help module.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -141,7 +141,7 @@ These parameters are common and hence have well-defined behavior.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named

--- a/templates/aboutTemplate.md
+++ b/templates/aboutTemplate.md
@@ -14,7 +14,7 @@ This will be transformed into the text file
 as `about_SomeHelpTopicFileName`.
 Do not include file extensions.
 The second header should have no spaces.
-```              
+```
 
 # SHORT DESCRIPTION
 {{ Short Description Placeholder }}
@@ -54,4 +54,4 @@ The generated about topic will be encoded UTF-8.
 - {{ Keyword Placeholder }}
 - {{ Keyword Placeholder }}
 - {{ Keyword Placeholder }}
-- {{ Keyword Placeholder }}    
+- {{ Keyword Placeholder }}


### PR DESCRIPTION
* Minor help updates based on rerunning `Update-MarkdownHelp` to remove trailing spaces and line breaks
* Clean up trailing spaces from about_ help template