### PR TITLE
Add PowerShell language info-string to code blocks issue #318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 * Preserve line breaks after headers when Update-MarkdownHelp is used [#319](https://github.com/PowerShell/platyPS/issues/319)
 * MAML generation now pads example titles with dash (-) to improve readability [#119](https://github.com/PowerShell/platyPS/issues/119)
 * Fixed issue with New-MarkdownHelp preventing CommonParameter being added for advanced functions and workflows [#223](https://github.com/PowerShell/platyPS/issues/223) [#253](https://github.com/PowerShell/platyPS/issues/253)
+* Fixed issue with Update-MarkdownHelp removing named info-string from code fence [#318](https://github.com/PowerShell/platyPS/issues/318)
+* Update-MarkdownHelp and New-MarkdownHelp will now add PowerShell language info-string to code blocks [#294](https://github.com/PowerShell/platyPS/issues/294)
 
 ## 0.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ CHANGELOG
 ## Not released
 
 * Clean up trailing whitespace during markdown generation [#225](https://github.com/PowerShell/platyPS/issues/225)
-* Preserve line breaks after headers when Update-MarkdownHelp is used [#319](https://github.com/PowerShell/platyPS/issues/319)
+* Preserve line breaks after headers when `Update-MarkdownHelp` is used [#319](https://github.com/PowerShell/platyPS/issues/319)
 * MAML generation now pads example titles with dash (-) to improve readability [#119](https://github.com/PowerShell/platyPS/issues/119)
-* Fixed issue with New-MarkdownHelp preventing CommonParameter being added for advanced functions and workflows [#223](https://github.com/PowerShell/platyPS/issues/223) [#253](https://github.com/PowerShell/platyPS/issues/253)
-* Fixed issue with Update-MarkdownHelp removing named info-string from code fence [#318](https://github.com/PowerShell/platyPS/issues/318)
-* Update-MarkdownHelp and New-MarkdownHelp will now add PowerShell language info-string to code blocks [#294](https://github.com/PowerShell/platyPS/issues/294)
+* Fixed issue with `New-MarkdownHelp` preventing CommonParameter being added for advanced functions and workflows [#223](https://github.com/PowerShell/platyPS/issues/223) [#253](https://github.com/PowerShell/platyPS/issues/253)
+* Fixed issue with `Update-MarkdownHelp` removing named info-string from code fence [#318](https://github.com/PowerShell/platyPS/issues/318)
 
 ## 0.8.3
 

--- a/src/Markdown.MAML/Markdown.MAML.csproj
+++ b/src/Markdown.MAML/Markdown.MAML.csproj
@@ -50,6 +50,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\MAML\MamlCodeBlock.cs" />
     <Compile Include="Model\MAML\MamlExample.cs" />
     <Compile Include="Model\MAML\MamlInputOutput.cs" />
     <Compile Include="Model\MAML\MamlLink.cs" />

--- a/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
@@ -19,6 +19,7 @@ namespace Markdown.MAML.Model.MAML
 
         /// <summary>
         /// An optional language or info-string. If no language string is suppled plain text is assumed.
+        /// For more information see: http://spec.commonmark.org/0.28/#info-string
         /// </summary>
         public string LanguageMoniker { get; private set; }
 

--- a/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
@@ -14,7 +14,7 @@ namespace Markdown.MAML.Model.MAML
         public MamlCodeBlock(string text, string languageMoniker = null)
         {
             Text = text;
-            LanguageMoniker = languageMoniker;
+            LanguageMoniker = languageMoniker ?? string.Empty;
         }
 
         /// <summary>

--- a/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlCodeBlock.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Markdown.MAML.Model.MAML
+{
+    /// <summary>
+    /// A section of code such as PowerShell commands or command output.
+    /// </summary>
+    public sealed class MamlCodeBlock
+    {
+        public MamlCodeBlock(string text, string languageMoniker = null)
+        {
+            Text = text;
+            LanguageMoniker = languageMoniker;
+        }
+
+        /// <summary>
+        /// An optional language or info-string. If no language string is suppled plain text is assumed.
+        /// </summary>
+        public string LanguageMoniker { get; private set; }
+
+        /// <summary>
+        /// The text of the code block.
+        /// </summary>
+        public string Text { get; private set; }
+    }
+}

--- a/src/Markdown.MAML/Model/MAML/MamlExample.cs
+++ b/src/Markdown.MAML/Model/MAML/MamlExample.cs
@@ -10,7 +10,7 @@ namespace Markdown.MAML.Model.MAML
     public class MamlExample
     {
         public string Title { get; set; }
-        public string Code { get; set; }
+        public MamlCodeBlock[] Code { get; set; }
         public string Remarks { get; set; }
         public string Introduction { get; set; }
 

--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -165,7 +165,7 @@ namespace Markdown.MAML.Renderer
         {
             return new XElement(commandNS + "example",
                     new XElement(mamlNS + "title", PadExampleTitle(example.Title)),
-                    new XElement(devNS + "code", example.Code),
+                    new XElement(devNS + "code", string.Join("\r\n\r\n", example.Code.Select(block => block.Text))),
                     new XElement(devNS + "remarks", GenerateParagraphs(example.Remarks)));
         }
 

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -20,11 +20,7 @@ namespace Markdown.MAML.Renderer
     {
         private StringBuilder _stringBuilder = new StringBuilder();
 
-        private static Regex DetectPSLanguageExpression = new Regex(@"^(PS C:\\>| {0,}[a-z]{3,11}-[a-z0-9]{2,}|#)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private ParserMode _mode;
-
-        private int _maxLineWidth { get; set; }
 
         public int MaxSyntaxWidth { get; private set; }
 
@@ -39,11 +35,6 @@ namespace Markdown.MAML.Renderer
         {
             this.MaxSyntaxWidth = maxSyntaxWidth;
             this._mode = mode;
-        }
-
-        public MarkdownV2Renderer(int maxLineWidth)
-        {
-            _maxLineWidth = maxLineWidth;
         }
 
         public string MamlModelToString(MamlCommand mamlCommand, bool skipYamlHeader)
@@ -354,9 +345,12 @@ namespace Markdown.MAML.Renderer
                     AddParagraphs(example.Introduction);
                 }
 
-                for (var i = 0; example.Code != null && i < example.Code.Length; i++)
+                if (example.Code != null)
                 {
-                    AddCodeSnippet(example.Code[i].Text, example.Code[i].LanguageMoniker, true);
+                    for (var i = 0; i < example.Code.Length; i++)
+                    {
+                        AddCodeSnippet(example.Code[i].Text, example.Code[i].LanguageMoniker);
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(example.Remarks))
@@ -473,13 +467,8 @@ namespace Markdown.MAML.Renderer
             }
         }
 
-        private void AddCodeSnippet(string code, string lang = "", bool detectLanguage = false)
+        private void AddCodeSnippet(string code, string lang = "")
         {
-            if (detectLanguage && string.IsNullOrEmpty(lang))
-            {
-                lang = DetectLanguage(code);
-            }
-
             _stringBuilder.AppendFormat("```{1}{2}{0}{2}```{2}{2}", code, lang, Environment.NewLine);
         }
 
@@ -611,23 +600,7 @@ namespace Markdown.MAML.Renderer
                 // per https://github.com/PowerShell/platyPS/issues/121 we don't perform escaping for () in markdown renderer, but we do in the parser
                 //.Replace(@"(", @"\(")
                 //.Replace(@")", @"\)")
-                .Replace(@"`", @"\`")
-
-                ;
-        }
-
-        private string DetectLanguage(string hint)
-        {
-            // Detect PowerShell based on first line
-            // - Look PS C:\> prefix followed 
-            // - Look for standalone PowerShell verbs-noun, current verbs use 3-11 characters
-            // - Look for inline help # character
-            if (DetectPSLanguageExpression.IsMatch(hint))
-            {
-                return "powershell";
-            }
-
-            return string.Empty;
+                .Replace(@"`", @"\`");
         }
     }
 }

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -352,9 +352,9 @@ namespace Markdown.MAML.Renderer
                     AddParagraphs(example.Introduction);
                 }
 
-                if (example.Code != null)
+                for (var i = 0; example.Code != null && i < example.Code.Length; i++)
                 {
-                    AddCodeSnippet(example.Code);
+                    AddCodeSnippet(example.Code[i].Text, example.Code[i].LanguageMoniker);
                 }
 
                 if (!string.IsNullOrEmpty(example.Remarks))

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -20,6 +20,8 @@ namespace Markdown.MAML.Renderer
     {
         private StringBuilder _stringBuilder = new StringBuilder();
 
+        private static Regex DetectPSLanguageExpression = new Regex(@"^(PS C:\\>| {0,}[a-z]{3,11}-[a-z0-9]{2,}|#)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private ParserMode _mode;
 
         private int _maxLineWidth { get; set; }
@@ -354,7 +356,7 @@ namespace Markdown.MAML.Renderer
 
                 for (var i = 0; example.Code != null && i < example.Code.Length; i++)
                 {
-                    AddCodeSnippet(example.Code[i].Text, example.Code[i].LanguageMoniker);
+                    AddCodeSnippet(example.Code[i].Text, example.Code[i].LanguageMoniker, true);
                 }
 
                 if (!string.IsNullOrEmpty(example.Remarks))
@@ -471,8 +473,13 @@ namespace Markdown.MAML.Renderer
             }
         }
 
-        private void AddCodeSnippet(string code, string lang = "")
+        private void AddCodeSnippet(string code, string lang = "", bool detectLanguage = false)
         {
+            if (detectLanguage && string.IsNullOrEmpty(lang))
+            {
+                lang = DetectLanguage(code);
+            }
+
             _stringBuilder.AppendFormat("```{1}{2}{0}{2}```{2}{2}", code, lang, Environment.NewLine);
         }
 
@@ -607,6 +614,20 @@ namespace Markdown.MAML.Renderer
                 .Replace(@"`", @"\`")
 
                 ;
+        }
+
+        private string DetectLanguage(string hint)
+        {
+            // Detect PowerShell based on first line
+            // - Look PS C:\> prefix followed 
+            // - Look for standalone PowerShell verbs-noun, current verbs use 3-11 characters
+            // - Look for inline help # character
+            if (DetectPSLanguageExpression.IsMatch(hint))
+            {
+                return "powershell";
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/src/Markdown.MAML/Renderer/YamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/YamlRenderer.cs
@@ -49,7 +49,7 @@ namespace Markdown.MAML.Renderer
             {
                 Name = mamlExample.Title,
                 PreCode = mamlExample.Introduction,
-                Code = mamlExample.Code,
+                Code = string.Join("\r\n\r\n", mamlExample.Code.Select(block => block.Text)),
                 PostCode = mamlExample.Remarks
             };
         }

--- a/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
@@ -177,18 +177,15 @@ namespace Markdown.MAML.Transformer
                 };
                 example.Introduction = GetTextFromParagraphNode(ParagraphNodeRule());
                 example.FormatOption = headingNode.FormatOption;
-                CodeBlockNode codeBlock;
-                while ((codeBlock = CodeBlockRule()) != null)
+                CodeBlockNode codeBlockNode;
+                List<MamlCodeBlock> codeBlocks = new List<MamlCodeBlock>();
+
+                while ((codeBlockNode = CodeBlockRule()) != null)
                 {
-                    if (example.Code == null)
-                    {
-                        example.Code = codeBlock.Text;
-                    }
-                    else
-                    {
-                        example.Code += "\r\n\r\n" + codeBlock.Text;
-                    }
+                    codeBlocks.Add(new MamlCodeBlock(codeBlockNode.Text, codeBlockNode.LanguageMoniker));
                 }
+
+                example.Code = codeBlocks.ToArray();
 
                 example.Remarks = GetTextFromParagraphNode(ParagraphNodeRule());
 

--- a/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerBase.cs
@@ -24,8 +24,6 @@ namespace Markdown.MAML.Transformer
         internal const int EXAMPLE_HEADING_LEVEL = 3;
         internal const int PARAMETERSET_NAME_HEADING_LEVEL = 3;
 
-        private static Regex DetectPSLanguageExpression = new Regex(@"^(PS C:\\>| {0,}[a-z]{3,11}-[a-z0-9]{2,}|#)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         public ModelTransformerBase(Action<string> infoCallback, Action<string> warningCallback)
         {
             _infoCallback = infoCallback;
@@ -187,7 +185,7 @@ namespace Markdown.MAML.Transformer
                 {
                     codeBlocks.Add(new MamlCodeBlock(
                         codeBlockNode.Text,
-                        string.IsNullOrEmpty(codeBlockNode.LanguageMoniker) ? DetectLanguage(codeBlockNode.Text) : codeBlockNode.LanguageMoniker
+                        codeBlockNode.LanguageMoniker
                     ));
                 }
 
@@ -204,20 +202,6 @@ namespace Markdown.MAML.Transformer
                 throw headingException;
             }
             
-        }
-
-        private string DetectLanguage(string hint)
-        {
-            // Detect PowerShell based on first line
-            // - Look PS C:\> prefix followed 
-            // - Look for standalone PowerShell verbs-noun, current verbs use 3-11 characters
-            // - Look for inline help # character
-            if (DetectPSLanguageExpression.IsMatch(hint))
-            {
-                return "powershell";
-            }
-
-            return string.Empty;
         }
 
         protected void RelatedLinksRule(MamlCommand commmand)

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -134,7 +134,9 @@ function New-MarkdownHelp
                 $MamlExampleObject = New-Object -TypeName Markdown.MAML.Model.MAML.MamlExample
 
                 $MamlExampleObject.Title = 'Example 1'
-                $MamlExampleObject.Code = 'PS C:\> {{ Add example code here }}'
+                $MamlExampleObject.Code = @(
+                    New-Object -TypeName Markdown.MAML.Model.MAML.MamlCodeBlock ('PS C:\> {{ Add example code here }}', 'powershell')
+                )
                 $MamlExampleObject.Remarks = '{{ Add example description here }}'
 
                 $MamlCommandObject.Examples.Add($MamlExampleObject)
@@ -2500,7 +2502,9 @@ function ConvertPsObjectsToMamlModel
 
         $MamlExampleObject.Introduction = $Example.introduction
         $MamlExampleObject.Title = $Example.title
-        $MamlExampleObject.Code = $Example.code
+        $MamlExampleObject.Code = @(
+            New-Object -TypeName Markdown.MAML.Model.MAML.MamlCodeBlock ($Example.code, '')
+        )
 
         $RemarkText = $Example.remarks.text | AddLineBreaksForParagraphs
         

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -204,7 +204,7 @@ function New-MarkdownHelp
                             $a['Module'] = $module
                         }
 
-                        $helpFileName = GetHelpFileName (Get-Command @a)    
+                        $helpFileName = GetHelpFileName (Get-Command @a)
                     }
 
                     Write-Verbose "Maml things module is: $($mamlObject.ModuleName)"

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -92,7 +92,7 @@ When calling Update-MarkdownHelp line breaks should be preserved.
 ## EXAMPLES
 
 ### Example 1: With no line break or description
-```
+```powershell
 PS C:\> Write-Host 'This is output.'
 ```
 
@@ -105,7 +105,7 @@ This is example 1 remark.
 ### Example 2: With no line break
 This is an example description.
 
-```
+```powershell
 PS C:\> Update-MarkdownHelp
 ```
 
@@ -113,7 +113,7 @@ This is example 2 remark.
 
 ### Example 3: With line break and no description
 
-```
+```powershell
 PS C:\> Update-MarkdownHelp
 ```
 
@@ -123,7 +123,7 @@ This is example 3 remark.
 
 This is an example description.
 
-```powershell
+```preserve
 PS C:\> Update-MarkdownHelp
 ```
 

--- a/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
+++ b/test/Markdown.MAML.Test/EndToEnd/EndToEndTests.cs
@@ -93,7 +93,11 @@ When calling Update-MarkdownHelp line breaks should be preserved.
 
 ### Example 1: With no line break or description
 ```
-PS C:\> Update-MarkdownHelp
+PS C:\> Write-Host 'This is output.'
+```
+
+```
+This is output.
 ```
 
 This is example 1 remark.
@@ -119,8 +123,12 @@ This is example 3 remark.
 
 This is an example description.
 
-```
+```powershell
 PS C:\> Update-MarkdownHelp
+```
+
+```text
+Output
 ```
 
 This is example 4 remark.

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -66,10 +66,17 @@ namespace Markdown.MAML.Test.Renderer
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
-            }
-            );
+            });
+            command.Examples.Add(new MamlExample()
+            {
+                Title = "Example 2",
+                Code = new[] {
+                    new MamlCodeBlock("PS:> Get-Help -YouNeedIt", "powershell"),
+                    new MamlCodeBlock("Output")},
+                Remarks = "This does stuff!"
+            });
             command.Links.Add(new MamlLink()
             {
                     LinkName = "PowerShell made by Microsoft Hackathon",
@@ -102,6 +109,11 @@ namespace Markdown.MAML.Test.Renderer
             string[] example1 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:examples/command:example[contains(maml:title,'Example 1')]/dev:code");
             Assert.Equal(1, example1.Length);
             Assert.Equal("PS:> Get-Help -YouNeedIt", example1[0]);
+
+            // Check that multiple code blocks in the same example merge together when rendering maml
+            string[] example2 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:examples/command:example[contains(maml:title,'Example 2')]/dev:code");
+            Assert.Equal(1, example2.Length);
+            Assert.Equal("PS:> Get-Help -YouNeedIt\r\n\r\nOutput", example2[0]);
         }
 
         [Fact]
@@ -182,28 +194,28 @@ namespace Markdown.MAML.Test.Renderer
             var example1 = new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             };
 
             var example10 = new MamlExample()
             {
                 Title = "Example 10",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             };
 
             var exampleWithTitle = new MamlExample()
             {
                 Title = "Example 11: With a title",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             };
 
             var exampleWithLongTitle = new MamlExample()
             {
                 Title = "Example 12: ".PadRight(66, 'A'),
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             };
 

--- a/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MarkdownV2RendererTests.cs
@@ -138,14 +138,14 @@ namespace Markdown.MAML.Test.Renderer
             var example1 = new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS C:\\> Get-Help",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help") },
                 Remarks = "This is an example to get help."
             };
 
             var example2 = new MamlExample()
             {
                 Title = "Example 2",
-                Code = "PS C:\\> Get-Help -Full",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help -Full") },
                 Introduction = "Intro"
             };
 
@@ -153,7 +153,7 @@ namespace Markdown.MAML.Test.Renderer
             {
                 Title = "Example 3",
                 FormatOption = SectionFormatOption.LineBreakAfterHeader,
-                Code = "PS C:\\> Get-Help",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help", "powershell") },
                 Remarks = "This is an example to get help."
             };
 
@@ -161,28 +161,28 @@ namespace Markdown.MAML.Test.Renderer
             {
                 Title = "Example 4",
                 FormatOption = SectionFormatOption.LineBreakAfterHeader,
-                Code = "PS C:\\> Get-Help -Full",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help -Full") },
                 Introduction = "Intro"
             };
 
             var example5 = new MamlExample()
             {
                 Title = "---Example 5---",
-                Code = "PS C:\\> Get-Help -Full",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help -Full") },
                 Introduction = "With some dashes and no spaces"
             };
 
             var example6 = new MamlExample()
             {
                 Title = "------------------ Example 6: With extra info ------------------",
-                Code = "PS C:\\> Get-Help -Full",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help -Full") },
                 Introduction = "Padded to 64 characters and spaces"
             };
 
             var example7 = new MamlExample()
             {
                 Title = "Example 7: ".PadRight(66, 'A'),
-                Code = "PS C:\\> Get-Help -Full",
+                Code = new[] { new MamlCodeBlock("PS C:\\> Get-Help -Full") },
                 Introduction = "Greater then 64 characters"
             };
 
@@ -201,7 +201,7 @@ namespace Markdown.MAML.Test.Renderer
             Assert.Contains("### Example 2\r\nIntro\r\n\r\n```", markdown);
 
             // Uses line break and should be preserved
-            Assert.Contains("### Example 3\r\n\r\n```", markdown);
+            Assert.Contains("### Example 3\r\n\r\n```powershell", markdown);
             Assert.Contains("### Example 4\r\n\r\nIntro\r\n\r\n```", markdown);
 
             // Includes title padding that should be removed
@@ -353,18 +353,18 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             });
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 2",
-                Code = "PS:> Get-Help -YouNeedTwo",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedTwo") },
             });
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 3",
-                Code = "PS:> Get-Help -YouNeedTwo",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedTwo") },
             });
             command.Links.Add(new MamlLink()
             {

--- a/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
@@ -49,7 +49,7 @@ namespace Markdown.MAML.Test.Renderer
             var example = writtenModel.Examples.Single();
 
             Assert.Equal(model.Examples.Single().Introduction, example.PreCode);
-            Assert.Equal(model.Examples.Single().Code, example.Code);
+            Assert.Equal(model.Examples.Single().Code.Single().Text, example.Code);
             Assert.Equal(model.Examples.Single().Remarks, example.PostCode);
             Assert.Equal(model.Examples.Single().Title, example.Name);
         }
@@ -216,7 +216,7 @@ namespace Markdown.MAML.Test.Renderer
             command.Examples.Add(new MamlExample
             {
                 Remarks = "Example 1 remarks",
-                Code = "Example 1 code",
+                Code = new [] { new MamlCodeBlock("Example 1 code") },
                 Introduction = "Example 1 intro",
                 Title = "Example 1 title"
             });

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -139,7 +139,7 @@ namespace Markdown.MAML.Test.Transformer
             originalCommand.Examples.Add(new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             }
             );

--- a/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlMultiModelMergerTests.cs
@@ -168,7 +168,7 @@ Third Command
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff!"
             }
             );
