### PR TITLE
compare getcontent to new value

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1863,7 +1863,7 @@ function MySetContent
         if ((MyGetContent -Path $Path -Encoding $Encoding) -eq $value)
         {
             Write-Verbose "Not writing to $Path, because content is not changing."
-            return
+            return (Get-ChildItem $Path)
         }
 
         if (-not $Force)

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -1860,6 +1860,12 @@ function MySetContent
             return
         }
 
+        if ((MyGetContent -Path $Path -Encoding $Encoding) -eq $value)
+        {
+            Write-Verbose "Not writing to $Path, because content is not changing."
+            return
+        }
+
         if (-not $Force)
         {
             Write-Error "Cannot write to $Path, file exists. Use -Force to overwrite."

--- a/test/Pester/FullLoop.Tests.ps1
+++ b/test/Pester/FullLoop.Tests.ps1
@@ -18,6 +18,10 @@ Describe 'Full loop for Add-Member cmdlet' {
         $file.FullName | Should Be (Join-Path $outFolder "$cmdlet.md")
     }
 
+    It 'writes nothing if content is not changing' {
+        {New-MarkdownHelp -command $cmdlet -OutputFolder $outFolder -Encoding ([System.Text.Encoding]::UTF8) -ea Stop} | Should -Not -Throw
+    }
+
     # test -MarkdownFile piping
     $generatedMaml = $file | New-ExternalHelp -Verbose -OutputPath $outFolder -Force
 


### PR DESCRIPTION
This is about https://github.com/PowerShell/platyPS/issues/393

Content check is done before testing for `-Force` switch. This means these all three commands work fine, while only the first one updates file.

```PowerShell
New-MarkdownHelp -Command Get-Date -OutputFolder MyFolder
New-MarkdownHelp -Command Get-Date -OutputFolder MyFolder -Verbose # file exists, no changes
New-MarkdownHelp -Command Get-Date -OutputFolder MyFolder -Verbose -Force
```

Second option is to move this check after `-Force` check (6 lines below), which would cause 2nd command to fail, but 3rd one would still work as expected.