### PR TITLE
Run Appveyor CI on branches other than v2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: 0.11.0.{build}
 
+branches:
+  except:
+    - v2
+
 install:
     - ps: |
         Write-Host "PowerShell Version:" $PSVersionTable.PSVersion.tostring()


### PR DESCRIPTION
Make sure the AppVeyor CI is not run on v2 branch.