### PR TITLE
(AB-1952370) Add link to docs repo in issue picker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Support
     url: https://github.com/PowerShell/PowerShell/blob/master/.github/SUPPORT.md
     about: PowerShell Support Questions/Help
+  - name: Documentation Issue
+    url: https://github.com/MicrosoftDocs/PowerShell-Docs-Modules/issues/new
+    about: Please open issues on documentation for PlatyPS here.


### PR DESCRIPTION
Prior to this change the issue picker did not enumerate where to file documentation issues or requests. This change extends the list of links for the issue picker to include a direct link to the documentation repository to file a new issue.