### PR TITLE
Lowercase description element name

### DIFF
--- a/src/Markdown.MAML/Renderer/MamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/MamlRenderer.cs
@@ -118,7 +118,7 @@ namespace Markdown.MAML.Renderer
                     new XAttribute("aliases", param.Aliases.Any() ? string.Join(", ", param.Aliases) : "none"),
 
                     new XElement(mamlNS + "name", param.Name),
-                    new XElement(mamlNS + "Description", GenerateParagraphs(param.Description)),
+                    new XElement(mamlNS + "description", GenerateParagraphs(param.Description)),
                     isSyntax && param.ParameterValueGroup.Any() 
                         ? new XElement(commandNS + "parameterValueGroup", param.ParameterValueGroup.Select(pvg => CreateParameterValueGroup(pvg))) 
                         : null,

--- a/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/MamlRendererTests.cs
@@ -98,11 +98,11 @@ namespace Markdown.MAML.Test.Renderer
             Assert.Single(description);
             Assert.Equal("This is a long description.", description[0]);
 
-            string[] parameter1 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Name']/maml:Description/maml:para");
+            string[] parameter1 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Name']/maml:description/maml:para");
             Assert.Single(parameter1);
             Assert.Equal("This is the name parameter description.", parameter1[0]);
 
-            string[] parameter2 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Path']/maml:Description/maml:para");
+            string[] parameter2 = EndToEndTests.GetXmlContent(maml, "/msh:helpItems/command:command/command:parameters/command:parameter[maml:name='Path']/maml:description/maml:para");
             Assert.Single(parameter2);
             Assert.Equal("This is the path parameter description.", parameter2[0]);
 


### PR DESCRIPTION
Make the description element name (`maml:description`) for params lowercase.
Because all other elements are lowercase and this one is an exception.
It breaks automatic processing of case-sensitive apps (e.g. based on XSLT).