### PR TITLE
Prevents error when function was deleted

### DIFF
--- a/docs/Update-MarkdownHelp.md
+++ b/docs/Update-MarkdownHelp.md
@@ -14,7 +14,8 @@ Update PlatyPS markdown help files.
 
 ```
 Update-MarkdownHelp [-Path] <String[]> [[-Encoding] <Encoding>] [[-LogPath] <String>] [-LogAppend]
- [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput] [-Session <PSSession>] [<CommonParameters>]
+ [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput] [-Force] [-Session <PSSession>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -110,7 +111,7 @@ Accept wildcard characters: False
 ### -LogPath
 Specifies a file path for log information.
 The cmdlet writes the VERBOSE stream to the log.
-If you specify the *Verbose* parameter, this cmdlet also writes that information to the console. 
+If you specify the *Verbose* parameter, this cmdlet also writes that information to the console.
 
 
 ```yaml
@@ -143,7 +144,7 @@ Accept wildcard characters: True
 
 ### -AlphabeticParamsOrder
 Order parameters alphabetically by name in PARAMETERS section.
-There are 5 exceptions: -Confirm, -WhatIf, -IncludeTotalCount, -Skip, and -First parameters will be the last. 
+There are 5 exceptions: -Confirm, -WhatIf, -IncludeTotalCount, -Skip, and -First parameters will be the last.
 These parameters are common and hence have well-defined behavior.
 
 ```yaml
@@ -205,6 +206,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+Remove help files that no longer exists within sessions (for example if function was deleted)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -225,4 +241,3 @@ This cmdlet returns a **FileInfo[]** object for updated files.
 [Character Encoding in the .NET Framework](https://msdn.microsoft.com/en-us/library/ms404377.aspx)
 
 [Using PowerShell to write a file in UTF-8 without the BOM](http://stackoverflow.com/questions/5596982/using-powershell-to-write-a-file-in-utf-8-without-the-bom)
-

--- a/docs/Update-MarkdownHelpModule.md
+++ b/docs/Update-MarkdownHelpModule.md
@@ -14,7 +14,7 @@ Update all files in a markdown help module folder.
 
 ```
 Update-MarkdownHelpModule [-Path] <String[]> [[-Encoding] <Encoding>] [-RefreshModulePage]
- [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput]
+ [[-LogPath] <String>] [-LogAppend] [-AlphabeticParamsOrder] [-UseFullTypeName] [-UpdateInputOutput] [-Force]
  [-Session <PSSession>] [<CommonParameters>]
 ```
 
@@ -85,9 +85,9 @@ Accept wildcard characters: False
 ```
 
 ### -LogPath
-Specifies a file path for log information. 
-The cmdlet writes the VERBOSE stream to the log. 
-If you specify the *Verbose* parameter, this cmdlet also writes that information to the console. 
+Specifies a file path for log information.
+The cmdlet writes the VERBOSE stream to the log.
+If you specify the *Verbose* parameter, this cmdlet also writes that information to the console.
 
 
 ```yaml
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 
 ### -Path
 Specifies an array of paths of markdown folders to update.
-The folder must contain a module page from which this cmdlet can get the module name. 
+The folder must contain a module page from which this cmdlet can get the module name.
 
 
 ```yaml
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 
 ### -AlphabeticParamsOrder
 Order parameters alphabetically by name in PARAMETERS section.
-There are 5 exceptions: -Confirm, -WhatIf, -IncludeTotalCount, -Skip, and -First parameters will be the last. 
+There are 5 exceptions: -Confirm, -WhatIf, -IncludeTotalCount, -Skip, and -First parameters will be the last.
 These parameters are common and hence have well-defined behavior.
 
 ```yaml
@@ -198,18 +198,33 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+Remove help files that no longer exists within sessions (for example if function was deleted)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String[]
-You can pipe an array of paths to this cmdlet. 
+You can pipe an array of paths to this cmdlet.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo[]
-This cmdlet returns a **FileInfo[]** object for updated and new files. 
+This cmdlet returns a **FileInfo[]** object for updated and new files.
 
 ## NOTES
 

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -357,7 +357,7 @@ function Update-MarkdownHelp
         [switch]$AlphabeticParamsOrder,
         [switch]$UseFullTypeName,
         [switch]$UpdateInputOutput,
-
+        [Switch]$Force,
         [System.Management.Automation.Runspaces.PSSession]$Session
     )
 
@@ -417,8 +417,16 @@ function Update-MarkdownHelp
             $command = Get-Command $name -ErrorAction SilentlyContinue
             if (-not $command)
             {
-                log -warning  "command $name not found in the session, skipping upgrade for $filePath"
-                return
+                if ($Force) {
+                    if (Test-Path $filePath) {
+                        Remove-Item -Path $filePath -Confirm:$false
+                        log -warning "command $name not found in the session, removed $filePath"
+                        return
+                    }
+                } else {
+                    log -warning  "command $name not found in the session, skipping upgrade for $filePath"
+                    return
+                }
             }
 
             # update the help file entry in the metadata
@@ -564,7 +572,7 @@ function Update-MarkdownHelpModule
         [switch]$AlphabeticParamsOrder,
         [switch]$UseFullTypeName,
         [switch]$UpdateInputOutput,
-
+        [switch]$Force,
         [System.Management.Automation.Runspaces.PSSession]$Session
     )
 
@@ -618,7 +626,7 @@ function Update-MarkdownHelpModule
             # always append on this call
             log ("[Update-MarkdownHelpModule]" + (Get-Date).ToString())
             log ("Updating docs for Module " + $module + " in " + $modulePath)
-            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder -UseFullTypeName:$UseFullTypeName -UpdateInputOutput:$UpdateInputOutput
+            $affectedFiles = Update-MarkdownHelp -Session $Session -Path $modulePath -LogPath $LogPath -LogAppend -Encoding $Encoding -AlphabeticParamsOrder:$AlphabeticParamsOrder -UseFullTypeName:$UseFullTypeName -UpdateInputOutput:$UpdateInputOutput -Force:$Force
             $affectedFiles # yeild
 
             $allCommands = GetCommands -AsNames -Module $Module

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -414,7 +414,7 @@ function Update-MarkdownHelp
             $oldModel = $oldModels[0]
 
             $name = $oldModel.Name
-            $command = Get-Command $name
+            $command = Get-Command $name -ErrorAction SilentlyContinue
             if (-not $command)
             {
                 log -warning  "command $name not found in the session, skipping upgrade for $filePath"


### PR DESCRIPTION
This is fix for https://github.com/PowerShell/platyPS/issues/395

Since warning was already there we just need to to make sure command errors silently rather then displaying an error that it doesn't exists. 