### PR TITLE
Allow New-YamlHelp to generate YAML for Common Parameters

### DIFF
--- a/src/Markdown.MAML/Renderer/YamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/YamlRenderer.cs
@@ -31,6 +31,17 @@ namespace Markdown.MAML.Renderer
                 Syntaxes = mamlCommand.Syntax.Select(CreateSyntax).ToList()
             };
 
+            if (mamlCommand.SupportCommonParameters)
+            {
+                var commonParam = new YamlParameter
+                {
+                    Name = "<CommonParameters>",
+                    Description = "This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216)."
+                };
+
+                model.OptionalParameters.Add(commonParam);
+            }
+
             using (var writer = new StringWriter())
             {
                 serializer.Serialize(writer, model);

--- a/src/Markdown.MAML/Renderer/YamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/YamlRenderer.cs
@@ -35,8 +35,8 @@ namespace Markdown.MAML.Renderer
             {
                 var commonParam = new YamlParameter
                 {
-                    Name = "<CommonParameters>",
-                    Description = "This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216)."
+                    Name = "<" + Markdown.MAML.Resources.MarkdownStrings.CommonParametersToken + ">",
+                    Description = Markdown.MAML.Resources.MarkdownStrings.CommonParametersText
                 };
 
                 model.OptionalParameters.Add(commonParam);

--- a/src/Markdown.MAML/Renderer/YamlRenderer.cs
+++ b/src/Markdown.MAML/Renderer/YamlRenderer.cs
@@ -35,7 +35,7 @@ namespace Markdown.MAML.Renderer
             {
                 var commonParam = new YamlParameter
                 {
-                    Name = "<" + Markdown.MAML.Resources.MarkdownStrings.CommonParametersToken + ">",
+                    Name = Markdown.MAML.Resources.MarkdownStrings.CommonParametersToken,
                     Description = Markdown.MAML.Resources.MarkdownStrings.CommonParametersText
                 };
 

--- a/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
@@ -119,7 +119,7 @@ namespace Markdown.MAML.Test.Renderer
 
             var writtenModel = deserializer.Deserialize<YamlCommand>(output);
 
-            Assert.Single(writtenModel.OptionalParameters);
+            Assert.Equal(2, writtenModel.OptionalParameters.Count);
 
             var optionalParameter = writtenModel.OptionalParameters.Single();
             var expectedParameter = model.Parameters.Single(p => !p.Required);
@@ -197,7 +197,7 @@ namespace Markdown.MAML.Test.Renderer
             var syntax = writtenModel.Syntaxes.Single();
 
             Assert.Equal(model.Syntax.Single().ParameterSetName, syntax.ParameterValueGroup);
-            
+
             Assert.Single(syntax.Parameters);
             Assert.Equal(model.Syntax.Single().Parameters.Single().Name, syntax.Parameters.Single());
         }

--- a/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
+++ b/test/Markdown.MAML.Test/Renderer/YamlRendererTests.cs
@@ -121,7 +121,7 @@ namespace Markdown.MAML.Test.Renderer
 
             Assert.Equal(2, writtenModel.OptionalParameters.Count);
 
-            var optionalParameter = writtenModel.OptionalParameters.Single();
+            var optionalParameter = writtenModel.OptionalParameters.First();
             var expectedParameter = model.Parameters.Single(p => !p.Required);
 
             Assert.Equal(expectedParameter.Globbing, optionalParameter.AcceptWildcardCharacters);

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -1621,7 +1621,7 @@ Describe 'New-YamlHelp' {
         $yamlModel.RequiredParameters[0].Name | Should Be 'Path'
         $yamlModel.RequiredParameters[1].Name | Should Be 'OutputFolder'
 
-        $yamlModel.OptionalParameters.Count | Should Be 2
+        $yamlModel.OptionalParameters.Count | Should Be 3
 
         $yamlModel.OptionalParameters[0].Name | Should Be 'Encoding'
         $yamlModel.OptionalParameters[1].Name | Should Be 'Force'


### PR DESCRIPTION
Fixes #540 

Remove the code which blocked generating yaml for Common Parameters. 

Add tests for the same.