### PR TITLE
Update V2 specs to include more parameter metadata

### DIFF
--- a/specs/alias-prototype.md
+++ b/specs/alias-prototype.md
@@ -2,15 +2,11 @@
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 Locale: en-US
 Module Name: Microsoft.PowerShell.Management
-ms.date: 03/27/2020
+ms.date: 12/05/2023
 online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.2&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Get-ChildItem
-alias:
-  all: [dir, gci]
-  windows: [ls]
-  macos:
-  linux:
+alias: [dir, gci, ls]
 ---
 # Get-ChildItem
 

--- a/specs/platyps_2.0_update.md
+++ b/specs/platyps_2.0_update.md
@@ -110,24 +110,46 @@ Dynamic: True
 Providers: Alias, Function
 Values from remaining args: False
 Do not show: False
+Is credential: False
+Is obsolete: False
 Release status: Feature Preview
 ```
 ~~~
+
+Notes
+
+- Values for most items should be obtained by reflection.
+- Provider information will have to be tested individually based on the currently loaded providers.
+- The `Default value` should be obtained by reflection, if possible.
+  - The default value for **SwitchParameter** types should be `False`.
+- If possible, the `Parameter sets` and `Providers` values should be simplified to show `(All)` when
+  the value is the same for all parameter sets or providers.
 
 New metadata
 
 - `Dynamic`
   - Type: boolean
+    -  Obtained by reflection of parameter attributes
   - Required
 - `Providers`
   - Type: string containing one or more provider names (comma-separated)
   - Optional - expected when `Dynamic` is true
 - `Values from remaining args`
   - Type: boolean
+    -  Obtained by reflection of parameter attributes
   - Required
 - `Do not show`
   - Type: boolean
+    -  Obtained by reflection of parameter attributes
   - Required
+- `Is credential`
+  - Type: boolean
+    -  Obtained by reflection of parameter attributes
+  - Required
+- `Is obsolete`
+  - Type: boolean
+    -  Obtained by reflection of parameter attributes
+    - Required
 - `Release status`
   - Type: string representation of one enum value from:
     - 'Preview' - typically not used for parameters
@@ -150,11 +172,7 @@ is difficult to discover, so don't need `*-MarkdownHelp` cmdlets to create it bu
 to support it. The author can add the information to the YAML frontmatter. For example:
 
 ```yaml
-aliases:
-  all: [dir, gci]
-  windows: [ls]
-  macOS:
-  linux:
+aliases: [dir, gci, ls]
 ```
 
 Add new H2 for documenting aliases.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update V2 specs to include more parameter metadata

## PR Context

- Corrected alias metadata and example
- Added more descriptions for parameter metadata
- Added `Is credential` and `Is obsolete` to the metadata