### PR TITLE
Improve Example output formatting

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2865,15 +2865,17 @@ function ConvertPsObjectsToMamlModel
 
         $MamlExampleObject.Introduction = $Example.introduction
         $MamlExampleObject.Title = $Example.title
+        
+        $CodeBlock = @"
+$($Example.code.Trim())
+
+$($Example.remarks.text.Trim())
+"@
+        $CodeBlock = $CodeBlock.Trim()
         $MamlExampleObject.Code = @(
-            New-Object -TypeName Markdown.MAML.Model.MAML.MamlCodeBlock ($Example.code, '')
+            New-Object -TypeName Markdown.MAML.Model.MAML.MamlCodeBlock($CodeBlock, 'powershell')
         )
 
-        $RemarkText = $Example.remarks |
-            DescriptionToPara |
-            AddLineBreaksForParagraphs
-
-        $MamlExampleObject.Remarks = $RemarkText
         $MamlCommandObject.Examples.Add($MamlExampleObject)
     }
 


### PR DESCRIPTION
The current formatting does not tag the code block as PowerShell. The remarks attribute sometimes is the formatted output of the example which is not within the code block. If there is a new line between the command example and the output of the command in the ".EXAMPLE", the output is considered remarks and will be unformatted by the current implementation. This provides, subjectively, a more esthetic output.

Here are examples of the output:
https://github.com/roberttoups/IPv4Toolbox/blob/master/Docs/Invoke-IPv4ListSort.md
https://github.com/roberttoups/IPv4Toolbox/blob/master/Docs/Get-SubnetInformation.md