### PR TITLE
Added UseFullTypeName switch to Update-MarkdownHelpModule

### DIFF
--- a/docs/Get-HelpPreview.md
+++ b/docs/Get-HelpPreview.md
@@ -13,7 +13,7 @@ Displays your generated external help as **Get-Help** output.
 ## SYNTAX
 
 ```
-Get-HelpPreview -Path <String[]> [-ConvertNotesToList] [-ConvertDoubleDashLists] [<CommonParameters>]
+Get-HelpPreview [-Path] <String[]> [-ConvertNotesToList] [-ConvertDoubleDashLists] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,19 +45,21 @@ The second command displays the **Name** property for each of the objects in $He
 
 ## PARAMETERS
 
-### -Path
-Specifies an array of paths of MAML external help files.
+### -ConvertDoubleDashLists
+Indicates that this cmldet converts double-hyphen list bullets into single-hyphen bullets. 
+Double-hyphen lists are common in Windows PowerShell documentation. 
+Markdown accepts single-hyphens for lists.
 
 ```yaml
-Type: String[]
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: True
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -ConvertNotesToList
@@ -76,20 +78,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ConvertDoubleDashLists
-Indicates that this cmldet converts double-hyphen list bullets into single-hyphen bullets. 
-Double-hyphen lists are common in Windows PowerShell documentation. 
-Markdown accepts single-hyphens for lists.
+### -Path
+Specifies an array of paths of MAML external help files.
 
 ```yaml
-Type: SwitchParameter
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
-Position: Named
+Required: True
+Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/Get-MarkdownMetadata.md
+++ b/docs/Get-MarkdownMetadata.md
@@ -14,7 +14,7 @@ Gets metadata from the header of a markdown file.
 
 ### FromPath (Default)
 ```
-Get-MarkdownMetadata -Path <String[]> [<CommonParameters>]
+Get-MarkdownMetadata [-Path] <String[]> [<CommonParameters>]
 ```
 
 ### FromMarkdownString
@@ -89,22 +89,6 @@ This command gets metadata from each of the markdown files in the .\docs folder.
 
 ## PARAMETERS
 
-### -Path
-Specifies an array of paths of markdown files or folders.
-
-
-```yaml
-Type: String[]
-Parameter Sets: FromPath
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: True
-```
-
 ### -Markdown
 Specifies a string that contains markdown formatted text.
 
@@ -118,6 +102,22 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Specifies an array of paths of markdown files or folders.
+
+
+```yaml
+Type: String[]
+Parameter Sets: FromPath
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/Merge-MarkdownHelp.md
+++ b/docs/Merge-MarkdownHelp.md
@@ -13,8 +13,8 @@ Merge multiple markdown versions of the same cmdlet into a single markdown file.
 ## SYNTAX
 
 ```
-Merge-MarkdownHelp [-Path] <String[]> [-OutputPath] <String> [-Encoding <Encoding>] [-ExplicitApplicableIfAll]
- [-Force] [[-MergeMarker] <String>] [<CommonParameters>]
+Merge-MarkdownHelp [-Path] <String[]> [-OutputPath] <String> [[-Encoding] <Encoding>]
+ [-ExplicitApplicableIfAll] [-Force] [[-MergeMarker] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -61,7 +61,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 2
 Default value: UTF8 without BOM
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -142,7 +142,7 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### CommonParameters

--- a/docs/New-ExternalHelp.md
+++ b/docs/New-ExternalHelp.md
@@ -13,7 +13,7 @@ Creates external help file based on markdown supported by PlatyPS.
 ## SYNTAX
 
 ```
-New-ExternalHelp -Path <String[]> -OutputPath <String> [-ApplicableTag <String[]>] [-Encoding <Encoding>]
+New-ExternalHelp [-Path] <String[]> -OutputPath <String> [-ApplicableTag <String[]>] [-Encoding <Encoding>]
  [-MaxAboutWidth <Int32>] [-ErrorLogFile <String>] [-Force] [-ShowProgress] [<CommonParameters>]
 ```
 
@@ -75,16 +75,20 @@ This command writes the warnings and errors to the WarningsAndErrors.json file.
 
 ## PARAMETERS
 
-### -OutputPath
-Specifies the path of a folder where this cmdlet saves your external help file.
-The folder name should end with a locale folder, as in the following example: `.\out\PlatyPS\en-US\`.
+### -ApplicableTag
+Specify array of tags to use as a filter.
+If cmdlet has `applicable` in the yaml metadata and none of the passed tags is
+mentioned there, cmdlet would be ignored in the generated help.
+Same applies to the Parameter level `applicable` yaml metadata.
+If `applicable` is ommited, cmdlet or parameter would be always present.
+See [design issue](https://github.com/PowerShell/platyPS/issues/273) for more details.
 
 ```yaml
