### PR TITLE
Add UpdateInputOutput parameter to Update-MarkdownHelp and Update-MarkdownHelpModule

### DIFF
--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -14,7 +14,7 @@ Update PlatyPS markdown help files.
 
 ```
 Update-MarkdownHelp [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath] <String>] [-LogAppend]
- [-AlphabeticParamsOrder] [-UseFullTypeName] [-Session <PSSession>] [<CommonParameters>]
+ [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput] [-Session <PSSession>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -180,6 +180,21 @@ This is required to get accurate parameters metadata from the remote session.
 
 ```yaml
 Type: PSSession
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UpdateInputOutput
+Refreshes the Input and Output section to reflect the current state of the cmdlet.  WARNING: this parameter will remove any manual additions to these sections.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -14,7 +14,8 @@ Update all files in a markdown help module folder.
 
 ```
 Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [-RefreshModulePage]
- [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-Session <PSSession>] [<CommonParameters>]
+ [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [-Session <PSSession>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -157,6 +158,21 @@ This is required to get accurate parameters metadata from the remote session.
 
 ```yaml
 Type: PSSession
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseFullTypeName
+Indicates that the target document will use a full type name instead of a short name for parameters.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -14,8 +14,8 @@ Update all files in a markdown help module folder.
 
 ```
 Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [-RefreshModulePage]
- [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [-Session <PSSession>]
- [<CommonParameters>]
+ [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput]
+ [-Session <PSSession>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -170,6 +170,21 @@ Accept wildcard characters: False
 
 ### -UseFullTypeName
 Indicates that the target document will use a full type name instead of a short name for parameters.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UpdateInputOutput
+Refreshes the Input and Output sections to reflect the current state of the cmdlet.  WARNING: this parameter will remove any manual additions to these sections.
 
 ```yaml
 Type: SwitchParameter

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -274,7 +274,6 @@ namespace Markdown.MAML.Renderer
 
             AddHeader(ModelTransformerBase.PARAMETERSET_NAME_HEADING_LEVEL, '-' + parameter.Name, extraNewLine: extraNewLine);
 
-            // for some reason, in the update mode parameters produces extra newline.
             AddParagraphs(parameter.Description);
             
             var sets = SimplifyParamSets(GetParamSetDictionary(parameter.Name, command.Syntax));

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -64,7 +64,7 @@ namespace Markdown.MAML.Renderer
                 yamlHeader["schema"] = "2.0.0";
                 AddYamlHeader(yamlHeader);
             }
-
+            
             AddCommand(mamlCommand);
 
             // at the end, just normalize all ends
@@ -140,7 +140,7 @@ namespace Markdown.MAML.Renderer
                 return;
             }
 
-            var extraNewLine = string.IsNullOrEmpty(io.Description) || ShouldBreak(io.FormatOption);
+            var extraNewLine = ShouldBreak(io.FormatOption);
             AddHeader(ModelTransformerBase.INPUT_OUTPUT_TYPENAME_HEADING_LEVEL, io.TypeName, extraNewLine);
             AddParagraphs(io.Description);
         }

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -64,7 +64,7 @@ namespace Markdown.MAML.Renderer
                 yamlHeader["schema"] = "2.0.0";
                 AddYamlHeader(yamlHeader);
             }
-            
+
             AddCommand(mamlCommand);
 
             // at the end, just normalize all ends

--- a/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
+++ b/src/Markdown.MAML/Renderer/Markdownv2Renderer.cs
@@ -275,7 +275,7 @@ namespace Markdown.MAML.Renderer
             AddHeader(ModelTransformerBase.PARAMETERSET_NAME_HEADING_LEVEL, '-' + parameter.Name, extraNewLine: extraNewLine);
 
             // for some reason, in the update mode parameters produces extra newline.
-            AddParagraphs(parameter.Description, this._mode == ParserMode.FormattingPreserve);
+            AddParagraphs(parameter.Description);
             
             var sets = SimplifyParamSets(GetParamSetDictionary(parameter.Name, command.Syntax));
             foreach (var set in sets)

--- a/src/Markdown.MAML/Transformer/MamlModelMerger.cs
+++ b/src/Markdown.MAML/Transformer/MamlModelMerger.cs
@@ -21,7 +21,7 @@ namespace Markdown.MAML.Transformer
             _infoCallback = infoCallback;
         }
 
-        public MamlCommand Merge(MamlCommand metadataModel, MamlCommand stringModel)
+        public MamlCommand Merge(MamlCommand metadataModel, MamlCommand stringModel, bool updateInputOutput)
         {
             MamlCommand result = null;
             _cmdletUpdated = false;
@@ -66,17 +66,35 @@ namespace Markdown.MAML.Transformer
                 Report($"    Exception Examples: \r\n{ex.Message}\r\n");
                 _cmdletUpdated = true;
             }