@@ -225,7 +225,7 @@ Third Command
             command.Examples.Add(new MamlExample()
             {
                 Title = "Example 1",
-                Code = "PS:> Get-Help -YouNeedIt",
+                Code = new[] { new MamlCodeBlock("PS:> Get-Help -YouNeedIt") },
                 Remarks = "This does stuff too!"
             }
             );

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -160,14 +160,12 @@ Output
             // Confirm example fields and code block language is read
             Assert.Equal("This is an example.", mamlCommand.Examples[0].Introduction);
             Assert.Equal(SectionFormatOption.LineBreakAfterHeader, mamlCommand.Examples[0].FormatOption);
+            Assert.Equal(2, mamlCommand.Examples[0].Code.Length);
             Assert.Equal("powershell", mamlCommand.Examples[0].Code[0].LanguageMoniker);
             Assert.Equal(string.Empty, mamlCommand.Examples[0].Code[1].LanguageMoniker);
 
-            // Confirm example fields and code block language is detected
+            // Confirm example fields
             Assert.Equal(SectionFormatOption.None, mamlCommand.Examples[1].FormatOption);
-            Assert.Equal("powershell", mamlCommand.Examples[1].Code[0].LanguageMoniker);
-            Assert.Equal("powershell", mamlCommand.Examples[1].Code[1].LanguageMoniker);
-            Assert.Equal(string.Empty, mamlCommand.Examples[1].Code[2].LanguageMoniker);
         }
 
         [Fact]

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -368,21 +368,23 @@ Introduction
 ```
 # PS code here
 ```
