### PR TITLE
implement the module file reader

### DIFF
--- a/src/Command/CompareCommandHelpCommand.cs
+++ b/src/Command/CompareCommandHelpCommand.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+using Microsoft.PowerShell.PlatyPS.Model;
+using System.Linq;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    /// <summary>
+    /// Cmdlet to import a markdown file and convert it to a CommandHelp object.
+    /// </summary>
+
+    [Cmdlet(VerbsData.Compare, "CommandHelp")]
+    public class CompareCommandHelpCommand : PSCmdlet
+    {
+        /// <summary>
+        /// The reference for comparison.
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        public CommandHelp? Reference { get; set; }
+
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        public CommandHelp? Difference { get; set; }
+
+        [Parameter]
+        public string[] PropertyNamesToExclude { get; set; } = new string[0];
+
+        List<String> DiagnosticMessages = new();
+
+        protected override void ProcessRecord()
+        {
+            if (Reference is null)
+            {
+                WriteError(new ErrorRecord(new ArgumentNullException("Reference object may not be null"), "errorId", ErrorCategory.InvalidData, null));
+                return;
+            }
+
+            if (Difference is null)
+            {
+                WriteError(new ErrorRecord(new ArgumentNullException("Difference object may not be null"), "errorId", ErrorCategory.InvalidData, null));
+                return;
+            }
+
+
+            var refObject = new PSObject((CommandHelp)Reference);
+            var difObject = new PSObject((CommandHelp)Difference);
+
+            CompareProperty(refObject, difObject, 0);
+
+            WriteObject(DiagnosticMessages);
+            DiagnosticMessages.Clear();
+        }
+
+        private void CompareProperty(PSObject refObject, PSObject difObject, int offset)
+        {
+            var spaces = new string(' ', offset);
+            foreach (var property in refObject.Properties)
+            {
+                if (property.Value is String || ! (property.Value is IEnumerable))
+                {
+                    var difProperty = difObject.Properties.Where(p => string.Compare(property.Name, p.Name) == 0).First();
+                    if (LanguagePrimitives.Equals(difProperty.Value, property.Value))
+                    {
+                        var vString = property.Value is null ? string.Empty : property.Value.ToString();
+                        var val = vString.Length > 20 ? vString.Substring(0,17) : vString;
+                        DiagnosticMessages.Add($"{spaces}{property.Name} are the same ({val})");
+                    }
+                    else
+                    {
+                        DiagnosticMessages.Add($"{spaces}{property.Name} are not the same '{property.Value}' vs '{difProperty.Value}'");
+                    }
+                }
+                else if (property.Value is IDictionary)
+                {
+                    DiagnosticMessages.Add($"Inspecting {property.Name}");
+                    var rDictionary = (IDictionary)property.Value;
+                    var dDictionary = (IDictionary)difObject.Properties.Where(p => string.Compare(property.Name, p.Name) == 0).First().Value;
+                    foreach (var key in rDictionary.Keys)
+                    {
+                        if (LanguagePrimitives.Equals(rDictionary[key], dDictionary[key]))
+                        {
+                            DiagnosticMessages.Add($"{spaces}  {key} are the same ({rDictionary[key]})");
+                        }
+                        else
+                        {
+                            DiagnosticMessages.Add($"{spaces}  {key} not the same {rDictionary[key]} vs {dDictionary[key]}");
+                        }
+                    }
+
+                }
+                else if (property.Value is IList rList)
+                {
+                    DiagnosticMessages.Add($"Inspecting {property.Name}");
+                    var dList = (IList)difObject.Properties.Where(p => string.Compare(property.Name, p.Name) == 0).First().Value;
+                    if (rList.Count == 0 && dList.Count == 0)
+                    {
+                        DiagnosticMessages.Add($"{spaces}Lists are empty");
+                    }
+                    else if (rList.Count != dList.Count)
+                    {
+                        DiagnosticMessages.Add($"{spaces}Lists are different sizes ({rList.Count} vs {dList.Count})");
+                    }
+                    else
+                    {
+                        for (int i = 0; i < rList.Count; i++)
+                        {
+                            var rPSO = new PSObject(rList[i]);
+                            var dPSO = new PSObject(dList[i]);
+                            CompareProperty(rPSO, dPSO, offset + 2);
+                        }
+                    }
+                }
+                else if (property.Value is Array rArray)
+                {
+                    DiagnosticMessages.Add($"Inspecting {property.Name}");
+                    var dArray = (Array)difObject.Properties.Where(p => string.Compare(property.Name, p.Name) == 0).First().Value;
+                    if (rArray.Length == 0 && dArray.Length == 0)
+                    {
+                        DiagnosticMessages.Add($"{spaces}Arrays are empty");
+                    }
+                    else if (rArray.Length != dArray.Length)
+                    {
+                        DiagnosticMessages.Add($"{spaces}Arrays are different sizes ({rArray.Length} vs {dArray.Length})");
+                    }
+                    else
+                    {
+                        for (int i = 0; i < rArray.Length; i++)
+                        {
+                            var rPSO = new PSObject(rArray.GetValue(i));
+                            var dPSO = new PSObject(dArray.GetValue(i));
+                            CompareProperty(rPSO, dPSO, offset + 2);
+                        }
+                    }
+                }
+                else
+                {
+                    DiagnosticMessages.Add($"{spaces}Skipping {property.Name}");
+                }
+            }
+        }
+    }
+}

