### PR TITLE
Fix New-ExternalHelpCab Typo

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1087,7 +1087,7 @@ function New-ExternalHelpCab
                 }
                 else
                 {
-                    Throw "$_ Module Landing Page path is nopt valid."
+                    Throw "$_ Module Landing Page path is not valid."
                 }
             })]
         [string] $LandingPagePath,


### PR DESCRIPTION
Fix typo in `-CabFilesFolder` parameter validation error message.