### PR TITLE
Fixing incorrect null-checks in Input/Output and help handling

### DIFF
--- a/src/platyPS/platyPS.psm1
+++ b/src/platyPS/platyPS.psm1
@@ -2867,7 +2867,7 @@ function ConvertPsObjectsToMamlModel
     }
 
     #Get Description
-    if($Help.description -ne $null)
+    if($null -ne $Help.description)
     {
         $MamlCommandObject.Description =  New-Object -TypeName Markdown.MAML.Model.Markdown.SectionBody (
             $Help.description |
@@ -2930,7 +2930,7 @@ function ConvertPsObjectsToMamlModel
     $Help.inputTypes.inputType | ForEach-Object {
         $InputDescription = $_.description
         $inputtypes = $_.type.name
-        if ($_.description -eq $null -and $_.type.name -ne $null)
+        if ($null -eq $_.description -and $null -ne $_.type.name)
         {
             $inputtypes = $_.type.name.split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)
         }
@@ -2957,7 +2957,7 @@ function ConvertPsObjectsToMamlModel
     $Help.returnValues.returnValue | ForEach-Object {
         $OuputDescription = $_.description
         $Outputtypes = $_.type.name
-        if ($_.description -eq $null -and $_.type.name -ne $null)
+        if ($null -eq $_.description -and $null -ne $_.type.name)
         {
             $Outputtypes = $_.type.name.split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)
         }


### PR DESCRIPTION
Fixing null checks in `ConvertPSObjectToMamlModel`. 

With the current behavior, new lines are added/removed every other run causing constant repository churn.
# PR Summary

Ensures that scalar null comparison is performed without type conversion.

## PR Context
Updating Markdown files without this PR resulted in a file toggling between this:
![image](https://user-images.githubusercontent.com/3505151/216566047-7f7156f8-5939-4462-a116-305ac1fed1be.png)
and this:
![image](https://user-images.githubusercontent.com/3505151/216566260-264237f6-ade2-4be8-9fe3-26722dd04618.png)

A real annoyance because of the constant repository churn or selective reverts.