--- a/src/Command/ConvertToCommandHelpCommand.cs
+++ b/src/Command/ConvertToCommandHelpCommand.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+
+using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+using Microsoft.PowerShell.PlatyPS.Model;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    /// <summary>
+    /// Cmdlet to import a markdown file and convert it to a CommandHelp object.
+    /// </summary>
+    [Cmdlet(VerbsData.ConvertTo, "CommandHelp")]
+    public sealed class ConvertToCommandHelpCommand : PSCmdlet
+    {
+#region cmdlet parameters
+
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+        public string[] CommandInfo { get; set; } = new string[0];
+
+#endregion
+
+        Collection<CommandHelp>? cmdHelpObjs = null;
+
+        TransformSettings transformSettings = new();
+
+        protected override void BeginProcessing()
+        {
+            transformSettings = new TransformSettings()
+            {
+                AlphabeticParamsOrder = true,
+                CreateModulePage = false,
+                DoubleDashList = false,
+                ExcludeDontShow = true,
+                HelpVersion = "3.0.0",
+                Locale = CultureInfo.GetCultureInfo("en-US"),
+                UseFullTypeName = true
+            };
+        }
+
+        protected override void ProcessRecord()
+        {
+            foreach (var cInfo in CommandInfo)
+            {
+                cmdHelpObjs = new TransformCommand(transformSettings).Transform(CommandInfo);
+                foreach (var cHelp in cmdHelpObjs)
+                {
+                    WriteObject(cHelp);
+                }
+            }
+        }
+    }
+}

--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -29,6 +29,8 @@ namespace Microsoft.PowerShell.PlatyPS
         public CommandHelp[] Command { get; set; } = Array.Empty<CommandHelp>();
 
         [Parameter()]
+        [ArgumentToEncodingTransformation]
+        [ArgumentEncodingCompletions]
         public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         [Parameter()]

--- a/src/Command/ExportMarkdownHelpCommand.cs
+++ b/src/Command/ExportMarkdownHelpCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
@@ -26,8 +27,10 @@ namespace Microsoft.PowerShell.PlatyPS
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public object[] Command { get; set; } = Array.Empty<string>();
 
-        [Parameter()]
-        public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        [Parameter]
+        [ArgumentToEncodingTransformation]
+        [ArgumentEncodingCompletions]
+        public System.Text.Encoding Encoding { get; set; }  = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         [Parameter()]
         public SwitchParameter Force { get; set; }

--- a/src/Command/ExportYamlCommandHelp.cs
+++ b/src/Command/ExportYamlCommandHelp.cs
@@ -27,6 +27,8 @@ namespace Microsoft.PowerShell.PlatyPS
         public CommandHelp[] Command { get; set; } = Array.Empty<CommandHelp>();
 
         [Parameter()]
