### PR TITLE
Fix unsafe characters in command names breaking markdown file creation

### DIFF
--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -346,7 +346,7 @@ Write-Host 'Hello World!'
             Adds a file name extension to a supplied name.
 
             .DESCRIPTION
-            Adds a file name extension to a supplied name.
+            Given a filename and an extension this function joins them together.
             Takes any strings for the file name or extension.
 
             .PARAMETER Second

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -1026,18 +1026,18 @@ if (-not $global:IsUnix) {
 
 Describe 'ConvertToSafeFilename' {
 
-    function global:Test-UnsafeFilename?
+    function global:"Test-Unsafe/Filename"
     {
         param(
             [string]$Foo
         )
     }
 
-    It "generates a safe filename for a windows OS when given a bad input" -Skip:$global:IsUnix {
+    It "generates a safe filename for a windows OS when given a bad input" {
         $drop = "TestDrive:\MD\ConvertToSafeFilename"
         Remove-Item -rec $drop -ErrorAction SilentlyContinue
-        $file = New-MarkdownHelp -Command "Test-UnsafeFilename?" -OutputFolder $drop
-        $file.Name | Should Be 'Test-UnsafeFilename_.md'
+        $file = New-MarkdownHelp -Command "Test-Unsafe/Filename" -OutputFolder $drop
+        $file.Name | Should Be 'Test-Unsafe_Filename.md'
     }
 }
 

--- a/test/Pester/PlatyPs.Tests.ps1
+++ b/test/Pester/PlatyPs.Tests.ps1
@@ -1024,6 +1024,23 @@ if (-not $global:IsUnix) {
 #endregion
 }
 
+Describe 'ConvertToSafeFilename' {
+
+    function global:Test-UnsafeFilename?
+    {
+        param(
+            [string]$Foo
+        )
+    }
+
+    It "generates a safe filename for a windows OS when given a bad input" -Skip:$global:IsUnix {
+        $drop = "TestDrive:\MD\ConvertToSafeFilename"
+        Remove-Item -rec $drop -ErrorAction SilentlyContinue
+        $file = New-MarkdownHelp -Command "Test-UnsafeFilename?" -OutputFolder $drop
+        $file.Name | Should Be 'Test-UnsafeFilename_.md'
+    }
+}
+
 Describe 'Update-MarkdownHelp -LogPath' {
 
     It 'checks the log exists' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This replaces unsafe characters in command names with underscores so that file creation will work if this library tries to create files for strangely named functions like:
 - `gh?`
 - `git?`

![image](https://github.com/PowerShell/platyPS/assets/13159458/d52a09c4-c8e2-4f5c-9217-483fd34e9512)


> **Note**
> The master branch currently has a failing test because it's checking for a single instance of a string in the output markdown which should be there twice, once in the synopsis and once in the description. It looks like it's been failing for a long time, I fixed it by making the description and the synopsis unique on line 349 of `test/Pester/PlatyPs.Tests.ps1`. This could be fixed in this PR or I can descope it https://ci.appveyor.com/project/PowerShell/markdown-maml/branch/master

## PR Context

I've been trying to generate help docs for PowerShellAI and it uses question marks in command names which causes platyPS to fail when run on Windows.  
Fixes https://github.com/PowerShell/platyPS/issues/602
