### PR TITLE
Implemented fix for https://github.com/PowerShell/platyPS/issues/401

### DIFF
--- a/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
+++ b/src/Markdown.MAML/Transformer/ModelTransformerVersion2.cs
@@ -218,11 +218,7 @@ namespace Markdown.MAML.Transformer
                     {
                         // special case: there is only one parameter set and it's the default one
                         // we don't specify the name in this case.
-                    }
-                    else
-                    {
-                        continue;
-                    }                    
+                    }                   
                 }
                 else
                 {

--- a/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
+++ b/test/Markdown.MAML.Test/Transformer/ParserAndTransformerTestsV2.cs
@@ -577,11 +577,17 @@ Accept wildcard characters: false
             Assert.Contains("bz", bazParam.Aliases);
             Assert.Contains("z", bazParam.Aliases);
 
-            Assert.Equal(2, mamlCommand.Syntax.Count);
-            Assert.Equal("FooParam", mamlCommand.Syntax[1].Parameters[0].Name);
-            Assert.Equal("BazParam", mamlCommand.Syntax[1].Parameters[1].Name);
-            Assert.Equal("FooParam", mamlCommand.Syntax[0].Parameters[0].Name);
-            Assert.Equal("BarParam", mamlCommand.Syntax[0].Parameters[1].Name);
+           Assert.Equal(3, mamlCommand.Syntax.Count);
+           Assert.Null(mamlCommand.Syntax[0].ParameterSetName);
+           Assert.Equal("FooParam", mamlCommand.Syntax[0].Parameters[0].Name);
+
+           Assert.Equal("BarParamSet", mamlCommand.Syntax[1].ParameterSetName);
+           Assert.Equal("FooParam", mamlCommand.Syntax[1].Parameters[0].Name);
+           Assert.Equal("BarParam", mamlCommand.Syntax[1].Parameters[1].Name);
+
+           Assert.Equal("BazParamSet", mamlCommand.Syntax[2].ParameterSetName);
+           Assert.Equal("FooParam", mamlCommand.Syntax[2].Parameters[0].Name);
+           Assert.Equal("BazParam", mamlCommand.Syntax[2].Parameters[1].Name);
         }
 
         [Fact]


### PR DESCRIPTION
If the a parameter is in all parameter sets and there is parameter set containing only this parameter no syntax item is generated for this parameter set.