+        [ArgumentToEncodingTransformation]
+        [ArgumentEncodingCompletions]
         public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         [Parameter()]

--- a/src/Command/NewMarkownHelpCommand.cs
+++ b/src/Command/NewMarkownHelpCommand.cs
@@ -27,6 +27,8 @@ namespace Microsoft.PowerShell.PlatyPS
         public string[] Command { get; set; } = Array.Empty<string>();
 
         [Parameter()]
+        [ArgumentToEncodingTransformation]
+        [ArgumentEncodingCompletions]
         public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         [Parameter()]

--- a/src/Common/EncodingUtils.cs
+++ b/src/Common/EncodingUtils.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    internal static class EncodingConversion
+    {
+        internal const string ANSI = "ansi";
+        internal const string Ascii = "ascii";
+        internal const string BigEndianUnicode = "bigendianunicode";
+        internal const string BigEndianUtf32 = "bigendianutf32";
+        internal const string Default = "default";
+        internal const string OEM = "oem";
+        internal const string String = "string";
+        internal const string Unicode = "unicode";
+        internal const string Unknown = "unknown";
+        internal const string Utf7 = "utf7";
+        internal const string Utf8 = "utf8";
+        internal const string Utf8Bom = "utf8BOM";
+        internal const string Utf8NoBom = "utf8NoBOM";
+        internal const string Utf32 = "utf32";
+
+        internal static readonly string[] TabCompletionResults = {
+                ANSI, Ascii, BigEndianUnicode, BigEndianUtf32, /* OEM, */ Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
+            };
+
+        internal static readonly Dictionary<string, Encoding> encodingMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { ANSI, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage) },
+            { Ascii, Encoding.ASCII },
+            { BigEndianUnicode, Encoding.BigEndianUnicode },
+            { BigEndianUtf32, new UTF32Encoding(bigEndian: true, byteOrderMark: true) },
+            { Default, Encoding.Default },
+            // { OEM, ClrFacade.GetOEMEncoding() },
+            { String, Encoding.Unicode },
+            { Unicode, Encoding.Unicode },
+            { Unknown, Encoding.Unicode },
+#pragma warning disable SYSLIB0001
+            { Utf7, Encoding.UTF7 },
+#pragma warning restore SYSLIB0001
+            { Utf8, Encoding.Default },
+            { Utf8Bom, Encoding.UTF8 },
+            { Utf8NoBom, Encoding.Default },
+            { Utf32, Encoding.UTF32 },
+        };
+
+        /// <summary>
+        /// Retrieve the encoding parameter from the command line
+        /// it throws if the encoding does not match the known ones.
+        /// </summary>
+        /// <returns>A System.Text.Encoding object (null if no encoding specified).</returns>
+        internal static Encoding? Convert(Cmdlet cmdlet, string encoding)
+        {
+            if (string.IsNullOrEmpty(encoding))
+            {
+                // no parameter passed, default to UTF8
+                return Encoding.Default;
+            }
+
+            if (encodingMap.TryGetValue(encoding, out Encoding foundEncoding))
+            {
+                // Write a warning if using utf7 as it is obsolete in .NET5
+                if (string.Equals(encoding, Utf7, StringComparison.OrdinalIgnoreCase))
+                {
+                    cmdlet.WriteWarning("Utf7 encoding is obsolete");
+                }
+
+                return foundEncoding;
+            }
+
+            // error condition: unknown encoding value
+            string validEncodingValues = string.Join(", ", TabCompletionResults);
+            string msg = @"Encoding '{Encoding.Name} is not valid.";
+
+            ErrorRecord errorRecord = new ErrorRecord(
+                new ArgumentException("Encoding"),
+                "WriteToFileEncodingUnknown",
+                ErrorCategory.InvalidArgument,
+                null);
+
+            errorRecord.ErrorDetails = new ErrorDetails(msg);
+            cmdlet.ThrowTerminatingError(errorRecord);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Warn if the encoding has been designated as obsolete.
+        /// </summary>
+        /// <param name="cmdlet">A cmdlet instance which is used to emit the warning.</param>
+        /// <param name="encoding">The encoding to check for obsolescence.</param>
+        internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
+        {
+            // Check for UTF-7 by checking for code page 65000
+            // See: https://learn.microsoft.com/dotnet/core/compatibility/corefx#utf-7-code-paths-are-obsolete
+            if (encoding != null && encoding.CodePage == 65000)
+            {
+                cmdlet.WriteWarning("Utf7 encoding is obsolete.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// To make it easier to specify -Encoding parameter, we add an ArgumentTransformationAttribute here.
+    /// When the input data is of type string and is valid to be converted to System.Text.Encoding, we do
+    /// the conversion and return the converted value. Otherwise, we just return the input data.
+    /// </summary>
+    internal sealed class ArgumentToEncodingTransformationAttribute : ArgumentTransformationAttribute
+    {
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            switch (inputData)
+            {
+                case string stringName:
+                    if (EncodingConversion.encodingMap.TryGetValue(stringName, out Encoding foundEncoding))
+                    {
+                        return foundEncoding;
+                    }
+                    else
+                    {
+                        return Encoding.GetEncoding(stringName);
+                    }
+                case int intName:
+                    return Encoding.GetEncoding(intName);
+            }
+
+            return inputData;
+        }
+    }
+
+    /// <summary>
+    /// Provides the set of Encoding values for tab completion of an Encoding parameter.
+    /// </summary>
+    internal sealed class ArgumentEncodingCompletionsAttribute : ArgumentCompletionsAttribute
+    {
+        public ArgumentEncodingCompletionsAttribute() : base(
+            EncodingConversion.ANSI,
+            EncodingConversion.Ascii,
+            EncodingConversion.BigEndianUnicode,
+            EncodingConversion.BigEndianUtf32,
+            // EncodingConversion.OEM,
+            EncodingConversion.Unicode,
+            EncodingConversion.Utf7,
+            EncodingConversion.Utf8,
+            EncodingConversion.Utf8Bom,
+            EncodingConversion.Utf8NoBom,
+            EncodingConversion.Utf32
+        )
+        { }
+    }
+
+        /// <summary>
+    /// This attribute is used to specify an argument completions for a parameter of a cmdlet or function
+    /// based on string array.
+    /// <example>
+    ///     [Parameter()]
+    ///     [ArgumentCompletions("Option1","Option2","Option3")]
+    ///     public string Noun { get; set; }
+    /// </example>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class ArgumentCompletionsAttribute : Attribute
+    {
+        private readonly string[] _completions;
+
+        /// <summary>
+        /// Initializes a new instance of the ArgumentCompletionsAttribute class.
+        /// </summary>
+        /// <param name="completions">List of complete values.</param>
+        /// <exception cref="ArgumentNullException">For null arguments.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">For invalid arguments.</exception>
+        public ArgumentCompletionsAttribute(params string[] completions)
+        {
+            if (completions == null)
+            {
+                throw new ArgumentNullException(nameof(completions));
+            }
+
+            if (completions.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(completions), string.Join(", ", completions));
+            }
+
+            _completions = completions;
+        }
+
+        /// <summary>
+        /// The function returns completions for arguments.
+        /// </summary>
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            var wordToCompletePattern = WildcardPattern.Get(string.IsNullOrWhiteSpace(wordToComplete) ? "*" : wordToComplete + "*", WildcardOptions.IgnoreCase);
+
+            foreach (var str in _completions)
+            {
+                if (wordToCompletePattern.IsMatch(str))
+                {
+                    yield return new CompletionResult(str, str, CompletionResultType.ParameterValue, str);
+                }
+            }
+        }
+    }
+}

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.PlatyPS
         }
     }
 
