### PR TITLE
Fix the loader to work on PowerShell 7.0 too (.NET 3.1)

### DIFF
--- a/src/ModuleInitAndCleanup.cs
+++ b/src/ModuleInitAndCleanup.cs
@@ -76,9 +76,8 @@ namespace Microsoft.PowerShell.PlatyPS
         private readonly object _customContext;
         private readonly MethodInfo _loadFromAssemblyPath;
 
-        private AssemblyLoadContextProxy(string loadContextName)
+        private AssemblyLoadContextProxy(Type alc, string loadContextName)
         {
-            var alc = typeof(object).Assembly.GetType("System.Runtime.Loader.AssemblyLoadContext");
             var ctor = alc.GetConstructor(new[] { typeof(string), typeof(bool) });
             _loadFromAssemblyPath = alc.GetMethod("LoadFromAssemblyPath", new[] { typeof(string) });
             _customContext = ctor.Invoke(new object[] { loadContextName, false });
@@ -96,8 +95,9 @@ namespace Microsoft.PowerShell.PlatyPS
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return Environment.Version.Major > 4
-                ? new AssemblyLoadContextProxy(name)
+            var alc = typeof(object).Assembly.GetType("System.Runtime.Loader.AssemblyLoadContext");
+            return alc is not null
+                ? new AssemblyLoadContextProxy(alc, name)
                 : null;
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the loader to work on PowerShell 7.0 too (.NET 3.1).
The check `Environment.Version.Major > 4` was not accurate to reflect whether we are running in .NET Core, for example, it fails when running in PowerShell 7.0.
Fix it by checking if the `AssemblyLoadContext` type is available at runtime.