### PR TITLE
Fix generic type name to avoid ` in type names

### DIFF
--- a/src/Model/Constants.cs
+++ b/src/Model/Constants.cs
@@ -35,7 +35,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
         internal const string OptionalSwitchParamTemplate = "[-{0}]";
         internal const string RequiredSwitchParamTemplate = "-{0}";
 
-
         internal const char   SingleSpace = ' ';
         internal const string ParameterSetHeaderDefaultTemplate = "### {0} (Default)";
         internal const string ParameterSetHeaderTemplate = "### {0}";
@@ -50,6 +49,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
         internal const string DelimiterComma = ", ";
         internal const string SystemObjectTypename = "System.Object";
         internal const string SyntaxCommonParameters = "[<CommonParameters>]";
+        internal const string GenericParameterBackTick = "`";
+        internal const string GenericParameterTypeNameStart = "<";
+        internal const string GenericParameterTypeNameEnd = ">";
 
         internal const string RequiredParameterSetsTemplate = "True ({0}) False ({1})";
         internal const string NotesItemHeaderTemplate = "### {0}";

--- a/src/TransformBase.cs
+++ b/src/TransformBase.cs
@@ -227,6 +227,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
                     if (genericName.Contains(Constants.GenericParameterBackTick))
                     {
+                        // This removes `2 from type name like: System.Collections.Generic.Dictionary`2
                         sb.Append(genericName.Remove(genericName.IndexOf(Constants.GenericParameterBackTick)));
                     }
                     else

--- a/src/TransformBase.cs
+++ b/src/TransformBase.cs
@@ -225,8 +225,16 @@ namespace Microsoft.PowerShell.PlatyPS
                         type.GetGenericTypeDefinition().FullName ?? string.Empty :
                         type.GetGenericTypeDefinition().Name;
 
-                    sb.Append(genericName);
-                    sb.Append('[');
+                    if (genericName.Contains(Constants.GenericParameterBackTick))
+                    {
+                        sb.Append(genericName.Remove(genericName.IndexOf(Constants.GenericParameterBackTick)));
+                    }
+                    else
+                    {
+                        sb.Append(genericName);
+                    }
+
+                    sb.Append(Constants.GenericParameterTypeNameStart);
 
                     List<string> genericParameters = new();
 
@@ -240,7 +248,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
                     sb.Append(string.Join(",", genericParameters));
 
-                    sb.Append(']');
+                    sb.Append(Constants.GenericParameterTypeNameEnd);
 
                     typeName = sb.ToString();
                 }

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -427,7 +427,7 @@ Write-Host 'Hello World!'
         It 'use full type name when specified' -Pending {
             $expectedParameters = normalizeEnds @'
 Type: System.String
-Type: System.Nullable`1[System.Int32]
+Type: System.Nullable<System.Int32>
 Type: System.Management.Automation.SwitchParameter
 
 '@


### PR DESCRIPTION
Avoid having ` in the typenames for generated markdown

Fixes https://github.com/PowerShell/platyPS/issues/519