### PR TITLE
Handle extra field Tag in the description fields

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2680,7 +2680,13 @@ function ConvertPsObjectsToMamlModel
     }
     else
     {
-        $MamlCommandObject.Synopsis = New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody ($Help.Synopsis.Trim())
+        $MamlCommandObject.Synopsis = New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody (
+            # $Help.Synopsis only contains the first paragraph
+            # https://github.com/PowerShell/platyPS/issues/328
+            $Help.details.description |
+            DescriptionToPara |
+            AddLineBreaksForParagraphs
+        )
     }
 
     #Get Description


### PR DESCRIPTION
- Found that Exchange uses `@{Text=ChangeOwner; Tag=* }` inside some of the items in `description`. There should not be any harm in always assuming that there could be some extra info in the `Tag` property.

- Correct the way we extract Synopsis from the help object. Fix #328