-```PowerShell
+```powershell
 # PS More code here
 ```
 Remarks
 
 ");
             var mamlCommand = NodeModelToMamlModelV2(doc).ToArray();
-            Assert.Equal(mamlCommand.Count(), 1);
+            Assert.Equal(1, mamlCommand.Count());
             var examples = mamlCommand[0].Examples.ToArray();
-            Assert.Equal(examples.Count(), 2);
-            Assert.Equal(examples[0].Title, "--EXAMPLE1--");
-            Assert.Equal(examples[0].Code, "# PS code here");
-            Assert.Equal(examples[0].Remarks, "Remarks");
-            Assert.Equal(examples[0].Introduction, "Introduction");
-            Assert.Equal(examples[1].Code, "# PS code here\r\n\r\n# PS More code here");
+            Assert.Equal(2, examples.Count());
+            Assert.Equal("--EXAMPLE1--", examples[0].Title);
+            Assert.Equal("# PS code here", examples[0].Code[0].Text);
+            Assert.Equal("Remarks", examples[0].Remarks);
+            Assert.Equal("Introduction", examples[0].Introduction);
+            Assert.Equal("# PS code here", examples[1].Code[0].Text);
+            Assert.Equal("# PS More code here", examples[1].Code[1].Text);
+            Assert.Equal("powershell", examples[1].Code[1].LanguageMoniker);
         }
 
         [Fact]

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -132,10 +132,42 @@ This is an example.
 ```powershell
 PS C:\> Get-PSDocumentHeader -Path '.\build\Default\Server1.md';
 ```
+
+```
+Output
+```
+
+### Example 2
+This is an example.
+
+```
+PS C:\> Get-PSDocumentHeader -Path '.\build\Default\Server1.md';
+```
+
+```
+Get-PSDocumentHeader -Path '.\build\Default\Server1.md';
+```
+
+```
+Output
+```
 ");
             MamlCommand mamlCommand = NodeModelToMamlModelV2(doc).First();
+
+            // Check the number of examples
+            Assert.Equal(2, mamlCommand.Examples.Count);
+
+            // Confirm example fields and code block language is read
             Assert.Equal("This is an example.", mamlCommand.Examples[0].Introduction);
             Assert.Equal(SectionFormatOption.LineBreakAfterHeader, mamlCommand.Examples[0].FormatOption);
+            Assert.Equal("powershell", mamlCommand.Examples[0].Code[0].LanguageMoniker);
+            Assert.Equal(string.Empty, mamlCommand.Examples[0].Code[1].LanguageMoniker);
+
+            // Confirm example fields and code block language is detected
+            Assert.Equal(SectionFormatOption.None, mamlCommand.Examples[1].FormatOption);
+            Assert.Equal("powershell", mamlCommand.Examples[1].Code[0].LanguageMoniker);
+            Assert.Equal("powershell", mamlCommand.Examples[1].Code[1].LanguageMoniker);
+            Assert.Equal(string.Empty, mamlCommand.Examples[1].Code[2].LanguageMoniker);
         }
 
         [Fact]

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -645,7 +645,7 @@ Describe 'Get-Help & Get-Command on Add-Computer to build MAML Model Object' {
         It 'Validates the examples by checking Add-Computer Example 1' {
 
             $mamlModelObject.Examples[0].Title | Should be "Example 1: Add a local computer to a domain then restart the computer"
-            $mamlModelObject.Examples[0].Code | Should be "PS C:\>Add-Computer -DomainName `"Domain01`" -Restart"
+            $mamlModelObject.Examples[0].Code[0].Text | Should be "PS C:\>Add-Computer -DomainName `"Domain01`" -Restart"
             $mamlModelObject.Examples[0].Remarks.Substring(0,120) | Should be "This command adds the local computer to the Domain01 domain and then restarts the computer to make the change effective."
 
         }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -260,11 +260,11 @@ Describe 'New-MarkdownHelp' {
             System.String. Add-Extension returns a string with the extension or file name.
 
             .EXAMPLE
-            C:\PS> Test-PlatyPSFunction "File"
+            PS C:\> Test-PlatyPSFunction "File"
             File.txt
 
             .EXAMPLE
-            C:\PS> Test-PlatyPSFunction "File" -First "doc"
+            PS C:\> Test-PlatyPSFunction "File" -First "doc"
             File.doc
 
             .LINK
@@ -306,6 +306,10 @@ Describe 'New-MarkdownHelp' {
 
         It 'generates markdown with placeholder for parameter with no description' {
             ($content | Where-Object {$_ -eq '{{Fill Common Description}}'} | Measure-Object).Count | Should Be 1
+        }
+
+        It 'generates markdown example powershell code blocks' {
+            $content | Out-String | Should Match '(\w|\W)+\r\n### EXAMPLE 1\r\n```powershell\r\nTest-PlatyPSFunction "File"\r\n```'
         }
     }
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -307,10 +307,6 @@ Describe 'New-MarkdownHelp' {
         It 'generates markdown with placeholder for parameter with no description' {
             ($content | Where-Object {$_ -eq '{{Fill Common Description}}'} | Measure-Object).Count | Should Be 1
         }
-
-        It 'generates markdown example powershell code blocks' {
-            $content | Out-String | Should Match '(\w|\W)+\r\n### EXAMPLE 1\r\n```powershell\r\nTest-PlatyPSFunction "File"\r\n```'
-        }
     }
 
     Context 'Generated markdown features: no comment-based help' {


### PR DESCRIPTION
* Fixed issue with Update-MarkdownHelp removing named info-string from code fence #318

Fix #318
