### PR TITLE
Updates for Syntax parsing and writing

### DIFF
--- a/src/Command/NewMarkownHelpCommand.cs
+++ b/src/Command/NewMarkownHelpCommand.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     var settings = new CommandHelpWriterSettings(Encoding, $"{fullPath}{Constants.DirectorySeparator}{cmdletHelp.Title}.md");
                     using var cmdWrt = new CommandHelpMarkdownWriter(settings);
-                    WriteObject(cmdWrt.Write(cmdletHelp, Metadata));
+                    WriteObject(this.InvokeProvider.Item.Get(cmdWrt.Write(cmdletHelp, Metadata).FullName));
                 }
 
                 if (WithModulePage)
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     var modulePageSettings = new CommandHelpWriterSettings(Encoding, resolvedPathModulePagePath);
                     using var modulePageWriter = new ModulePageWriter(modulePageSettings);
 
-                    WriteObject(modulePageWriter.Write(cmdHelpObjs));
+                    WriteObject(this.InvokeProvider.Item.Get(modulePageWriter.Write(cmdHelpObjs).FullName));
                 }
             }
         }

--- a/src/Model/SyntaxParameter.cs
+++ b/src/Model/SyntaxParameter.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Microsoft.PowerShell.PlatyPS.Model
+{
+    /// <summary>
+    /// Class to represent the properties of a parameter used for a syntax item in PowerShell help.
+    /// </summary>
+    public class SyntaxParameter : IEquatable<SyntaxParameter>
+    {
+        public string ParameterName { get; set; } = string.Empty;
+        public string ParameterType { get; set; } = string.Empty;
+        public string Position { get; set; } = string.Empty; // this can look like an int or "named", or empty
+        public bool IsMandatory { get; set; }
+        public bool IsPositional { get; set; }
+        public bool IsSwitchParameter { get; set; }
+
+        public SyntaxParameter()
+        {
+
+        }
+
+        public SyntaxParameter(string name)
+        {
+            ParameterName = name;
+        }
+
+        public SyntaxParameter(string name, string type, string position, bool isMandatory, bool isPositional, bool isSwitchParameter)
+        {
+            ParameterName = name;
+            ParameterType = type;
+            Position = position;
+            IsMandatory = isMandatory;
+            IsPositional = isPositional;
+            IsSwitchParameter = isSwitchParameter;
+        }
+    
+        /// <summary>
+        /// We build the string that is identical to the output of Get-Command -Syntax
+        /// This could look like:
+        /// [[-Parameter] <string>] optional and positional
+        /// [-Parameter] optional, type SwitchParameter
+        /// -Parameter <string> mandatory, non-positional
+        /// [-Parameter] <string> positional, mandatory
+        /// </summary>
+        /// <returns>A string</returns>
+        public override string ToString()
+        {
+            StringBuilder sb = Constants.StringBuilderPool.Get();
+            if (! IsMandatory)
+            {
+                sb.Append("[");
+            }
+
+            // Positional parameters are surrounded by square brackets
+            if (IsPositional)
+            {
+                sb.Append("[");
+            }
+
+            sb.Append($"-{ParameterName}");
+            if (IsPositional || IsSwitchParameter)
+            {
+                sb.Append("]");
+            }
+
+            if (! IsSwitchParameter)
+            {
+                sb.Append($" <{ParameterType}>");
+                if (! IsMandatory)
+                {
+                    sb.Append("]");
+                }
+            }
+            // It's not possible to have an optional, positional switch parameter
+
+            try
+            {
+                return sb.ToString();
+            }
+            finally
+            {
+                Constants.StringBuilderPool.Return(sb);
+            }
+        }
+
+        public bool Equals(SyntaxParameter other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+            return other.IsMandatory == IsMandatory &&
+                    other.IsPositional == IsPositional &&
+                    other.IsSwitchParameter == IsSwitchParameter &&
+                    string.Compare(other.ParameterName, ParameterName, true) == 0 &&
+                    string.Compare(other.ParameterType, ParameterType, true) == 0 &&
+                    string.Compare(other.Position, Position, true) == 0;
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+            if (other is SyntaxParameter syntaxParameter2)
+            {
+                return Equals(syntaxParameter2);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return (ParameterName, ParameterType, Position).GetHashCode();
+        }
+
+        public static bool operator ==(SyntaxParameter syntaxParameter1, SyntaxParameter syntaxParameter2)
+        {
+            if (syntaxParameter1 is not null && syntaxParameter2 is not null)
+            {
+                return syntaxParameter1.Equals(syntaxParameter2);
+            }
+            return false;
+        }
+
+        public static bool operator !=(SyntaxParameter syntaxParameter1, SyntaxParameter syntaxParameter2)
+        {
+            if (syntaxParameter1 is not null && syntaxParameter2 is not null)
+            {
+                return ! syntaxParameter1.Equals(syntaxParameter2);
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
update the syntax parser and writer.
I've added a SyntaxParameter to better parse the parameters in a syntax line.
The output for syntax is now correct, with proper line breaks and indentation
Update New-MarkdownHelp so it emits an adapted fileinfo object and it looks better now.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