-Type: String
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -111,11 +115,17 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Force
-Indicates that this cmdlet overwrites an existing file that has the same name.
+### -ErrorLogFile
+The path where this cmdlet will save formatted results log file.
+
+The path must include the location and name of the folder and file name with
+the json extension. The JSON object contains three properties, Message, FilePath,
+and Severity (Warning or Error).
+
+If this path is not provided, no log will be generated.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -126,32 +136,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Path
-Specifies an array of paths of markdown files or folders.
-This cmdlet creates external help based on these files and folders.
+### -Force
+Indicates that this cmdlet overwrites an existing file that has the same name.
 
 ```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: True
-```
-
-### -ApplicableTag
-Specify array of tags to use as a filter.
-If cmdlet has `applicable` in the yaml metadata and none of the passed tags is
-mentioned there, cmdlet would be ignored in the generated help.
-Same applies to the Parameter level `applicable` yaml metadata.
-If `applicable` is ommited, cmdlet or parameter would be always present.
-See [design issue](https://github.com/PowerShell/platyPS/issues/273) for more details.
-
-```yaml
-Type: String[]
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -182,24 +171,35 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ErrorLogFile
-The path where this cmdlet will save formatted results log file.
-
-The path must include the location and name of the folder and file name with
-the json extension. The JSON object contains three properties, Message, FilePath,
-and Severity (Warning or Error).
-
-If this path is not provided, no log will be generated.
+### -OutputPath
+Specifies the path of a folder where this cmdlet saves your external help file.
+The folder name should end with a locale folder, as in the following example: `.\out\PlatyPS\en-US\`.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Specifies an array of paths of markdown files or folders.
+This cmdlet creates external help based on these files and folders.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/New-ExternalHelpCab.md
+++ b/docs/New-ExternalHelpCab.md
@@ -13,7 +13,7 @@ Generates a .cab file.
 ## SYNTAX
 
 ```
-New-ExternalHelpCab -CabFilesFolder <String> -LandingPagePath <String> -OutputFolder <String>
+New-ExternalHelpCab [-CabFilesFolder] <String> [-LandingPagePath] <String> [-OutputFolder] <String>
  [-IncrementHelpVersion] [<CommonParameters>]
 ```
 
@@ -53,6 +53,21 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncrementHelpVersion
+Automatically increment the help version in the module markdown file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -70,7 +85,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -86,22 +101,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IncrementHelpVersion
-Automatically increment the help version in the module markdown file.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-MarkdownHelp.md
+++ b/docs/New-MarkdownHelp.md
@@ -129,6 +129,23 @@ The command creates a file named PSReadLine.md that contains links to the other 
 
 ## PARAMETERS
 
+### -AlphabeticParamsOrder
+Order parameters alphabetically by name in PARAMETERS section.
+There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
+These parameters are common and hence have well-defined behavior.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Command
 Specifies the name of a command in your current session.
 This can be any command supported by Windows PowerShell help, such as a cmdlet or a function.
@@ -139,6 +156,39 @@ Parameter Sets: FromCommand
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConvertDoubleDashLists
+Indicates that this cmldet converts double-hyphen list bullets into single-hyphen bullets. 
+Double-hyphen lists are common in Windows PowerShell documentation. 
+Markdown accepts single-hyphens for lists. 
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FromMaml
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConvertNotesToList
+Indicates that this cmldet formats multiple paragraph items in the **NOTES** section as single list items. 
+This output follows TechNet formatting. 
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FromMaml
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -360,65 +410,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WithModulePage
-Indicates that this cmdlet creates a module page in the output folder.
-This file has the name that the *ModuleName* parameter specifies.
-If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
-
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: FromModule, FromMaml
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ConvertNotesToList
-Indicates that this cmldet formats multiple paragraph items in the **NOTES** section as single list items. 
-This output follows TechNet formatting. 
+### -Session
+Provides support for remote commands.
+Pass the session that you used to create the commands with `Import-PSSession`.
+This is required to get accurate parameters metadata from the remote session.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: FromMaml
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ConvertDoubleDashLists
-Indicates that this cmldet converts double-hyphen list bullets into single-hyphen bullets. 
-Double-hyphen lists are common in Windows PowerShell documentation. 
-Markdown accepts single-hyphens for lists. 
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: FromMaml
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AlphabeticParamsOrder
-Order parameters alphabetically by name in PARAMETERS section.
-There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
-These parameters are common and hence have well-defined behavior.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
+Type: PSSession
+Parameter Sets: FromModule, FromCommand
 Aliases:
 
 Required: False
@@ -443,14 +442,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Session
-Provides support for remote commands.
-Pass the session that you used to create the commands with `Import-PSSession`.
-This is required to get accurate parameters metadata from the remote session.
+### -WithModulePage
+Indicates that this cmdlet creates a module page in the output folder.
+This file has the name that the *ModuleName* parameter specifies.
+If you did not specify that parameter, the cmdlet supplies the default name MamlModule.
+
 
 ```yaml
-Type: PSSession
-Parameter Sets: FromModule, FromCommand
+Type: SwitchParameter
+Parameter Sets: FromModule, FromMaml
 Aliases:
 
 Required: False

--- a/docs/New-YamlHelp.md
+++ b/docs/New-YamlHelp.md
@@ -104,6 +104,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputFolder
+Specifies the folder to create the YAML files in
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Path
 Specifies an array of paths of markdown files or folders.
 This cmdlet creates external help based on these files and folders.
@@ -117,21 +132,6 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
-```
-
-### -OutputFolder
-Specifies the folder to create the YAML files in
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -14,7 +14,7 @@ Update PlatyPS markdown help files.
 
 ```
 Update-MarkdownHelp [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath] <String>] [-LogAppend]
