### PR TITLE
fixes #389 when using external scripts

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -207,6 +207,13 @@ function New-MarkdownHelp
                             Name = $commandName
                         }
 
+                        # fixes https://github.com/PowerShell/platyPS/issues/389 for generating docs using relative script paths
+                        # check if external command and updated command to use a path.
+                        # by defualt Get-Command does not search the current location for scripts
+                        if (Resolve-Path $commandName -Relative -ErrorAction SilentlyContinue -OutVariable script) {
+                            $a['Name'] = $script
+                        }
+
                         if ($module) {
                             # for module case, scope it just to this module
                             $a['Module'] = $module

--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -203,14 +203,17 @@ function New-MarkdownHelp
                     }
                     else
                     {
+                        
                         $a = @{
                             Name = $commandName
                         }
 
                         # fixes https://github.com/PowerShell/platyPS/issues/389 for generating docs using relative script paths
-                        # check if external command and updated command to use a path.
-                        # by defualt Get-Command does not search the current location for scripts
-                        if (Resolve-Path $commandName -Relative -ErrorAction SilentlyContinue -OutVariable script) {
+                        # check if external command and update command to use the path to the external script.
+                        # By defualt Get-Command does not search the current location for scripts
+                        $isLocalScript = $commandName -match "\\.*.\.ps1\b"
+                        $isLocalPathValid = [bool](Resolve-Path $commandName -Relative -ErrorAction SilentlyContinue -OutVariable script)
+                        if ($isLocalScript -AND $isLocalPathValid) {
                             $a['Name'] = $script
                         }
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -143,6 +143,17 @@ Describe 'New-MarkdownHelp' {
         }
     }
 
+    Context 'from external script' { 
+        It 'creates 2 markdown file from fully qualified and relative scripts' {
+            New-Item -Path TestDrive:\localscript.ps1 -force | Out-Null
+            $fqCommand = "TestDrive:\localscript.ps1"
+            $relCommand = ".\localscript.ps1"
+            Set-Location TestDrive:\
+            $files = New-MarkdownHelp -Command @($fqCommand, $relCommand) -OutputFolder TestDrive:\commands -Force
+            ($files | Measure-Object).Count | Should Be 2
+        }
+    }
+
     Context 'AlphabeticParamsOrder' {
         function global:Get-Alpha
         {


### PR DESCRIPTION
Right now, platy successfully finds and loads the command ( `.\my-script.ps1` ) but then passes only the name of the script ( not included the relative path ) to `Get-Command` to generate the file name. `Get-Command will not search the current working directory so will through a non-terminating error it seems. 

The most straightforward solution seemed to be, check if this command is an external script and if so, make sure we resolve the path ( relative to us ) and pass THAT to get-command. 

I'm not sure I fully understand the core of platy yet though so this may just be a work around solution rather than a full solution. Just let me know though. 

5 tests failed but those same 5 tests failed before I made the change so I think that's unrelated. 