-    public class MarkdownConverter
+    public partial class MarkdownConverter
     {
         /// <summary>
         /// Create a CommandHelp object from a markdown file.

--- a/src/MarkdownReader/ModuleFileMarkdownReader.cs
+++ b/src/MarkdownReader/ModuleFileMarkdownReader.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+using Microsoft.PowerShell.PlatyPS.Model;
+using YamlDotNet;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class ModuleCommandInfo : IEquatable<ModuleCommandInfo>
+    {
+        public string Name { get; set; }
+        public string Link { get; set; }
+        public string Description { get; set; }
+        public ModuleCommandInfo()
+        {
+            Name = string.Empty;
+            Link = string.Empty;
+            Description = string.Empty;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode() ^ Link.GetHashCode() ^ Description.GetHashCode();
+        }
+
+        public bool Equals(ModuleCommandInfo other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return (Name == other.Name && Link == other.Link && Description == other.Link);
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (other is ModuleCommandInfo info2)
+            {
+                return Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator == (ModuleCommandInfo info1, ModuleCommandInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator !=(ModuleCommandInfo info1, ModuleCommandInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return ! info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+    }
+
+    public class ModuleFileInfo : IEquatable<ModuleFileInfo>
+    {
+        public OrderedDictionary Metadata { get; set; }
+        public string Title { get; set; }
+        public string Module { get; set; }
+        public string Description { get; set; }
+        public string OptionalElement { get; set; }
+        public List<ModuleCommandInfo> Commands { get; set; }
+        [YamlIgnore]
+        public Diagnostics Diagnostics { get; set; }
+
+        public ModuleFileInfo()
+        {
+            Metadata = new();
+            Title = string.Empty;
+            Module = string.Empty;
+            Description = string.Empty;
+            OptionalElement = string.Empty;
+            Diagnostics = new();
+            Commands = new();
+        }
+
+        public override int GetHashCode()
+        {
+            return (Metadata, Title, Description).GetHashCode();
+        }
+
+        public bool Equals(ModuleFileInfo other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return (
+                string.Compare(Title, other.Title, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                string.Compare(Module, other.Module, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                string.Compare(Description, other.Description, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                Commands.SequenceEqual(other.Commands)
+                );
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (other is ModuleFileInfo info2)
+            {
+                return Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator == (ModuleFileInfo info1, ModuleFileInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator !=(ModuleFileInfo info1, ModuleFileInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return ! info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+    }
+
+    public partial class MarkdownConverter
+    {
+        public static ModuleFileInfo GetModuleFileInfoFromMarkdownFile(string path)
+        {
+            var md = ParsedMarkdownContent.ParseFile(path);
+            var moduleFileInfo = GetModuleFileInfoFromMarkdown(md);
+            moduleFileInfo.Diagnostics.FileName = path;
+            return moduleFileInfo;
+        }
+
+        internal static ModuleFileInfo GetModuleFileInfoFromMarkdown(ParsedMarkdownContent markdownContent)
+        {
+            /*
+            GetMetadataFromMarkdown
+            GetTitleFromMarkdown
+            GetDescription
+            GetModuleInfo - optional
+            GetModuleCommandInfo
+            */
+
+            ModuleFileInfo moduleFileInfo = new();
+            OrderedDictionary? metadata = GetMetadata(markdownContent.Ast);
+            if (metadata is null)
+            {
+                throw new InvalidDataException("null metadata");
+            }
+
+            moduleFileInfo.Metadata = metadata;
+            moduleFileInfo.Title = GetModuleFileTitleFromMarkdown(markdownContent.Ast);
+            moduleFileInfo.Description = GetModuleFileDescriptionFromMarkdown(markdownContent.Ast);
+            var optionalDescription = GetModuleFileOptionalDescriptionFromMarkdown(markdownContent.Ast);
+            if (optionalDescription is not null)
+            {
+                moduleFileInfo.OptionalElement = optionalDescription;
+            }
+
+            foreach(var moduleCommandInfo in GetModuleFileCommandsFromMarkdown(markdownContent.Ast))
+            {
+                moduleFileInfo.Commands.Add(moduleCommandInfo);
+            }
+
+            return moduleFileInfo;
+        }
+
+        internal static string GetModuleFileTitleFromMarkdown(MarkdownDocument ast)
+        {
+            return string.Empty;
+        }
+        internal static string GetModuleFileDescriptionFromMarkdown(MarkdownDocument ast)
+        {
+            return string.Empty;
+        }
+        internal static string GetModuleFileOptionalDescriptionFromMarkdown(MarkdownDocument ast)
+        {
+            return string.Empty;
+        }
+        internal static List<ModuleCommandInfo> GetModuleFileCommandsFromMarkdown(MarkdownDocument ast)
+        {
+            List<ModuleCommandInfo> list = new();
+            return list;
+        }
+    }
+}

--- a/src/MarkdownReader/ModuleFileMarkdownReader.cs
+++ b/src/MarkdownReader/ModuleFileMarkdownReader.cs
@@ -249,19 +249,31 @@ namespace Microsoft.PowerShell.PlatyPS
         {
             return string.Empty;
         }
+
+        /// <summary>
+        /// Read the module file looking for 
+        /// "### [name](markdownfile.md)
+        /// Description
+        /// </summary>
         internal static List<ModuleCommandInfo> GetModuleFileCommandsFromMarkdown(ParsedMarkdownContent md)
         {
             List<ModuleCommandInfo> list = new();
-            int index;
             md.CurrentIndex = md.FindHeader(3, "");
-            do {
+            int index = md.CurrentIndex;
+            while (!md.IsEnd())
+            {
                 var moduleCommandInfoLink = md.Take() as HeadingBlock;
                 var moduleCommandInfoDescription = md.Take() as ParagraphBlock;
-                var mfci = new ModuleCommandInfo();
-                mfci.Description = moduleCommandInfoDescription?ToString() ?? string.Empty;
-                list.Add(mfci);
-                index = md.FindHeader(3, "");
-            } while (index != -1);
+                if (moduleCommandInfoLink is not null && moduleCommandInfoDescription is not null)
+                {
+                    var mfci = new ModuleCommandInfo();
+                    mfci.Name = ((moduleCommandInfoLink?.Inline?.FirstChild as LinkInline)?.FirstChild as LiteralInline)?.ToString() ?? string.Empty;
+                    mfci.Link = (moduleCommandInfoLink?.Inline?.FirstChild as LinkInline)?.Url ?? string.Empty;
+                    mfci.Description = moduleCommandInfoDescription?.Inline?.FirstChild?.ToString() ?? string.Empty;
+                    list.Add(mfci);
+                }
+                // index = md.FindHeader(3, "");
+            }
 
             return list;
         }

--- a/src/MarkdownReader/V1ParameterMetadata.cs
+++ b/src/MarkdownReader/V1ParameterMetadata.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.PlatyPS
         {
             List<string> l = new();
 
-            var trueMatch = RequiredTruePattern.Match(Required);
+            var trueMatch = RequiredTruePattern.Match(Required ?? string.Empty);
             if (trueMatch.Success)
             {
                 string foundParameterSets = trueMatch.Groups[1].Value.Trim();

--- a/src/Microsoft.PowerShell.PlatyPS.psd1
+++ b/src/Microsoft.PowerShell.PlatyPS.psd1
@@ -42,7 +42,9 @@ CmdletsToExport = @(
     'Export-MamlCommandHelp',
     'Export-MarkdownCommandHelp'
     'Export-YamlCommandHelp'
-    'Test-MarkdownCommandHelp'
+    'Export-MamlCommandHelp',
+    'Test-MarkdownCommandHelp',
+    'ConvertTo-CommandHelp'
 )
 
 # Variables to export from this module

--- a/src/Microsoft.PowerShell.PlatyPS.psd1
+++ b/src/Microsoft.PowerShell.PlatyPS.psd1
@@ -44,7 +44,8 @@ CmdletsToExport = @(
     'Export-YamlCommandHelp'
     'Export-MamlCommandHelp',
     'Test-MarkdownCommandHelp',
-    'ConvertTo-CommandHelp'
+    'ConvertTo-CommandHelp',
+    'Compare-CommandHelp'
 )
 
 # Variables to export from this module

--- a/src/Model/Parameter.cs
+++ b/src/Model/Parameter.cs
@@ -17,11 +17,11 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public string Type { get; set;}
 
-        public string? Description { get; set;}
+        public string Description { get; set;}
 
-        public List<string>? ParameterValue { get; set;}
+        public List<string> ParameterValue { get; set;}
 
-        public string? DefaultValue { get; set;}
+        public string DefaultValue { get; set;}
 
         private List<string>? RequiredTrueParameterSets { get; set; }
         private List<string>? RequiredFalseParameterSets { get; set; }
@@ -31,25 +31,27 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public bool Globbing { get; set;}
 
-        public string? Aliases { get; set;}
+        public string Aliases { get; set;}
 
         public bool DontShow { get; set;}
 
-        public List<string>? AcceptedValues { get; private set; }
+        public List<string> AcceptedValues { get; private set; }
 
         public List<ParameterSet> ParameterSets { get; set; }
 
-        public string? HelpMessage { get; set; }
+        public string HelpMessage { get; set; }
 
         public Parameter(string name, string type)
         {
             Name = name;
             Type = type;
-            // Position = position;
             ParameterSets = new();
-            // var ps = new ParameterSet("All");
-            // ParameterSets.Add(ps);
-            // PipelineInput = new PipelineInputInfo(false);
+            ParameterValue = new();
+            Aliases = string.Empty;
+            AcceptedValues = new();
+            DefaultValue = string.Empty;
+            Description = string.Empty;
+            HelpMessage = string.Empty;
         }
 
         public void AddRequiredParameterSetsRange(bool required, IEnumerable<string> parameterSetNames)

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -526,14 +526,14 @@ namespace Microsoft.PowerShell.PlatyPS
 
             // Parameter parameter = new Parameter(name, type, position);
             Parameter parameter = new Parameter(name, type);
-            parameter.DefaultValue = defaultValue;
+            parameter.DefaultValue = defaultValue ?? string.Empty;
             parameter.AddAcceptedValueRange(acceptedValues);
             parameter.Description = description;
             // we will set the required attributed to all parameter sets since MAML doesn't have a way to disambiguate.
             parameter.ParameterSets.ForEach(x => x.IsRequired = required);
             parameter.VariableLength = variableLength;
             parameter.Globbing = globbing;
-            parameter.Aliases = aliases;
+            parameter.Aliases = aliases ?? string.Empty;
 
             // need to go the end of command:parameter
             if (reader.ReadState != ReadState.EndOfFile)

--- a/test/Pester/DiagnosticMessage.Tests.ps1
+++ b/test/Pester/DiagnosticMessage.Tests.ps1
@@ -20,11 +20,11 @@ Describe "Test Diagnostic Messages" {
     }
 
     It "Should populate the Messages property" {
-        $ch.Diagnostics.Messages.Count | Should -Be 33
+        $ch.Diagnostics.Messages.Count | Should -Be 37
     }
 
     It "Should have the correct number of Information entries" {
-        $ch.Diagnostics.Messages.Where({$_.Severity -eq "Information"}).Count | Should -Be 33
+        $ch.Diagnostics.Messages.Where({$_.Severity -eq "Information"}).Count | Should -Be 36
     }
 
     # this is 13 parameter names and the initial parameter finding which reports the number

--- a/test/Pester/assets/get-date.md
+++ b/test/Pester/assets/get-date.md
@@ -288,7 +288,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/test/Pester/assets/get-date.md
+++ b/test/Pester/assets/get-date.md
@@ -288,7 +288,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Implement the comparison tool which will provide a detailed comparison of 2 command help objects.
Implement a cmdlet which uses a commandinfo and returns a command help object (this is similar to new-markdownhelp but returns the command help object rather than creating a file.
add encoding attributes to the cmdlets which support `-Encoding`
fix up the diagnostics in the markdown reader.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