- [-AlphabeticParamsOrder] [-UseFullTypeName] [-Session <PSSession>] [<CommonParameters>]
+ [-AlphabeticParamsOrder] [-UseFullTypeName] [[-Session] <PSSession>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,6 +70,23 @@ This command updates a markdown help file.
 It writes log information to the markdown.log file.
 
 ## PARAMETERS
+
+### -AlphabeticParamsOrder
+Order parameters alphabetically by name in PARAMETERS section.
+There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
+These parameters are common and hence have well-defined behavior.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Encoding
 Specifies the character encoding for your markdown help files.
@@ -138,38 +155,6 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
-Accept wildcard characters: True
-```
-
-### -AlphabeticParamsOrder
-Order parameters alphabetically by name in PARAMETERS section.
-There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
-These parameters are common and hence have well-defined behavior.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UseFullTypeName
-Indicates that the target document will use a full type name instead of a short name for parameters.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -180,6 +165,21 @@ This is required to get accurate parameters metadata from the remote session.
 
 ```yaml
 Type: PSSession
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseFullTypeName
+Indicates that the target document will use a full type name instead of a short name for parameters.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -14,7 +14,8 @@ Update all files in a markdown help module folder.
 
 ```
 Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [-RefreshModulePage]
- [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-Session <PSSession>] [<CommonParameters>]
+ [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [[-Session] <PSSession>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -46,6 +47,23 @@ This command updates all the files in the specified folder based on the cmdlets 
 The command creates markdown help topics for any cmdlets that are not already included in the .\docs folder.
 
 ## PARAMETERS
+
+### -AlphabeticParamsOrder
+Order parameters alphabetically by name in PARAMETERS section.
+There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
+These parameters are common and hence have well-defined behavior.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Encoding
 Specifies the character encoding for your markdown help files.
@@ -115,28 +133,11 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -RefreshModulePage
 Update module page when updating the help module.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AlphabeticParamsOrder
-Order parameters alphabetically by name in PARAMETERS section.
-There are 2 exceptions: -Confirm and -WhatIf parameters will be the last. 
-These parameters are common and hence have well-defined behavior.
 
 ```yaml
 Type: SwitchParameter
@@ -157,6 +158,21 @@ This is required to get accurate parameters metadata from the remote session.
 
 ```yaml
 Type: PSSession
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseFullTypeName
+{{Fill UseFullTypeName Description}}
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -561,6 +561,7 @@ function Update-MarkdownHelpModule
         [string]$LogPath,
         [switch]$LogAppend,
         [switch]$AlphabeticParamsOrder,
+        [switch]$UseFullTypeName,
 
         [System.Management.Automation.Runspaces.PSSession]$Session
     )
@@ -615,7 +616,7 @@ function Update-MarkdownHelpModule
             # always append on this call
             log ("[Update-MarkdownHelpModule]" + (Get-Date).ToString())
             log ("Updating docs for Module " + $module + " in " + $modulePath)
-            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder
+            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder -UseFullTypeName:$UseFullTypeName
             $affectedFiles # yeild
 
             $allCommands = GetCommands -AsNames -Module $Module
@@ -629,7 +630,7 @@ function Update-MarkdownHelpModule
                 if ( -not ($updatedCommands -contains $_) )
                 {
                     log "Creating new markdown for command $_"
-                    $newFiles = New-MarkdownHelp -Command $_ -OutputFolder $modulePath -AlphabeticParamsOrder:$AlphabeticParamsOrder
+                    $newFiles = New-MarkdownHelp -Command $_ -OutputFolder $modulePath -AlphabeticParamsOrder:$AlphabeticParamsOrder -UseFullTypeName:$UseFullTypeName
                     $newFiles # yeild
                 }
             }

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -664,7 +664,7 @@ function New-MarkdownAboutHelp
 
     process
     {
-        if(Test-Path $OutputFolder)
+        if(Test-Path $OutputFolder -PathType Container)
         {
             $AboutContent = Get-Content $templatePath
             $AboutContent = $AboutContent.Replace("{{FileNameForHelpSystem}}",("about_" + $AboutName))


### PR DESCRIPTION
Added UseFullTypeName switch to Update-MarkdownHelpModule, to bring into line with New-MarkdownHelp & Update-MarkdownHelp

as discussed in https://github.com/PowerShell/platyPS/issues/375