-            try
+            if (updateInputOutput)
             {
-                // TODO: figure out what's the right thing for MamlInputOutput
-                result.Inputs.AddRange(stringModel.Inputs);
-                result.Outputs.AddRange(stringModel.Outputs);
+                try
+                {
+                    // TODO: figure out what's the right thing for MamlInputOutput
+                    result.Inputs.AddRange(metadataModel.Inputs);
+                    result.Outputs.AddRange(metadataModel.Outputs);
+                }
+                catch (Exception ex)
+                {
+                    Report($"---- ERROR UPDATING Cmdlet : {metadataModel.Name}----\r\n");
+                    Report($"    Exception Inputs and Outputs: \r\n{ex.Message}\r\n");
+                    _cmdletUpdated = true;
+                }
             }
-            catch (Exception ex)
+            else
             {
-                Report($"---- ERROR UPDATING Cmdlet : {metadataModel.Name}----\r\n");
-                Report($"    Exception Inputs and Outputs: \r\n{ex.Message}\r\n");
-                _cmdletUpdated = true;
+                try
+                {
+                    // TODO: figure out what's the right thing for MamlInputOutput
+                    result.Inputs.AddRange(stringModel.Inputs);
+                    result.Outputs.AddRange(stringModel.Outputs);
+                }
+                catch (Exception ex)
+                {
+                    Report($"---- ERROR UPDATING Cmdlet : {metadataModel.Name}----\r\n");
+                    Report($"    Exception Inputs and Outputs: \r\n{ex.Message}\r\n");
+                    _cmdletUpdated = true;
+                }
             }
 
             //Result takes in the merged parameter results.

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2765,7 +2765,7 @@ function ConvertPsObjectsToMamlModel
     $Inputs = @()
 
     $Help.inputTypes.inputType | ForEach-Object {
-        if ($_.description -eq $null)
+        if ($_.description -eq $null -and $_.type.name -ne $null)
         {
             $inputtypes = $_.type.name.split("`n")
             $inputtypes | ForEach-Object {
@@ -2799,7 +2799,7 @@ function ConvertPsObjectsToMamlModel
     $Outputs = @()
 
     $Help.returnValues.returnValue | ForEach-Object {
-        if ($_.description -eq $null)
+        if ($_.description -eq $null -and $_.type.name -ne $null)
         {
             $Outputtypes = $_.type.name.split("`n")
             $Outputtypes | ForEach-Object {

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -561,6 +561,7 @@ function Update-MarkdownHelpModule
         [string]$LogPath,
         [switch]$LogAppend,
         [switch]$AlphabeticParamsOrder,
+        [switch]$UseFullTypeName,
 
         [System.Management.Automation.Runspaces.PSSession]$Session
     )
@@ -615,7 +616,7 @@ function Update-MarkdownHelpModule
             # always append on this call
             log ("[Update-MarkdownHelpModule]" + (Get-Date).ToString())
             log ("Updating docs for Module " + $module + " in " + $modulePath)
-            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder
+            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder -UseFullTypeName:$UseFullTypeName
             $affectedFiles # yeild
 
             $allCommands = GetCommands -AsNames -Module $Module

--- a/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
+++ b/test/Markdown.MAML.Test/Transformer/MamlModelMergerTests.cs
@@ -21,7 +21,7 @@ namespace Markdown.MAML.Test.Transformer
             var originalCommand = GetOriginal();
             var metadataCommand = GetRegenerated();
 
-            var result = merger.Merge(metadataCommand, originalCommand);
+            var result = merger.Merge(metadataCommand, originalCommand, false);
 
             Assert.Equal(3, result.Parameters.Count);
             Assert.Equal(3, originalCommand.Parameters.Count);


### PR DESCRIPTION
Added UpdateInputObject parameter which will allow user to update the input and output for their existing markdown files.  Also updated the parser to correctly parse input and output from the get-help call.  Previously it would treat all types as a single string, now it will treat each type on a new line as a separate type.

Previously, parsed as:
"
Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultKey
Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultSecret
Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultCertificate
"

Now parsed as:
"Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultKey"
"Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultSecret"
"Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultCertificate"

This means that the output looks like:
### Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultKey
### Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultSecret
### Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultCertificate

Instead of:
### Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultKey
Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultSecret
Microsoft.Azure.Commands.KeyVault.Models.PSKeyVaultCertificate