### PR TITLE
Additional updates for OPS release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
      "files.exclude": {
         "out/**": true
     },
-    "dotnet.defaultSolution": "platyPS.sln"
+    "dotnet.defaultSolution": "platyPS.sln",
+    "sarif-viewer.connectToGithubCodeScanning": "off"
 }

--- a/build.ps1
+++ b/build.ps1
@@ -71,7 +71,13 @@ if ($PSCmdlet.ParameterSetName -eq 'Build') {
             $moduleFiles += $expectedPdbPath
         }
 
-        Copy-Item -Path "$expectedBuildPath/Markdig.Signed.dll", "$expectedBuildPath/YamlDotNet.dll" -Destination $depsFolder -Verbose
+        $neededAssemblies = "System.Buffers.dll", "System.Memory.dll",
+            "System.Numerics.Vectors.dll", "System.Runtime.CompilerServices.Unsafe.dll",
+            "Markdig.Signed.dll","YamlDotNet.dll"
+        
+        $neededAssemblyLocations = $neededAssemblies | ForEach-Object { "${expectedBuildPath}/${_}" }
+
+        Copy-Item -Path $neededAssemblyLocations -Destination $depsFolder -Verbose
         Copy-Item -Path $moduleFiles -Destination $moduleRoot -Verbose
     }
     finally {
@@ -93,6 +99,7 @@ elseif ($PSCmdlet.ParameterSetName -eq 'Test') {
 
     # we need to run on both pwsh and powershell
     $PSEXE = (Get-Process -Id $PID).MainModule.FileName
+    Write-Verbose -Verbose -Message ("Running tests on PowerShell Version: " + $PSVersionTable.PSVersion)
     & $PSEXE -noprofile -c "$sb"
 
     $results = [xml](Get-Content $PesterLogPath)

--- a/build.ps1
+++ b/build.ps1
@@ -91,7 +91,9 @@ elseif ($PSCmdlet.ParameterSetName -eq 'Test') {
 
     write-verbose -verbose -message "$sb"
 
-    pwsh -noprofile -c "$sb"
+    # we need to run on both pwsh and powershell
+    $PSEXE = (Get-Process -Id $PID).MainModule.FileName
+    & $PSEXE -noprofile -c "$sb"
 
     $results = [xml](Get-Content $PesterLogPath)
     if ($results."test-results".failures -ne 0) {

--- a/src/Command/CompareCommandHelpCommand.cs
+++ b/src/Command/CompareCommandHelpCommand.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Management.Automation;
 using Microsoft.PowerShell.PlatyPS.Model;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
@@ -31,7 +32,7 @@ namespace Microsoft.PowerShell.PlatyPS
         public CommandHelp? Difference { get; set; }
 
         [Parameter]
-        public string[] PropertyNamesToExclude { get; set; } = new string[0];
+        public string[] PropertyNamesToExclude { get; set; } = new string[] { "Diagnostics", "ParameterNames" };
 
         List<String> DiagnosticMessages = new();
 

--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.PlatyPS
         public SwitchParameter Force { get; set; }
 
         [Parameter(Mandatory = true, Position = 1)]
-        public string OutputDirectory { get; set; } = string.Empty;
+        public string OutputFolder { get; set; } = string.Empty;
 
         private List<CommandHelp> _commandHelps = new List<CommandHelp>();
         #endregion
@@ -57,9 +57,9 @@ namespace Microsoft.PowerShell.PlatyPS
 
         protected override void EndProcessing()
         {
-            if (ShouldProcess(OutputDirectory))
+            if (ShouldProcess(OutputFolder))
             {
-                outputDirectory = PathUtils.CreateOrGetOutputDirectory(this, OutputDirectory, Force);
+                outputDirectory = PathUtils.CreateOrGetOutputDirectory(this, OutputFolder, Force);
             }
             else
             {
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
             if (outputDirectory is null)
             {
-                ThrowTerminatingError(new ErrorRecord(new InvalidOperationException("file is null"), "fileInfo is null", ErrorCategory.InvalidOperation, OutputDirectory));
+                ThrowTerminatingError(new ErrorRecord(new InvalidOperationException("file is null"), "fileInfo is null", ErrorCategory.InvalidOperation, OutputFolder));
                 throw new InvalidOperationException("fileInfo is null"); // not reached
             }
 

--- a/src/Command/ExportMarkdownModuleFileCommand.cs
+++ b/src/Command/ExportMarkdownModuleFileCommand.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.PlatyPS
                             }
                             else
                             {
-                                moduleFile.Metadata[key] = (string)kv.Value;
+                                moduleFile.Metadata[key] = kv.Value;
                             }
                         }
                     }

--- a/src/Command/ExportYamlModuleFileCommand.cs
+++ b/src/Command/ExportYamlModuleFileCommand.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
 using System.Management.Automation;
 using Microsoft.PowerShell.PlatyPS.Model;
@@ -59,7 +57,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
             foreach (ModuleFileInfo moduleFile in ModuleFile)
             {
-                if (moduleFile.Metadata.ContainsKey("Module Name"))
+                if (moduleFile.Metadata.Contains("Module Name"))
                 {
                     moduleName = moduleFile.Metadata["Module Name"].ToString();
                 }

--- a/src/Command/Measure-PlatyPSMarkdown.cs
+++ b/src/Command/Measure-PlatyPSMarkdown.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using Microsoft.PowerShell.PlatyPS.Model;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    /// <summary>
+    /// Cmdlet to determine the type of markdown file.
+    /// </summary>
+    [Cmdlet(VerbsDiagnostic.Measure, "PlatyPSMarkdown", DefaultParameterSetName = "Path", HelpUri = "")]
+    [OutputType(typeof(CommandHelp))]
+    public sealed class MeasurePlatyPSMarkdown : PSCmdlet
+    {
+#region cmdlet parameters
+
+        [Parameter(Mandatory=true, Position=0, ValueFromPipeline=true, ParameterSetName= "Path")]
+        [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
+        public string[] Path { get; set; } = Array.Empty<string>();
+
+        [Parameter(Mandatory=true, ValueFromPipeline=true, ParameterSetName= "LiteralPath")]
+        [ValidateNotNullOrEmpty]
+        public string[] LiteralPath { get; set; } = Array.Empty<string>();
+
+#endregion
+
+        protected override void ProcessRecord()
+        {
+            List<string> resolvedPaths;
+            try
+            {
+                // This is a list because the resolution process can result in multiple paths (in the case of non-literal path).
+                resolvedPaths = PathUtils.ResolvePath(this, ParameterSetName == "LiteralPath" ? LiteralPath : Path, ParameterSetName == "LiteralPath" ? true : false);
+            }
+            catch (Exception e)
+            {
+                WriteError(new ErrorRecord(e, "Could not resolve Path", ErrorCategory.InvalidOperation, ParameterSetName == "LiteralPath" ? LiteralPath : Path));
+                return;
+            }
+
+            // These should be resolved paths, whether -LiteralPath was used or not.
+            foreach (string path in resolvedPaths)
+            {
+                try
+                {
+                    var markdownInfo = MarkdownProbe.Identify(path);
+                    WriteObject(markdownInfo);
+                }
+                catch (Exception e)
+                {
+                    WriteError(new ErrorRecord(e, "FailedToImportMarkdown", ErrorCategory.InvalidOperation, path));
+                }
+            }
+        }
+    }
+}

--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -157,7 +157,21 @@ namespace Microsoft.PowerShell.PlatyPS
                         var pr = new ProgressRecord(0, "Transforming cmdlet", $"{cmd.ModuleName}\\{cmd.Name}");
                         pr.PercentComplete = (int)Math.Round(((double)currentOffset++ / (double)(cmdCollection.Count)) * 100);
                         WriteProgress(pr);
-                        cmdHelpObjs.Add(new TransformCommand(transformSettings).Transform(cmd));
+                        var transformedCommand = new TransformCommand(transformSettings).Transform(cmd);
+                        if (transformedCommand is not null && transformedCommand.Metadata is not null && ! string.IsNullOrEmpty(HelpInfoUri))
+                        {
+                            transformedCommand.Metadata["HelpInfoUri"] = HelpInfoUri;
+                        }
+
+                        if (transformedCommand is not null && transformedCommand.Metadata is not null && ! string.IsNullOrEmpty(HelpUri))
+                        {
+                            transformedCommand.Metadata["HelpUri"] = HelpUri;
+                        }
+
+                        if (transformedCommand is not null)
+                        {
+                            cmdHelpObjs.Add(transformedCommand);
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.PlatyPS
                         ExcludeDontShow = false,
                         FwLink = HelpInfoUri,
                         HelpVersion = HelpVersion.ToString(),
-                        Locale = Locale is null ? CultureInfo.CurrentUICulture : new CultureInfo(Locale),
+                        Locale = Locale is null ? CultureInfo.CurrentCulture : new CultureInfo(Locale),
                         ModuleName = cmd.ModuleName is null ? string.Empty : cmd.ModuleName,
                         ModuleGuid = cmd.Module?.Guid is null ? Guid.Empty : cmd.Module.Guid,
                         OnlineVersionUrl = HelpUri,

--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
-
+using Microsoft.PowerShell.Commands;
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
@@ -118,6 +118,10 @@ namespace Microsoft.PowerShell.PlatyPS
 
             List<CommandHelp> cmdHelpObjs = new List<CommandHelp>();
             Dictionary<string, PSModuleInfo> moduleTable = new();
+            foreach (var providedModule in Module)
+            {
+                moduleTable[providedModule.Name] = providedModule;
+            }
 
             if (cmdCollection.Count > 0)
             {
@@ -126,7 +130,6 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     if (cmd.Module is not null && ! string.IsNullOrEmpty(cmd.Module.Name) && ! moduleTable.ContainsKey(cmd.Module.Name))
                     {
-                        moduleTable[cmd.Module.Name] = cmd.Module;
                         if (HelpInfoUri == string.Empty && ! string.IsNullOrEmpty(cmd.Module.HelpInfoUri))
                         {
                             HelpInfoUri = cmd.Module.HelpInfoUri;

--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -158,20 +158,24 @@ namespace Microsoft.PowerShell.PlatyPS
                         pr.PercentComplete = (int)Math.Round(((double)currentOffset++ / (double)(cmdCollection.Count)) * 100);
                         WriteProgress(pr);
                         var transformedCommand = new TransformCommand(transformSettings).Transform(cmd);
-                        if (transformedCommand is not null && transformedCommand.Metadata is not null && ! string.IsNullOrEmpty(HelpInfoUri))
+
+                        if (transformedCommand is null)
                         {
-                            transformedCommand.Metadata["HelpInfoUri"] = HelpInfoUri;
+                            throw new InvalidDataException("Command transformation failed");
                         }
 
-                        if (transformedCommand is not null && transformedCommand.Metadata is not null && ! string.IsNullOrEmpty(HelpUri))
+                        if (transformedCommand.Metadata is null)
+                        {
+                            transformedCommand.Metadata = new();
+                        }
+
+                        // update the HelpUri if the parameter was used.
+                        if (! string.IsNullOrEmpty(HelpUri))
                         {
                             transformedCommand.Metadata["HelpUri"] = HelpUri;
                         }
 
-                        if (transformedCommand is not null)
-                        {
-                            cmdHelpObjs.Add(transformedCommand);
-                        }
+                        cmdHelpObjs.Add(transformedCommand);
                     }
                     catch (Exception e)
                     {
@@ -214,6 +218,11 @@ namespace Microsoft.PowerShell.PlatyPS
                     {
                         moduleFileInfo.Metadata["Module Guid"] = group.First<CommandHelp>().ModuleGuid.ToString();
                     }
+                }
+
+                if (! string.IsNullOrEmpty(HelpInfoUri))
+                {
+                    moduleFileInfo.Metadata["HelpInfoUri"] = HelpInfoUri;
                 }
 
                 List<ModuleCommandInfo> mciList = new();

--- a/src/Command/NewMarkdownModuleFileCommand.cs
+++ b/src/Command/NewMarkdownModuleFileCommand.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+using Microsoft.PowerShell.PlatyPS.Model;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    /// <summary>
+    /// Cmdlet to generate the markdown help for commands, all commands in a module.
+    /// </summary>
+    [Cmdlet(VerbsCommon.New, "MarkdownModuleFile", HelpUri = "")]
+    [OutputType(typeof(FileInfo[]))]
+    public sealed class NewMarkdownModuleFileCommand : PSCmdlet
+    {
+        #region cmdlet parameters
+
+        [Parameter(ValueFromPipeline = true)]
+        public CommandHelp[] CommandHelp { get; set; } = Array.Empty<CommandHelp>();
+
+        [Parameter()]
+        [ArgumentToEncodingTransformation]
+        [ArgumentCompleter(typeof(EncodingCompleter))]
+        public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        [Parameter()]
+        public SwitchParameter Force { get; set; }
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string HelpUri { get; set; } = string.Empty;
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string HelpInfoUri { get; set; } = string.Empty;
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public Version HelpVersion { get; set; } = new Version(1, 0, 0, 0);
+
+        [Parameter]
+        public string? Locale { get; set; }
+
+        [Parameter()]
+        public Hashtable? Metadata { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public string OutputFolder { get; set; } = Environment.CurrentDirectory;
+
+        #endregion
+
+        private string outputFolderBase = string.Empty;
+        private List<CommandHelp> allCommandHelp = new();
+
+        protected override void BeginProcessing()
+        {
+            outputFolderBase = this.SessionState.Path.GetUnresolvedProviderPathFromPSPath(OutputFolder);
+            if (File.Exists(outputFolderBase))
+            {
+                var exception = new InvalidOperationException(string.Format(Microsoft_PowerShell_PlatyPS_Resources.PathIsNotFolder, outputFolderBase));
+                ErrorRecord err = new ErrorRecord(exception, "PathIsNotFolder", ErrorCategory.InvalidOperation, outputFolderBase);
+                ThrowTerminatingError(err);
+            }
+
+            if (!Directory.Exists(outputFolderBase))
+            {
+                Directory.CreateDirectory(outputFolderBase);
+            }
+        }
+
+        // Gather up all of the commands from modules or commands
+        protected override void ProcessRecord()
+        {
+            allCommandHelp.AddRange(CommandHelp);
+        }
+
+        // now that the commands are all gathered, transform them into command help objects
+        protected override void EndProcessing()
+        {
+            if (!ShouldProcess(OutputFolder))
+            {
+                return;
+            }
+
+            // Group the commands by Module Name
+            var commandGroup = allCommandHelp.GroupBy(c => c.ModuleName);
+            foreach(var group in commandGroup)
+            {
+                if (group.Count() < 1)
+                {
+                    continue;
+                }
+
+                string moduleName = group.First<CommandHelp>().ModuleName;
+                string moduleFolder = Path.Combine(outputFolderBase, moduleName);
+                CultureInfo locale = group.First<CommandHelp>().Locale;
+                ModuleFileInfo moduleFileInfo;
+
+                var psModuleInfo = GetModuleInfo(moduleName);
+                // Prefer psModuleInfo to create the moduleFileInfo.
+                if (psModuleInfo is not null)
+                {
+                    moduleFileInfo = new ModuleFileInfo(psModuleInfo, locale);
+                    if (string.IsNullOrEmpty(moduleFileInfo.Description.Trim()))
+                    {
+                        moduleFileInfo.Description = Constants.FillInDescription;
+                    }
+                }
+                else
+                {
+                    moduleFileInfo = new($"{moduleName} Module", moduleName, group.First<CommandHelp>().Locale)
+                    {
+                        Description = "{{ Add module description here. }}"
+                    };
+
+                    if (group.First<CommandHelp>().ModuleGuid is not null)
+                    {
+                        moduleFileInfo.Metadata["Module Guid"] = group.First<CommandHelp>().ModuleGuid.ToString();
+                    }
+                }
+
+                // Now add the commands to the command group
+                ModuleCommandGroup mcg = new(moduleName);
+                foreach(var cmdHelp in group)
+                {
+                    var moduleCommandInfo = new ModuleCommandInfo()
+                    {
+                        Name = cmdHelp.Title,
+                        Link = $"{cmdHelp.Title}.md",
+                        Description = Constants.FillInDescription,
+                    };
+
+                    mcg.Commands.Add(moduleCommandInfo);
+                }
+                moduleFileInfo.CommandGroups.Add(mcg);
+
+                string moduleFilePath = Path.Combine(moduleFolder, $"{moduleName}.md");
+                var modulePageSettings = new WriterSettings(Encoding, moduleFilePath);
+                using var modulePageWriter = new ModulePageWriter(modulePageSettings);
+                if (new FileInfo(moduleFilePath).Exists && ! Force)
+                {
+                    WriteWarning(string.Format(Constants.skippingMessageFmt, moduleFilePath));
+                }
+                else
+                {
+                    // Update the help version in the module metadata
+                    moduleFileInfo.Metadata["Help Version"] = HelpVersion.ToString();
+                    WriteObject(this.InvokeProvider.Item.Get(modulePageWriter.Write(moduleFileInfo).FullName));
+                }
+            }
+        }
+
+        PSModuleInfo? GetModuleInfo(string moduleName)
+        {
+            using (var powershell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace))
+            {
+                // try to just retrieve the module
+                var result = powershell.AddCommand("Get-Module").AddParameter("Name", moduleName).Invoke<PSObject>();
+                if ((result is null || powershell.HadErrors) || (result is not null && result.Count == 0))
+                {
+                    // The module is not loaded, so try to load it.
+                    powershell.Commands.Clear();
+                    result = powershell.AddCommand("Import-Module").AddParameter("Name", moduleName).AddParameter("PassThru", true).Invoke<PSObject>();
+                }
+
+                if (result is not null && result.Count == 1)
+                {
+                    if (result[0].BaseObject is PSModuleInfo psModuleInfo)
+                    {
+                        return psModuleInfo;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Command/Update-MarkdownCommandHelp.cs
+++ b/src/Command/Update-MarkdownCommandHelp.cs
@@ -246,17 +246,20 @@ namespace Microsoft.PowerShell.PlatyPS
             // dynamic parameters are currently unhandled
             foreach(var param in fromCommand)
             {
-                var helpParam = fromHelp.Where(x => string.Compare(x.Name, param.Name) == 0).First<Parameter>();
-                if (helpParam is null)
+                var helpParams = fromHelp.Where(x => string.Compare(x.Name, param.Name) == 0);
+                if (helpParams.Count() == 0)
                 {
                     diagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Merge, $"updating {param.Name}, not found in help.", DiagnosticSeverity.Information, "TryGetMergedParameters", -1));
                     var newParameter = new Parameter(param)
                     {
-                        Description = "**FILL IN DESCRIPTION**"
+                        Description = Constants.FillInDescription,
                     };
                     mergedParameters.Add(param);
+                    continue;
                 }
-                else if (helpParam == param)
+
+                var helpParam = helpParams.First<Parameter>();
+                if (helpParam == param)
                 {
                     diagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Merge, $"No change to {param.Name}.", DiagnosticSeverity.Information, "TryGetMergedParameters", -1));
                     mergedParameters.Add(helpParam);

--- a/src/Command/UpdateMarkdownModuleFile.cs
+++ b/src/Command/UpdateMarkdownModuleFile.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+using Microsoft.PowerShell.PlatyPS.Model;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    /// <summary>
+    /// Cmdlet to update the markdown module file.
+    /// </summary>
+    [Cmdlet(VerbsData.Update, "MarkdownModuleFile", HelpUri = "")]
+    [OutputType(typeof(FileInfo[]))]
+    public sealed class UpdateMarkdownModuleFileCommand : PSCmdlet
+    {
+        #region cmdlet parameters
+
+        [Parameter(Mandatory = true, Position = 0)]
+        public ModuleFileInfo ModuleFile { get; set; } = new();
+
+        [Parameter(ValueFromPipeline = true, Mandatory = true, Position = 1)]
+        public CommandHelp[] CommandHelp { get; set; } = Array.Empty<CommandHelp>();
+
+        [Parameter()]
+        [ArgumentToEncodingTransformation]
+        [ArgumentCompleter(typeof(EncodingCompleter))]
+        public System.Text.Encoding Encoding { get; set; } = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        [Parameter()]
+        public SwitchParameter Force { get; set; }
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string HelpUri { get; set; } = string.Empty;
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string HelpInfoUri { get; set; } = string.Empty;
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public Version HelpVersion { get; set; } = new Version(1, 0, 0, 0);
+
+        [Parameter]
+        public string? Locale { get; set; }
+
+        [Parameter()]
+        public Hashtable? Metadata { get; set; }
+
+        [Parameter(Mandatory = true)]
+        public string OutputFolder { get; set; } = Environment.CurrentDirectory;
+
+        #endregion
+
+        private string outputFolderBase = string.Empty;
+        private List<CommandHelp> allCommandHelp = new();
+
+        ModuleFileInfo? newModuleFile;
+        protected override void BeginProcessing()
+        {
+            outputFolderBase = this.SessionState.Path.GetUnresolvedProviderPathFromPSPath(OutputFolder);
+            if (File.Exists(outputFolderBase))
+            {
+                var exception = new InvalidOperationException(string.Format(Microsoft_PowerShell_PlatyPS_Resources.PathIsNotFolder, outputFolderBase));
+                ErrorRecord err = new ErrorRecord(exception, "PathIsNotFolder", ErrorCategory.InvalidOperation, outputFolderBase);
+                ThrowTerminatingError(err);
+            }
+
+            if (!Directory.Exists(outputFolderBase))
+            {
+                Directory.CreateDirectory(outputFolderBase);
+            }
+        }
+
+        // Gather up all of the commands from modules or commands
+        protected override void ProcessRecord()
+        {
+            allCommandHelp.AddRange(CommandHelp);
+        }
+
+        // now that the commands are all gathered, transform them into command help objects
+        protected override void EndProcessing()
+        {
+            if (!ShouldProcess(OutputFolder))
+            {
+                return;
+            }
+
+            // Check to be sure that all of the command help objects are in all in the same module.
+            var wrongModules = allCommandHelp.Where<CommandHelp>(ch => string.Compare(ch.ModuleName, ModuleFile.Module) != 0);
+            if (wrongModules.Count() != 0)
+            {
+                ThrowTerminatingError(
+                    new ErrorRecord(
+                        new InvalidOperationException("All help must be in a single module"),
+                        "UpdateMarkdownModuleFile,InvalidOperation",
+                        ErrorCategory.InvalidOperation,
+                        wrongModules.ToArray()
+                    )
+                );
+            }
+
+
+            // work on a copy of the original
+            newModuleFile = new ModuleFileInfo(ModuleFile);
+            // Remove all of the command groups, we only use what was provided by the user.
+            newModuleFile.CommandGroups.Clear();
+            var moduleName = newModuleFile.Module;
+
+            if (Metadata?.Keys.Count > 0)
+            {
+                MetadataUtils.MergeNewModulefileMetadata(Metadata, newModuleFile);
+            }
+
+            string moduleFolder = Path.Combine(outputFolderBase, moduleName);
+            CultureInfo locale = string.IsNullOrEmpty(Locale) ? newModuleFile.Locale : CultureInfo.GetCultureInfo(Locale);
+
+            // Group the commands by Module Name
+            var commandGroup = allCommandHelp.OrderBy(help => help.Title).GroupBy(help => help.ModuleName);
+            foreach(var group in commandGroup)
+            {
+                ModuleCommandGroup mcg = new($"{moduleName} Cmdlets");
+                if (group.Count() < 1)
+                {
+                    newModuleFile.CommandGroups.Add(mcg);
+                    continue;
+                }
+
+                // Now add the commands to the command group
+                // and then add the command group to the module file.
+                foreach(var cmdHelp in group)
+                {
+                    var moduleCommandInfo = new ModuleCommandInfo()
+                    {
+                        Name = cmdHelp.Title,
+                        Link = $"{cmdHelp.Title}.md", // JWT - should this be a property of the command help object?
+                        Description = cmdHelp.Synopsis,
+                    };
+
+                    mcg.Commands.Add(moduleCommandInfo);
+                }
+
+                newModuleFile.CommandGroups.Add(mcg);
+
+                // ready the module file writer
+                string moduleFilePath = Path.Combine(moduleFolder, $"{moduleName}.md");
+                var modulePageSettings = new WriterSettings(Encoding, moduleFilePath);
+                using var modulePageWriter = new ModulePageWriter(modulePageSettings);
+                if (new FileInfo(moduleFilePath).Exists && ! Force)
+                {
+                    WriteWarning(string.Format(Constants.skippingMessageFmt, moduleFilePath));
+                }
+                else
+                {
+                    // Update the help version in the module metadata
+                    WriteObject(this.InvokeProvider.Item.Get(modulePageWriter.Write(newModuleFile).FullName));
+                }
+            }
+        }
+
+        PSModuleInfo? GetModuleInfo(string moduleName)
+        {
+            using (var powershell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace))
+            {
+                // try to just retrieve the module
+                var result = powershell.AddCommand("Get-Module").AddParameter("Name", moduleName).Invoke<PSObject>();
+                if ((result is null || powershell.HadErrors) || (result is not null && result.Count == 0))
+                {
+                    // The module is not loaded, so try to load it.
+                    powershell.Commands.Clear();
+                    result = powershell.AddCommand("Import-Module").AddParameter("Name", moduleName).AddParameter("PassThru", true).Invoke<PSObject>();
+                }
+
+                if (result is not null && result.Count == 1)
+                {
+                    if (result[0].BaseObject is PSModuleInfo psModuleInfo)
+                    {
+                        return psModuleInfo;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Common/EncodingUtils.cs
+++ b/src/Common/EncodingUtils.cs
@@ -30,7 +30,8 @@ namespace Microsoft.PowerShell.PlatyPS
         internal const string Utf32 = "utf32";
 
         internal static readonly string[] TabCompletionResults = {
-                ANSI, Ascii, BigEndianUnicode, BigEndianUtf32, /* OEM, */ Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
+                // Remove OEM as completion result.
+                ANSI, Ascii, BigEndianUnicode, BigEndianUtf32, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
             };
 
         internal static readonly Dictionary<string, Encoding> encodingMap = new(StringComparer.OrdinalIgnoreCase)

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -250,6 +250,10 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 od[Constants.SchemaVersionKey] = Constants.SchemaVersion;
             }
+            else if (!od.ContainsKey(Constants.SchemaVersionKey))
+            {
+                od[Constants.SchemaVersionKey] = Constants.SchemaVersion;
+            }
 
             // Be sure that document type is correctly present.
             if (! od.ContainsKey("document type"))

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -111,9 +111,9 @@ namespace Microsoft.PowerShell.PlatyPS
             return metadata;
         }
 
-        public static SortedDictionary<string, string> GetModuleFileBaseMetadata(PSModuleInfo moduleInfo, CultureInfo? locale)
+        public static OrderedDictionary GetModuleFileBaseMetadata(PSModuleInfo moduleInfo, CultureInfo? locale)
         {
-            SortedDictionary<string, string> metadata = new()
+            OrderedDictionary metadata = new()
             {
                 { "document type", "module" },
                 { "HelpInfoUri", moduleInfo.HelpInfoUri }, // was Download Help Link
@@ -133,9 +133,9 @@ namespace Microsoft.PowerShell.PlatyPS
         /// </summary>
         /// <param name="help">A ModuleFileInfo object to use.</param>
         /// <returns>A Dictionary with the base metadata for a command help file.</returns>
-        public static SortedDictionary<string, string> GetModuleFileBaseMetadata(string title, string name, CultureInfo? locale)
+        public static OrderedDictionary GetModuleFileBaseMetadata(string title, string name, CultureInfo? locale)
         {
-            SortedDictionary<string, string> metadata = new()
+            OrderedDictionary metadata = new()
             {
                 { "document type", "module" },
                 { "HelpInfoUri", string.Empty }, // was Download Help Link
@@ -162,6 +162,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
         private static Hashtable keysToMigrate = new Hashtable()
         {
+            { "Download Help Link", "HelpInfoUri" },
             { "online version", "HelpUri" },
             { "schema", "PlatyPS schema version" },
         };
@@ -220,43 +221,43 @@ namespace Microsoft.PowerShell.PlatyPS
         /// This ensures that we migrate the obsolete keys in metadata to the new versions.
         /// </summary>
         /// <param name="metadata"></param>
-        public static SortedDictionary<string, string> FixUpModuleFileMetadata(OrderedDictionary metadata)
+        public static OrderedDictionary FixUpModuleFileMetadata(OrderedDictionary metadata)
         {
-            SortedDictionary<string, string> od = new();
+            OrderedDictionary od = new();
             foreach (var key in metadata.Keys)
             {
                 if (keysToMigrate.ContainsKey(key))
                 {
                     // Create the new key and ignore the old key
-                    od[keysToMigrate[key].ToString()] = metadata[key] is null ? string.Empty : metadata[key].ToString();
+                    od[keysToMigrate[key].ToString()] = metadata[key] is null ? string.Empty : metadata[key];
                 }
                 else
                 {
-                    od[key.ToString()] = metadata[key] is null ? string.Empty : metadata[key].ToString();
+                    od[key.ToString()] = metadata[key] is null ? string.Empty : metadata[key];
                 }
             }
 
             // Remove the older keys that should have been migrated.
             foreach (var key in keysToMigrate.Keys)
             {
-                if (od.ContainsKey(key.ToString()))
+                if (od.Contains(key.ToString()))
                 {
                     od.Remove(key.ToString());
                 }
             }
 
             // Fix the version for the new schema version
-            if (od.ContainsKey(Constants.SchemaVersionKey) && string.Compare(od[Constants.SchemaVersionKey].ToString(), "2.0.0") == 0)
+            if (od.Contains(Constants.SchemaVersionKey) && string.Compare(od[Constants.SchemaVersionKey].ToString(), "2.0.0") == 0)
             {
                 od[Constants.SchemaVersionKey] = Constants.SchemaVersion;
             }
-            else if (!od.ContainsKey(Constants.SchemaVersionKey))
+            else if (!od.Contains(Constants.SchemaVersionKey))
             {
                 od[Constants.SchemaVersionKey] = Constants.SchemaVersion;
             }
 
             // Be sure that document type is correctly present.
-            if (! od.ContainsKey("document type"))
+            if (! od.Contains("document type"))
             {
                 od["document type"] = "module";
             }
@@ -264,9 +265,9 @@ namespace Microsoft.PowerShell.PlatyPS
             return od;
         }
 
-        internal static bool TryGetGuidFromMetadata(SortedDictionary<string, string> metadata, string term, out Guid guid)
+        internal static bool TryGetGuidFromMetadata(OrderedDictionary metadata, string term, out Guid guid)
         {
-            if (metadata.ContainsKey(term))
+            if (metadata.Contains(term))
             {
                 if (metadata[term] is not null && Guid.TryParse(metadata[term].ToString(), out var result))
                 {
@@ -279,9 +280,9 @@ namespace Microsoft.PowerShell.PlatyPS
             return false;
         }
 
-        internal static bool TryGetStringFromMetadata(SortedDictionary<string, string> metadata, string term, out string str)
+        internal static bool TryGetStringFromMetadata(OrderedDictionary metadata, string term, out string str)
         {
-            if (metadata.ContainsKey(term))
+            if (metadata.Contains(term))
             {
                 if (metadata[term] is not null)
                 {

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 { "document type", "cmdlet" },
                 { "title", help.Title },
                 { "Module Name", help.ModuleName },
-                { "Locale", help.Locale.Name },
+                { "Locale", string.IsNullOrEmpty(help.Locale.Name) ? "en-US" : help.Locale.Name },
                 { "PlatyPS schema version", "2024-05-01" }, // was schema
                 { "HelpUri", help.OnlineVersionUrl }, // was online version
                 { "ms.date", DateTime.Now.ToString("MM/dd/yyyy") },
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 { "document type", "module" },
                 { "HelpInfoUri", "xxx" }, // was Download Help Link
-                { "Locale", moduleFileInfo.Locale.Name },
+                { "Locale", string.IsNullOrEmpty(moduleFileInfo.Locale.Name) ? "en-US" : moduleFileInfo.Locale.Name },
                 { "PlatyPS schema version", "2024-05-01" },
                 { "ms.date", DateTime.Now.ToString("MM/dd/yyyy") },
                 { "title", moduleFileInfo.Title },
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 { "document type", "module" },
                 { "HelpInfoUri", moduleInfo.HelpInfoUri }, // was Download Help Link
-                { "Locale", locale?.Name ?? "en-us" },
+                { "Locale", locale?.Name ?? "en-US" },
                 { "PlatyPS schema version", "2024-05-01" },
                 { "ms.date", DateTime.Now.ToString("MM/dd/yyyy") },
                 { "title", $"{moduleInfo.Name} Module" },

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -228,11 +228,11 @@ namespace Microsoft.PowerShell.PlatyPS
                 if (keysToMigrate.ContainsKey(key))
                 {
                     // Create the new key and ignore the old key
-                    od[keysToMigrate[key].ToString()] = metadata[key].ToString();
+                    od[keysToMigrate[key].ToString()] = metadata[key] is null ? string.Empty : metadata[key].ToString();
                 }
                 else
                 {
-                    od[key.ToString()] = metadata[key].ToString();
+                    od[key.ToString()] = metadata[key] is null ? string.Empty : metadata[key].ToString();
                 }
             }
 

--- a/src/Common/TransformationAttribute.cs
+++ b/src/Common/TransformationAttribute.cs
@@ -18,22 +18,35 @@ namespace Microsoft.PowerShell.PlatyPS
 
         internal object AttemptParameterConvert(EngineIntrinsics engineIntrinsics, string name, Type type)
         {
-            if (type == typeof(PSModuleInfo))
+            using (var powershell = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace))
             {
-                var module = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Get-Module").AddParameter("Name", name).Invoke<PSModuleInfo>().First();
-                if (module is not null)
+                if (type == typeof(PSModuleInfo))
                 {
-                    return module;
+                    var results = powershell.AddCommand("Get-Module").AddParameter("Name", name).Invoke<PSModuleInfo>();
+                    powershell.Commands.Clear();
+                    if (results.Count == 0)
+                    {
+                        results = powershell.AddCommand("Import-Module").AddParameter("Name", name).AddParameter("PassThru").Invoke<PSModuleInfo>();
+                        powershell.Commands.Clear();
+                    }
+
+                    if (results.Count == 1 && results[0] is PSModuleInfo module)
+                    {
+                        return module;
+                    }
+                }
+
+                if (type == typeof(CommandInfo))
+                {
+                    var cmd = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Get-Command").AddParameter("Name", name).Invoke<CommandInfo>().First();
+                    if (cmd is not null)
+                    {
+                        return cmd;
+                    }
                 }
             }
-            if (type == typeof(CommandInfo))
-            {
-                var cmd = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Get-Command").AddParameter("Name", name).Invoke<CommandInfo>().First();
-                if (cmd is not null)
-                {
-                    return cmd;
-                }
-            }
+            
+            // We could not convert it, just return it for parameter binding.
             return name;
         }
 

--- a/src/Common/TransformationAttribute.cs
+++ b/src/Common/TransformationAttribute.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     }
                 }
             }
-            
+
             // We could not convert it, just return it for parameter binding.
             return name;
         }

--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -126,7 +126,8 @@ namespace Microsoft.PowerShell.PlatyPS
 
         /// <summary>
         /// Serialize the metadata for exporting.
-        /// We convert the ordered dictionary into a sorted dictionary.
+        /// We convert the ordered dictionary into a sorted dictionary
+        /// because we want the keys to be more easily findable.
         /// </summary>
         /// <param name="metadata">An ordered dictionary representing the metadata</param>
         /// <returns>System.String</returns>
@@ -154,12 +155,12 @@ namespace Microsoft.PowerShell.PlatyPS
                 var output = camelCaseDeserializer?.Deserialize<ModuleFileInfo>(File.ReadAllText(path));
                 if (output is not null)
                 {
-                    if (output.Metadata.ContainsKey("Module Name"))
+                    if (output.Metadata.Contains("Module Name"))
                     {
                         output.Module = output.Metadata["Module Name"].ToString();
                     }
 
-                    if (output.Metadata.ContainsKey("Module Guid"))
+                    if (output.Metadata.Contains("Module Guid"))
                     {
                         if (Guid.TryParse(output.Metadata["Module Guid"].ToString(), out Guid mGuid))
                         {
@@ -681,7 +682,7 @@ namespace Microsoft.PowerShell.PlatyPS
             OrderedDictionary od = new();
             foreach (var k in metadata.Keys)
             {
-                od[k.ToString()] = metadata[k].ToString();
+                od[k.ToString()] = metadata[k];
             }
 
             return od;

--- a/src/Diagnostics/DiagnosticMessage.cs
+++ b/src/Diagnostics/DiagnosticMessage.cs
@@ -69,5 +69,16 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             Identifier = identifier;
             Line = line;
         }
+
+        public override string ToString()
+        {
+            var message = string.IsNullOrEmpty(Identifier) ? Message[0] : Identifier;
+            if (message.Length > 65)
+            {
+                message = message.Substring(0, 65) + "...";
+            }
+
+            return string.Format("{0,-12} {1,-22} {2}", Severity.ToString(), Source.ToString(), message);
+        }
     }
 }

--- a/src/Diagnostics/DiagnosticMessageSource.cs
+++ b/src/Diagnostics/DiagnosticMessageSource.cs
@@ -22,5 +22,6 @@
         ModuleFileTitle,
         ModuleFileDescription,
         ModuleFileGroup,
-        ModuleFileCommand
+        ModuleFileCommand,
+        Identify
     }

--- a/src/MamlWriter/AlertSet.cs
+++ b/src/MamlWriter/AlertSet.cs
@@ -15,7 +15,12 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         ///     The command name for this syntax.
         /// </summary>
         [XmlElement("para", Namespace = Constants.XmlNamespace.MAML, Order = 0)]
-        public string Remark { get; set; } = string.Empty;
+        public List<string> Remark { get; set; }
+
+        public AlertItem()
+        {
+            Remark = new();
+        }
 
     }
 }

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -60,6 +60,16 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 }
             }
 
+            // Notes are reconstituted as Alerts in AlertSet
+            // We don't break up these lines, but provide a single paragraph
+            // to get better formatting.
+            if (commandHelp.Notes is not null)
+            {
+                AlertItem alert = new();
+                alert.Remark.Add(commandHelp.Notes);
+                command.AlertSet.Add(alert);
+            }
+
             if (commandHelp.Syntax is not null)
             {
                 foreach (var syntax in commandHelp.Syntax)

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -487,7 +487,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 return new Collection<Parameter>();
             }
 
-            var parameters = GetParameters(markdownContent, start + 1, out List<DiagnosticMessage> parameterDiagnostics);
+            var parameters = GetParameters(markdownContent, start, out List<DiagnosticMessage> parameterDiagnostics);
             var dm = new DiagnosticMessage(DiagnosticMessageSource.Parameter, "Parameters", DiagnosticSeverity.Information, $"{parameters.Count} parameters found", start);
             diagnostics.Add(dm);
             diagnostics.AddRange(parameterDiagnostics);

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -187,7 +187,7 @@ namespace Microsoft.PowerShell.PlatyPS
         internal static CommandHelp GetCommandHelpFromMarkdown(ParsedMarkdownContent markdownContent)
         {
             /*
-            GetMetadataFromMarkdown
+            GetMetadata
             GetTitleFromMarkdown
             GetSynopsisFromMarkdown // Not parsed
             GetSyntaxFromMarkdown // Must be parsed
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.PlatyPS
             OrderedDictionary? metadata = GetMetadata(markdownContent.Ast);
             if (metadata is null)
             {
-                throw new InvalidDataException("null metadata");
+                throw new InvalidDataException($"No metadata found in {markdownContent.FilePath}");
             }
             else
             {
@@ -256,7 +256,9 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             List<DiagnosticMessage> aliasesDiagnostics = new();
-            commandHelp.Aliases?.AddRange(GetAliasesFromMarkdown(markdownContent, out aliasesDiagnostics));
+            bool aliasHeaderFound = false;
+            commandHelp.Aliases?.AddRange(GetAliasesFromMarkdown(markdownContent, out aliasesDiagnostics, out aliasHeaderFound));
+            commandHelp.AliasHeaderFound = aliasHeaderFound;
             if (aliasesDiagnostics is not null && aliasesDiagnostics.Count > 0)
             {
                 aliasesDiagnostics.ForEach(d => commandHelp.Diagnostics.TryAddDiagnostic(d));
@@ -345,6 +347,13 @@ namespace Microsoft.PowerShell.PlatyPS
                     if (metadata.Inline?.FirstChild is Markdig.Syntax.Inlines.LiteralInline metadataText)
                     {
                         return ConvertTextToOrderedDictionary(metadataText.Content.Text);
+                    }
+                }
+                else if (ast[2] is Markdig.Syntax.ThematicBreakBlock && ast[1] is ParagraphBlock paragraph)
+                {
+                    if (paragraph.Inline?.FirstChild is LiteralInline metadataAsParagraph)
+                    {
+                        return ConvertTextToOrderedDictionary(metadataAsParagraph.Content.Text);
                     }
                 }
             }
@@ -487,7 +496,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 return new Collection<Parameter>();
             }
 
-            var parameters = GetParameters(markdownContent, start, out List<DiagnosticMessage> parameterDiagnostics);
+            var parameters = GetParameters(markdownContent, start + 1, out List<DiagnosticMessage> parameterDiagnostics);
             var dm = new DiagnosticMessage(DiagnosticMessageSource.Parameter, "Parameters", DiagnosticSeverity.Information, $"{parameters.Count} parameters found", start);
             diagnostics.Add(dm);
             diagnostics.AddRange(parameterDiagnostics);
@@ -732,9 +741,10 @@ namespace Microsoft.PowerShell.PlatyPS
             return parameters;
         }
 
-        internal static List<string> GetAliasesFromMarkdown(ParsedMarkdownContent markdownContent, out List<DiagnosticMessage> diagnostics)
+        internal static List<string> GetAliasesFromMarkdown(ParsedMarkdownContent markdownContent, out List<DiagnosticMessage> diagnostics, out bool aliasHeaderFound)
         {
             diagnostics = new List<DiagnosticMessage>();
+            aliasHeaderFound = false;
             var start = markdownContent.FindHeader(2, "ALIASES");
             if (start == -1)
             {
@@ -744,6 +754,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
             var aliasList = GetAliases(markdownContent.Ast, start + 1);
             diagnostics.Add(new DiagnosticMessage(DiagnosticMessageSource.Alias, "ALIASES header found", DiagnosticSeverity.Information, $"{aliasList.Count} aliases found", markdownContent.GetTextLine(start)));
+            aliasHeaderFound = true;
             return aliasList;
         }
 
@@ -1034,24 +1045,6 @@ namespace Microsoft.PowerShell.PlatyPS
                     if (exampleTitleBlock?.Inline?.FirstChild?.ToString() is string example)
                     {
                         exampleTitle = example.Trim();
-                        /*
-                        // example title with a number and a colon
-                        var exampleRegex1 = new System.Text.RegularExpressions.Regex(@"^Example\s+\d+[ :-]+\s");
-                        // no actual example title
-                        var exampleRegex2 = new System.Text.RegularExpressions.Regex(@"^Example\s+\d+[ :-]$");
-                        if (exampleRegex1.IsMatch(example))
-                        {
-                            exampleTitle = exampleRegex1.Replace(example, string.Empty).Trim();
-                        }
-                        else if (exampleRegex1.IsMatch(example))
-                        {
-                            exampleTitle = exampleRegex2.Replace(example, string.Empty).Trim();
-                        }
-                        else
-                        {
-                            exampleTitle = example.Trim();
-                        }
-                        */
                     }
                 }
 
@@ -1176,19 +1169,19 @@ namespace Microsoft.PowerShell.PlatyPS
                     // yaml does not allow '*' to start a value, so we need to change this to be (all).
                     // yamlBlock = yamlBlock.Replace("* (all)","\"(all)\"");
 
-                    if (ParameterMetadataV2.TryConvertToV2(yamlBlock, out var v2))
-                    {
-                        diagnostics.Add(
-                            new DiagnosticMessage(DiagnosticMessageSource.Parameter, $"{parameterName} found", DiagnosticSeverity.Information, "Version 2 metadata found", md[parameterItemIndex].Line + 1)
-                        );
-                        parameters.Add(new Parameter(parameterName, description, v2));
-                    }
-                    else if (ParameterMetadataV1.TryConvertToV1(yamlBlock, out var v1))
+                    if (ParameterMetadataV1.TryConvertToV1(yamlBlock, out var v1))
                     {
                         diagnostics.Add(
                             new DiagnosticMessage(DiagnosticMessageSource.Parameter, $"{parameterName} found", DiagnosticSeverity.Information, "Version 1 metadata found", md[parameterItemIndex].Line + 1)
                         );
                         parameters.Add(Parameter.ConvertV1ParameterToV2(parameterName, description, v1));
+                    }
+                    else if (ParameterMetadataV2.TryConvertToV2(yamlBlock, out var v2))
+                    {
+                        diagnostics.Add(
+                            new DiagnosticMessage(DiagnosticMessageSource.Parameter, $"{parameterName} found", DiagnosticSeverity.Information, "Version 2 metadata found", md[parameterItemIndex].Line + 1)
+                        );
+                        parameters.Add(new Parameter(parameterName, description, v2));
                     }
                     else if (YamlUtils.TryConvertYamlToDictionary(yamlBlock, out var yamlDict))
                     {
@@ -1616,225 +1609,6 @@ namespace Microsoft.PowerShell.PlatyPS
             diagnostics.Add(dm);
             return index > -1;
         }
-    }
-
-    public class ParsedMarkdownContent
-    {
-        public string FilePath { get; set; }
-        public List<string> MarkdownLines { get; set; }
-        public MarkdownDocument Ast { get; set; }
-        public int CurrentIndex { get; set; }
-        public List<string> Errors { get; set; }
-        public List<string> Warnings { get; set; }
-        public ParsedMarkdownContent(string fileContent)
-        {
-            MarkdownLines = new List<string>(fileContent.Replace("\r", "").Split(Constants.LineSplitter));
-            Ast = Markdig.Markdown.Parse(fileContent);
-            CurrentIndex = 0;
-            Errors = new List<string>();
-            Warnings = new List<string>();
-            FilePath = string.Empty;
-        }
-
-        public ParsedMarkdownContent(string[] lines)
-        {
-            MarkdownLines = new List<string>(lines);
-            Ast = Markdig.Markdown.Parse(string.Join("\n", lines));
-            CurrentIndex = 0;
-            Errors = new List<string>();
-            Warnings = new List<string>();
-            FilePath = string.Empty;
-        }
-
-        public static ParsedMarkdownContent ParseFile(string path)
-        {
-            var parsedMarkdownContent = new ParsedMarkdownContent(File.ReadAllLines(path));
-            parsedMarkdownContent.FilePath = path;
-            return parsedMarkdownContent;
-        }
-
-        public void AddError(string error)
-        {
-            Errors.Add(error);
-        }
-
-        public void AddWarning(string warning)
-        {
-            Warnings.Add(warning);
-        }
-
-        public void UnGet()
-        {
-            if (CurrentIndex > 0)
-            {
-                CurrentIndex--;
-            }
-        }
-
-        public void Reset()
-        {
-            CurrentIndex = 0;
-        }
-
-        public int FindHeader(int level, string title)
-        {
-            for(int i = CurrentIndex+1; i < Ast.Count; i++)
-            {
-                if (Ast[i] is HeadingBlock headerItem && headerItem.Level == level)
-                {
-                    if (title == string.Empty)
-                    {
-                        return i;
-                    }
-                    else if (string.Equals(headerItem?.Inline?.FirstChild?.ToString(), title, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return i;
-                    }
-                }
-            }
-
-            return -1;
-        }
-
-        public bool IsEnd()
-        {
-            return CurrentIndex < 0 || CurrentIndex >= Ast.Count - 1;
-        }
-
-        public object? Peek()
-        {
-            if (IsEnd())
-            {
-                return null;
-            }
-
-            return Ast[CurrentIndex+1];
-        }
-
-        public object? GetCurrent()
-        {
-            if (CurrentIndex < 0 || CurrentIndex >= Ast.Count)
-            {
-                return null;
-            }
-            else
-            {
-                return Ast[CurrentIndex];
-            }
-        }
-
-        public void Seek(int index)
-        {
-            CurrentIndex = index;
-        }
-
-        public object? Take()
-        {
-            if (CurrentIndex >= Ast.Count || CurrentIndex < 0)
-            {
-                return null;
-            }
-
-            try
-            {
-                return Ast[CurrentIndex];
-            }
-            finally
-            {
-                if (IsEnd())
-                {
-                    CurrentIndex = -1;
-                }
-                else
-                {
-                    CurrentIndex++;
-                }
-            }
-        }
-
-        public int GetTextLine(int offset)
-        {
-            if (offset < 0 || offset >= Ast.Count)
-            {
-                return -1;
-            }
-            else
-            {
-                return Ast[offset].Line + 1; // internally, we are 0 based
-            }
-        }
-
-        public bool IsEmptyHeader(int Level)
-        {
-            var currentHeader = Ast[CurrentIndex] as HeadingBlock;
-            var nextHeader = Ast[CurrentIndex + 1] as HeadingBlock;
-            if (currentHeader is not null && nextHeader is not null)
-            {
-                if (currentHeader.Level == Level && nextHeader.Level == Level)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public string GetStringFromAst(int endIndex)
-        {
-            if (endIndex <= CurrentIndex)
-            {
-                return string.Empty;
-            }
-
-            StringBuilder? sb = null;
-            try
-            {
-                sb = Constants.StringBuilderPool.Get();
-                int startLine = Ast[CurrentIndex].Line;
-                int endLine = Ast[endIndex].Line;
-                if (Ast[endIndex] is HeadingBlock)
-                {
-                    endLine--;
-                }
-
-                for(int i = startLine; i < endLine; i++)
-                {
-                    sb.AppendLine(MarkdownLines[i].TrimEnd());
-                }
-                return sb.ToString().Replace("\r", "").Trim();
-            }
-            finally
-            {
-                if (sb is not null)
-                {
-                    Constants.StringBuilderPool.Return(sb);
-                }
-            }
-        }
-
-        public string GetStringFromFile(int lineCount)
-        {
-            StringBuilder? sb = null;
-            try
-            {
-                sb = Constants.StringBuilderPool.Get();
-                int startLine = Ast[CurrentIndex].Line;
-                for(int i = startLine; i < startLine + lineCount; i++)
-                {
-                    sb.AppendLine(MarkdownLines[i].TrimEnd());
-                }
-
-                return sb.ToString().Replace("\r", "");
-            }
-            finally
-            {
-                if (sb is not null)
-                {
-                    Constants.StringBuilderPool.Return(sb);
-                }
-            }
-        }
-
     }
 
     public class MarkdownElement

--- a/src/MarkdownReader/MarkdownProbe.cs
+++ b/src/MarkdownReader/MarkdownProbe.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+using Microsoft.PowerShell.PlatyPS.Model;
+using System.CodeDom;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+
+    /// <summary>
+    /// A class to represent a parse error.
+    /// This might occur at any time, but especially when invalid yaml is included in the markdown.
+    /// </summary>
+    public class MarkdownProbe
+    {
+        public static MarkdownProbeInfo Identify(string path)
+        {
+            return new MarkdownProbeInfo(path);
+        }
+    }
+}

--- a/src/MarkdownReader/MarkdownProbeInfo.cs
+++ b/src/MarkdownReader/MarkdownProbeInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.PlatyPS
                         DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: cmdlet", DiagnosticSeverity.Information, "GetContentType", -1));
                         FileType = (MarkdownFileType.CommandHelp|MarkdownFileType.V2Schema);
                     }
-                    else if (documentType is not null && string.Compare(documentType.ToString(), "moduleFile", true) == 0)
+                    else if (documentType is not null && string.Compare(documentType.ToString(), "module", true) == 0)
                     {
                         FileType = (MarkdownFileType.ModuleFile|MarkdownFileType.V2Schema);
                         DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: modulefile", DiagnosticSeverity.Information, "GetContentType", -1));

--- a/src/MarkdownReader/MarkdownProbeInfo.cs
+++ b/src/MarkdownReader/MarkdownProbeInfo.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// using Markdig.Extensions.CustomContainers;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using Microsoft.PowerShell.PlatyPS.Model;
+using YamlDotNet.Core;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    [Flags]
+    public enum MarkdownFileType
+    {
+        Unknown         = 1 << 0x01,
+        CommandHelp     = 1 << 0x02,
+        ModuleFile      = 1 << 0x03,
+        ConceptualTopic = 1 << 0x04,
+        AboutTopic      = 1 << 0x05,
+        UnknownSchema   = 1 << 0x10,
+        V1Schema        = 1 << 0x20,
+        V2Schema        = 1 << 0x30,
+    }
+
+    /// <summary>
+    /// A class to represent the type of Markdown file we are parsing.
+    /// </summary>
+    ///
+    public class MarkdownProbeInfo
+    {
+        public string FilePath { get; set; }
+        public string? Title { get; set; }
+
+        public MarkdownFileType FileType { get; set; }
+
+        public ParsedMarkdownContent MarkdownContent { get; set; }
+
+        public OrderedDictionary? MetaData { get; set; }
+
+        public List<DiagnosticMessage> DiagnosticMessages { get; set; }
+
+        public MarkdownProbeInfo(string filePath)
+        {
+            FilePath = filePath;
+            DiagnosticMessages = new();
+            MarkdownContent = ParsedMarkdownContent.ParseFile(filePath);
+            MetaData = MarkdownConverter.GetMetadata(MarkdownContent.Ast);
+            GetContentType();
+        }
+
+        private void GetContentType()
+        {
+            FileType = MarkdownFileType.Unknown;
+            if (MetaData is not null && MetaData.Contains("title"))
+            {
+                Title = MetaData["title"].ToString();
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Found metadata and title", DiagnosticSeverity.Information, "GetContentType", -1));
+            }
+            else if (MetaData is null)
+            {
+                Title = "unknown";
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "metadata is null", DiagnosticSeverity.Information, "GetContentType", -1));
+            }
+            else
+            {
+                Title = "unknown";
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title not found", DiagnosticSeverity.Information, "GetContentType", -1));
+            }
+
+            if (MetaData is not null)
+            {
+                if (MetaData.Contains("document type"))
+                {
+                    var documentType = MetaData["document type"];
+                    if (documentType is not null && string.Compare(documentType.ToString(), "cmdlet", true) == 0)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: cmdlet", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType = (MarkdownFileType.CommandHelp|MarkdownFileType.V2Schema);
+                    }
+                    else if (documentType is not null && string.Compare(documentType.ToString(), "moduleFile", true) == 0)
+                    {
+                        FileType = (MarkdownFileType.ModuleFile|MarkdownFileType.V2Schema);
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: modulefile", DiagnosticSeverity.Information, "GetContentType", -1));
+                    }
+                }
+                else // hunt for more information
+                {
+                    DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type not found, searching elements", DiagnosticSeverity.Information, "GetContentType", -1));
+                    var synopsisIndex = MarkdownContent.FindHeader(2, "SYNOPSIS") != -1;
+                    var syntaxIndex = MarkdownContent.FindHeader(2, "SYNTAX") != -1;
+                    var exampleIndex = MarkdownContent.FindHeader(2, "EXAMPLES") != -1;
+                    var hasModuleGuid = MetaData.Contains("Module Guid");
+                    if (synopsisIndex && syntaxIndex && exampleIndex)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "synopsis/syntax/examples all found", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType = MarkdownFileType.CommandHelp;
+                    }
+                    else if (hasModuleGuid)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "module guid found", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType = MarkdownFileType.ModuleFile;
+                    }
+                    else if (Title.StartsWith("about", true, CultureInfo.InvariantCulture))
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title starts with 'about'", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType = MarkdownFileType.AboutTopic;
+                    }
+                    else
+                    {
+                        List<string> missingElements = new();
+                        if (! synopsisIndex)
+                        {
+                            missingElements.Add("SYNOPSIS");
+                        }
+
+                        if (! syntaxIndex)
+                        {
+                            missingElements.Add("SYNTAX");
+                        }
+
+                        if (! exampleIndex)
+                        {
+                            missingElements.Add("EXAMPLES");
+                        }
+
+                        if (! hasModuleGuid)
+                        {
+                            missingElements.Add("ModuleGuid");
+                        }
+
+                        string message = string.Format("Cannot determine file type: missing element(s): {0}", string.Join(", ", missingElements));
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, message, DiagnosticSeverity.Information, "GetContentType", -1));
+                    }
+
+                    if(MetaData.Contains("PlatyPS schema version"))
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version found - marking as v2", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType |= MarkdownFileType.V2Schema;
+                    }
+                    else if (FileType == MarkdownFileType.AboutTopic)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "no schema for about topics", DiagnosticSeverity.Information, "GetContentType", -1));
+                    }
+                    else if (FileType != MarkdownFileType.Unknown)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version not found - marking as v1", DiagnosticSeverity.Information, "GetContentType", -1));
+                        FileType |= MarkdownFileType.V1Schema;
+                    }
+                    else if (FileType == MarkdownFileType.Unknown)
+                    {
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Could not determine schema version", DiagnosticSeverity.Warning, "GetContentType", -1));
+                        FileType |= MarkdownFileType.UnknownSchema;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/MarkdownReader/ModuleCommandGroup.cs
+++ b/src/MarkdownReader/ModuleCommandGroup.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+// using System.Collections.Specialized;
+// using System.Collections.ObjectModel;
+// using System.Globalization;
+// using System.IO;
+using System.Linq;
+// using System.Text;
+// using System.Text.RegularExpressions;
+// using Markdig.Syntax;
+// using Markdig.Syntax.Inlines;
+// using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
+// using Microsoft.PowerShell.PlatyPS.Model;
+// using YamlDotNet;
+// using YamlDotNet.Serialization;
+// using System.Management.Automation;
+// using System.Security.Cryptography;
+// using System.Data.Common;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class ModuleCommandGroup : IEquatable<ModuleCommandGroup>
+    {
+        public string GroupTitle { get; set; }
+        public List<ModuleCommandInfo> Commands { get; set; }
+
+        public ModuleCommandGroup()
+        {
+            GroupTitle = string.Empty;
+            Commands = new();
+        }
+
+        public ModuleCommandGroup(ModuleCommandGroup mcg)
+        {
+            GroupTitle = mcg.GroupTitle;
+            Commands = new();
+            foreach(var command in mcg.Commands)
+            {
+                Commands.Add(new ModuleCommandInfo(command));
+            }
+        }
+
+        public ModuleCommandGroup(string title)
+        {
+            GroupTitle = title;
+            Commands = new();
+        }
+
+       public override int GetHashCode()
+        {
+            return (GroupTitle, Commands).GetHashCode();
+        }
+
+        public bool Equals(ModuleCommandGroup other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return (
+                string.Compare(GroupTitle, other.GroupTitle, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                Commands.SequenceEqual(other.Commands)
+                );
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (other is ModuleCommandGroup group2)
+            {
+                return Equals(group2);
+            }
+
+            return false;
+        }
+
+        public static bool operator == (ModuleCommandGroup group1, ModuleCommandGroup group2)
+        {
+            if (group1 is not null && group2 is not null)
+            {
+                return group1.Equals(group2);
+            }
+
+            return false;
+        }
+
+        public static bool operator !=(ModuleCommandGroup group1, ModuleCommandGroup group2)
+        {
+            if (group1 is not null && group2 is not null)
+            {
+                return ! group1.Equals(group2);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/MarkdownReader/ModuleCommandInfo.cs
+++ b/src/MarkdownReader/ModuleCommandInfo.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class ModuleCommandInfo : IEquatable<ModuleCommandInfo>
+    {
+        public string Name { get; set; }
+        public string Link { get; set; }
+        public string Description { get; set; }
+        public ModuleCommandInfo()
+        {
+            Name = string.Empty;
+            Link = string.Empty;
+            Description = string.Empty;
+        }
+
+        public ModuleCommandInfo(ModuleCommandInfo mci)
+        {
+            Name = mci.Name;
+            Link = mci.Link;
+            Description = mci.Description;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode() ^ Link.GetHashCode() ^ Description.GetHashCode();
+        }
+
+        public bool Equals(ModuleCommandInfo other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Compare(Name, other.Name) == 0 &&
+                string.Compare(Link, other.Link) == 0 &&
+                string.Compare(Description, other.Description) == 0;
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (other is ModuleCommandInfo info2)
+            {
+                return Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator == (ModuleCommandInfo info1, ModuleCommandInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator !=(ModuleCommandInfo info1, ModuleCommandInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return ! info1.Equals(info2);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/MarkdownReader/ModuleFileInfo.cs
+++ b/src/MarkdownReader/ModuleFileInfo.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Linq;
+using Microsoft.PowerShell.PlatyPS.Model;
+using YamlDotNet.Serialization;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class ModuleFileInfo : IEquatable<ModuleFileInfo>
+    {
+        public OrderedDictionary Metadata { get; set; }
+        public string Title { get; set; }
+        [YamlIgnore]
+        public string Module { get; set; }
+        [YamlIgnore]
+        public Guid? ModuleGuid { get; set; }
+        public string Description { get; set; }
+        [YamlIgnore]
+        public CultureInfo Locale { get; set; }
+        public List<ModuleCommandGroup> CommandGroups { get; set; }
+        [YamlIgnore]
+        public Diagnostics Diagnostics { get; set; }
+
+        public ModuleFileInfo()
+        {
+            Metadata = new();
+            Title = string.Empty;
+            Module = string.Empty;
+            Description = string.Empty;
+            Diagnostics = new();
+            CommandGroups = new();
+            Locale = CultureInfo.GetCultureInfo("en-US");
+        }
+
+        public ModuleFileInfo(ModuleFileInfo mfi)
+        {
+            Metadata = new();
+            if (mfi.Metadata is not null)
+            {
+                foreach (var key in mfi.Metadata.Keys)
+                {
+                    Metadata[key] = mfi.Metadata[key];
+                }
+            }
+
+            Title = mfi.Title;
+            Module = mfi.Module;
+            Locale = mfi.Locale;
+            Description = mfi.Description;
+            Diagnostics = new();
+            Diagnostics.TryAddDiagnostic(new DiagnosticMessage(DiagnosticMessageSource.ModuleFileTitle, "Copied MFI", DiagnosticSeverity.Information, "ModuleFileInfo:Constructor", -1));
+            CommandGroups = new();
+            foreach(var cg in mfi.CommandGroups)
+            {
+                CommandGroups.Add(new ModuleCommandGroup(cg));
+            }
+        }
+
+        public ModuleFileInfo(string title, string moduleName, CultureInfo? locale)
+        {
+            Metadata = MetadataUtils.GetModuleFileBaseMetadata(title, moduleName, locale);
+            Title = title;
+            Module = moduleName;
+            Description = string.Empty;
+            Diagnostics = new();
+            CommandGroups = new();
+            Locale = locale ?? CultureInfo.GetCultureInfo("en-US");
+        }
+
+        public ModuleFileInfo(PSModuleInfo moduleInfo, CultureInfo? locale)
+        {
+            Metadata = MetadataUtils.GetModuleFileBaseMetadata(moduleInfo, locale);
+            Title = $"{moduleInfo.Name} Module";
+            Module = $"{moduleInfo.Name}";
+            Description = moduleInfo.Description;
+            Diagnostics = new();
+            CommandGroups = new();
+            Locale = locale ?? CultureInfo.GetCultureInfo("en-US");
+        }
+
+        public override int GetHashCode()
+        {
+            return (Metadata, Title, Description).GetHashCode();
+        }
+
+        public bool Equals(ModuleFileInfo other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return (
+                string.Compare(Title, other.Title, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                string.Compare(Module, other.Module, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                string.Compare(Description, other.Description, StringComparison.CurrentCultureIgnoreCase) == 0 &&
+                CommandGroups.SequenceEqual(other.CommandGroups)
+                );
+        }
+
+        public override bool Equals(object other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (other is ModuleFileInfo info2)
+            {
+                return Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator == (ModuleFileInfo info1, ModuleFileInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return info1.Equals(info2);
+            }
+
+            return false;
+        }
+
+        public static bool operator !=(ModuleFileInfo info1, ModuleFileInfo info2)
+        {
+            if (info1 is not null && info2 is not null)
+            {
+                return ! info1.Equals(info2);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/MarkdownReader/ParsedMarkdownContent.cs
+++ b/src/MarkdownReader/ParsedMarkdownContent.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Markdig.Syntax;
+using Microsoft.PowerShell.PlatyPS.Model;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class ParsedMarkdownContent
+    {
+        public string FilePath { get; set; }
+        public List<string> MarkdownLines { get; set; }
+        public MarkdownDocument Ast { get; set; }
+        public int CurrentIndex { get; set; }
+        public List<string> Errors { get; set; }
+        public List<string> Warnings { get; set; }
+        public ParsedMarkdownContent(string fileContent)
+        {
+            MarkdownLines = new List<string>(fileContent.Replace("\r", "").Split(Constants.LineSplitter));
+            Ast = Markdig.Markdown.Parse(fileContent);
+            CurrentIndex = 0;
+            Errors = new List<string>();
+            Warnings = new List<string>();
+            FilePath = string.Empty;
+        }
+
+        public ParsedMarkdownContent(string[] lines)
+        {
+            MarkdownLines = new List<string>(lines);
+            Ast = Markdig.Markdown.Parse(string.Join("\n", lines));
+            CurrentIndex = 0;
+            Errors = new List<string>();
+            Warnings = new List<string>();
+            FilePath = string.Empty;
+        }
+
+        public static ParsedMarkdownContent ParseFile(string path)
+        {
+            var parsedMarkdownContent = new ParsedMarkdownContent(File.ReadAllLines(path));
+            parsedMarkdownContent.FilePath = path;
+            return parsedMarkdownContent;
+        }
+
+        public void AddError(string error)
+        {
+            Errors.Add(error);
+        }
+
+        public void AddWarning(string warning)
+        {
+            Warnings.Add(warning);
+        }
+
+        public void UnGet()
+        {
+            if (CurrentIndex > 0)
+            {
+                CurrentIndex--;
+            }
+        }
+
+        public void Reset()
+        {
+            CurrentIndex = 0;
+        }
+
+        public int FindHeader(int level, string title)
+        {
+            for(int i = CurrentIndex+1; i < Ast.Count; i++)
+            {
+                if (Ast[i] is HeadingBlock headerItem && headerItem.Level == level)
+                {
+                    if (title == string.Empty)
+                    {
+                        return i;
+                    }
+                    else if (string.Equals(headerItem?.Inline?.FirstChild?.ToString(), title, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        public bool IsEnd()
+        {
+            return CurrentIndex < 0 || CurrentIndex >= Ast.Count - 1;
+        }
+
+        public object? Peek()
+        {
+            if (IsEnd())
+            {
+                return null;
+            }
+
+            return Ast[CurrentIndex+1];
+        }
+
+        public object? GetCurrent()
+        {
+            if (CurrentIndex < 0 || CurrentIndex >= Ast.Count)
+            {
+                return null;
+            }
+            else
+            {
+                return Ast[CurrentIndex];
+            }
+        }
+
+        public void Seek(int index)
+        {
+            CurrentIndex = index;
+        }
+
+        public object? Take()
+        {
+            if (CurrentIndex >= Ast.Count || CurrentIndex < 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Ast[CurrentIndex];
+            }
+            finally
+            {
+                if (IsEnd())
+                {
+                    CurrentIndex = -1;
+                }
+                else
+                {
+                    CurrentIndex++;
+                }
+            }
+        }
+
+        public int GetTextLine(int offset)
+        {
+            if (offset < 0 || offset >= Ast.Count)
+            {
+                return -1;
+            }
+            else
+            {
+                return Ast[offset].Line + 1; // internally, we are 0 based
+            }
+        }
+
+        public bool IsEmptyHeader(int Level)
+        {
+            var currentHeader = Ast[CurrentIndex] as HeadingBlock;
+            var nextHeader = Ast[CurrentIndex + 1] as HeadingBlock;
+            if (currentHeader is not null && nextHeader is not null)
+            {
+                if (currentHeader.Level == Level && nextHeader.Level == Level)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public string GetStringFromAst(int endIndex)
+        {
+            if (endIndex <= CurrentIndex)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder? sb = null;
+            try
+            {
+                sb = Constants.StringBuilderPool.Get();
+                int startLine = Ast[CurrentIndex].Line;
+                int endLine = Ast[endIndex].Line;
+                if (Ast[endIndex] is HeadingBlock)
+                {
+                    endLine--;
+                }
+
+                for(int i = startLine; i < endLine; i++)
+                {
+                    sb.AppendLine(MarkdownLines[i].TrimEnd());
+                }
+                return sb.ToString().Replace("\r", "").Trim();
+            }
+            finally
+            {
+                if (sb is not null)
+                {
+                    Constants.StringBuilderPool.Return(sb);
+                }
+            }
+        }
+
+        public string GetStringFromFile(int lineCount)
+        {
+            StringBuilder? sb = null;
+            try
+            {
+                sb = Constants.StringBuilderPool.Get();
+                int startLine = Ast[CurrentIndex].Line;
+                for(int i = startLine; i < startLine + lineCount; i++)
+                {
+                    sb.AppendLine(MarkdownLines[i].TrimEnd());
+                }
+
+                return sb.ToString().Replace("\r", "");
+            }
+            finally
+            {
+                if (sb is not null)
+                {
+                    Constants.StringBuilderPool.Return(sb);
+                }
+            }
+        }
+
+    }
+}

--- a/src/MarkdownReader/V2ParameterMetadata.cs
+++ b/src/MarkdownReader/V2ParameterMetadata.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PowerShell.PlatyPS
     {
         public string Type { get; set;}
         public string DefaultValue { get; set;}
+        [YamlIgnore]
         public bool VariableLength { get; set;}
         public bool SupportsWildcards { get; set;}
         public List<string> ParameterValue { get; set;}
@@ -73,13 +74,13 @@ namespace Microsoft.PowerShell.PlatyPS
         {
             try
             {
-                var result = new DeserializerBuilder().Build().Deserialize<ParameterMetadataV2>(yaml);
+                var result = new DeserializerBuilder().IgnoreUnmatchedProperties().Build().Deserialize<ParameterMetadataV2>(yaml);
                 v2 = result;
                 return true;
             }
-            catch
+            catch (Exception deserializationFailure)
             {
-                ; // do nothing we couldn't parse the yaml, and we'll return false.
+                Console.WriteLine(deserializationFailure.Message);
             }
 
             v2 = new ParameterMetadataV2();

--- a/src/MarkdownReader/V2ParameterMetadata.cs
+++ b/src/MarkdownReader/V2ParameterMetadata.cs
@@ -41,7 +41,6 @@ namespace Microsoft.PowerShell.PlatyPS
     {
         public string Type { get; set;}
         public string DefaultValue { get; set;}
-        [YamlIgnore]
         public bool VariableLength { get; set;}
         public bool SupportsWildcards { get; set;}
         public List<string> ParameterValue { get; set;}

--- a/src/MarkdownWriter/CommandHelpMarkdownWriter.cs
+++ b/src/MarkdownWriter/CommandHelpMarkdownWriter.cs
@@ -94,8 +94,24 @@ namespace Microsoft.PowerShell.PlatyPS.MarkdownWriter
         {
             sb.AppendLine(Constants.mdAliasHeader);
             sb.AppendLine();
-            sb.AppendLine(Constants.AliasMessage);
-            sb.AppendLine();
+            if (help is null)
+            {
+                return;
+            }
+            else if (help?.Aliases is not null && help.Aliases.Count > 0 )
+            {
+                sb.AppendLine(Constants.AliasMessage1);
+                foreach(var alias in help.Aliases)
+                {
+                    sb.AppendLine($"   {alias}");
+                }
+                sb.AppendLine();
+            }
+            else if (help is not null && ! help.AliasHeaderFound)
+            {
+                sb.AppendLine(Constants.AliasMessage);
+                sb.AppendLine();
+            }
         }
 
         internal override void WriteExamples(CommandHelp help)
@@ -115,17 +131,6 @@ namespace Microsoft.PowerShell.PlatyPS.MarkdownWriter
                 sb.AppendLine($"{example.Remarks}");
                 sb.AppendLine();
             }
-
-            /*
-            int? totalExamples = help?.Examples?.Count;
-
-            for (int i = 0; i < totalExamples; i++)
-            {
-                sb.Append(help?.Examples?[i].ToExampleItemString(Constants.mdExampleItemHeaderTemplate, i + 1));
-                sb.AppendLine(); // new line for ToExampleItemString
-                sb.AppendLine(); // new line after each example
-            }
-            */
         }
 
         internal override void WriteParameters(CommandHelp help)

--- a/src/MarkdownWriter/ModulePageWriter.cs
+++ b/src/MarkdownWriter/ModulePageWriter.cs
@@ -4,8 +4,10 @@
 using Microsoft.PowerShell.PlatyPS.Model;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.IO;
 using System.Text;
 
@@ -85,7 +87,7 @@ namespace Microsoft.PowerShell.PlatyPS.MarkdownWriter
         private void WriteMetadata(ModuleFileInfo moduleFileInfo)
         {
             sb.AppendLine("---");
-            sb.Append(YamlUtils.SerializeElement(moduleFileInfo.Metadata));
+            sb.Append(YamlUtils.SerializeMetadata(moduleFileInfo.Metadata));
             sb.AppendLine("---");
         }
 
@@ -173,8 +175,11 @@ namespace Microsoft.PowerShell.PlatyPS.MarkdownWriter
                 {
                     sb.AppendLine($"### [{command.Name}]({command.Link})");
                     sb.AppendLine();
-                    sb.AppendLine($"{command.Description}");
-                    sb.AppendLine();
+                    if (! string.IsNullOrEmpty(command.Description))
+                    {
+                        sb.AppendLine($"{command.Description}");
+                        sb.AppendLine();
+                    }
                 }
             }
         }
@@ -213,11 +218,14 @@ namespace Microsoft.PowerShell.PlatyPS.MarkdownWriter
             {
                 sb.AppendFormat(Constants.mdModulePageCmdletLinkTemplate, command.Name, command.Link);
                 sb.AppendLine();
-                sb.AppendLine();
-                sb.AppendLine(command.Description);
-                sb.AppendLine();
+                if (! string.IsNullOrEmpty(command.Description))
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(command.Description);
+                    sb.AppendLine();
+                }
             }
-        }
+            }
 
         internal void WriteCmdletBlock(List<string> commandNames)
         {

--- a/src/Microsoft.PowerShell.PlatyPS.Format.ps1xml
+++ b/src/Microsoft.PowerShell.PlatyPS.Format.ps1xml
@@ -1,6 +1,82 @@
 <Configuration>
  <ViewDefinitions>
   <View>
+   <Name>platyPSDiagnostic</Name>
+    <ViewSelectedBy>
+     <TypeName>Microsoft.PowerShell.PlatyPS.Model.Diagnostics</TypeName>
+    </ViewSelectedBy>
+    <Controls>
+        <Control>
+            <Name>DiagnosticMessageList</Name>
+            <CustomControl>
+            <CustomEntries>
+                <CustomEntry>
+                <CustomItem>
+                    <Frame>
+                        <LeftIndent>2</LeftIndent>
+                        <CustomItem>
+                            <ExpressionBinding></ExpressionBinding>
+                            <NewLine/>
+                        </CustomItem>
+                    </Frame>
+                </CustomItem>
+                </CustomEntry>
+            </CustomEntries>
+            </CustomControl>
+        </Control>
+    </Controls>
+
+   <CustomControl>
+    <CustomEntries>
+     <CustomEntry>
+      <CustomItem>
+       <Text>Diagnostic Output</Text>
+       <NewLine/>
+
+       <Text>File: </Text>
+       <Frame>
+        <LeftIndent>2</LeftIndent>
+        <CustomItem>
+         <ExpressionBinding>
+          <PropertyName>FileName</PropertyName>
+         </ExpressionBinding>
+         <NewLine/>
+        </CustomItem>
+       </Frame>
+
+       <Text>HadErrors: </Text>
+       <Frame>
+        <LeftIndent>2</LeftIndent>
+        <CustomItem>
+         <ExpressionBinding>
+          <PropertyName>HadErrors</PropertyName>
+         </ExpressionBinding>
+         <NewLine/>
+        </CustomItem>
+       </Frame>
+
+       <NewLine/>
+       <Text>Messages:</Text>
+       <NewLine/>
+       <Frame>
+        <LeftIndent>0</LeftIndent>
+         <CustomItem>
+          <ExpressionBinding>
+           <PropertyName>Messages</PropertyName>
+		   <CustomControlName>DiagnosticMessageList</CustomControlName>
+           <EnumerateCollection/>
+          </ExpressionBinding>
+          <NewLine/>
+        </CustomItem>
+       </Frame>
+       <NewLine/>
+      </CustomItem>
+     </CustomEntry>
+    </CustomEntries>
+   </CustomControl>
+
+  </View>
+  <View>
    <Name>platyPSDetail</Name>
    <ViewSelectedBy>
     <TypeName>Microsoft.PowerShell.PlatyPS.MarkdownCommandHelpValidationResult</TypeName>
@@ -25,6 +101,7 @@
 	   </CustomEntries>
 	 </CustomControl>
    </Control>
+   
    </Controls>
 
    <CustomControl>
@@ -73,5 +150,55 @@
     </CustomEntries>
    </CustomControl>
   </View>
+
+    <View>
+    <Name>MarkdownProbeInfoTable</Name>
+    <ViewSelectedBy>
+     <TypeName>Microsoft.PowerShell.PlatyPS.MarkdownProbeInfo</TypeName>
+    </ViewSelectedBy>
+    <TableControl>
+     <TableHeaders>
+      <TableColumnHeader><Label>Title</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Filetype</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Filepath</Label></TableColumnHeader>
+     </TableHeaders>
+     <TableRowEntries>
+      <TableRowEntry>
+       <TableColumnItems>
+        <TableColumnItem><PropertyName>title</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>filetype</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>filepath</PropertyName></TableColumnItem>
+       </TableColumnItems>
+      </TableRowEntry>
+     </TableRowEntries>
+    </TableControl>
+   </View>
+   <View>
+    <Name>DiagnosticMessageTable</Name>
+    <ViewSelectedBy>
+     <TypeName>Microsoft.PowerShell.PlatyPS.Model.DiagnosticMessage</TypeName>
+    </ViewSelectedBy>
+    <TableControl>
+     <TableHeaders>
+      <TableColumnHeader><Label>Source</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Severity</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Message</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Identifier</Label></TableColumnHeader>
+      <TableColumnHeader><Label>Line</Label></TableColumnHeader>
+     </TableHeaders>
+     <TableRowEntries>
+      <TableRowEntry>
+       <TableColumnItems>
+        <TableColumnItem><PropertyName>Source</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>Severity</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>Message</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>Identifier</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>Line</PropertyName></TableColumnItem>
+       </TableColumnItems>
+      </TableRowEntry>
+     </TableRowEntries>
+    </TableControl>
+   </View>
+
  </ViewDefinitions>
 </Configuration>

--- a/src/Microsoft.PowerShell.PlatyPS.psd1
+++ b/src/Microsoft.PowerShell.PlatyPS.psd1
@@ -51,8 +51,11 @@ CmdletsToExport = @(
     'Export-MamlCommandHelp',
     'Test-MarkdownCommandHelp',
     'New-CommandHelp',
+    'New-MarkdownModuleFile',
     'Compare-CommandHelp',
+    'Measure-PlatyPSMarkdown',
     'Update-MarkdownCommandHelp',
+    'Update-MarkdownModuleFile',
     'Update-CommandHelp'
 )
 

--- a/src/Model/CommandHelp.cs
+++ b/src/Model/CommandHelp.cs
@@ -37,6 +37,9 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public List<SyntaxItem> Syntax { get; private set; }
 
+        // This is needed because if we find the header, but no aliases, we should not emit the boilerplate.
+        public bool AliasHeaderFound { get; set; }
+
         public List<string>? Aliases { get; private set; }
 
         public string? Description { get; set; }

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
@@ -11,6 +12,7 @@ using System.Text;
 using System.Xml;
 
 using Microsoft.PowerShell.PlatyPS.Model;
+using Microsoft.PowerShell.PlatyPS.YamlWriter;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
@@ -49,6 +51,10 @@ namespace Microsoft.PowerShell.PlatyPS
 
             var mamlFileInfo = new FileInfo(mamlFile);
             string moduleName = mamlFileInfo.Name.Remove(mamlFileInfo.Name.Length - Constants.MamlFileExtensionSuffix.Length);
+            if (moduleName.EndsWith(".dll", true, CultureInfo.InvariantCulture))
+            {
+                moduleName = moduleName.Remove(moduleName.Length - 4);
+            }
 
             using StreamReader stream = new(mamlFile);
 
@@ -68,6 +74,17 @@ namespace Microsoft.PowerShell.PlatyPS
                 if (cmdHelp is not null)
                 {
                     cmdHelp.ModuleName = moduleName;
+                    // Fix up some metadata from the help object
+                    if (cmdHelp.Metadata is not null)
+                    {
+                        cmdHelp.Metadata["external help file"] = mamlFileInfo.Name;
+                        var link = cmdHelp.RelatedLinks.Where(rl => string.Compare(rl.LinkText, "Online Version:", true) == 0);
+                        if (link is not null && link.Count() > 0)
+                        {
+                            cmdHelp.Metadata["HelpUri"] = link.First<Links>().Uri;
+                        }
+                    }
+
                     commandHelps.Add(cmdHelp);
                 }
             }
@@ -100,6 +117,8 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     cmdHelp.Parameters.RemoveAll(p => string.Compare(p.Name, MAML.Constants.NoCommonParameter, true) == 0);
                 }
+
+                cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadata(cmdHelp);
 
                 _paramSetMap.Clear();
             }

--- a/src/Transform/TransformSettings.cs
+++ b/src/Transform/TransformSettings.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
         public TransformSettings()
         {
-            Locale = CultureInfo.CurrentUICulture;
+            Locale = CultureInfo.CurrentCulture;
         }
 
         public TransformSettings(CultureInfo cultureInfo)

--- a/src/YamlWriter/YamlConstants.cs
+++ b/src/YamlWriter/YamlConstants.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
         internal const string YamlExtension = "yml";
         internal const string Example1 = "Example 1";
         internal const string ModuleNameHeaderTemplate = "Module Name: {0}";
-        internal const string DownloadHelpLinkTitle = "Download Help Link: ";
+        internal const string DownloadHelpLinkTitle = "HelpInfoUri: ";
         internal const string HelpVersionTitle = "Help Version: ";
         internal const string LocaleTemplate = "Locale: {0}";
         internal const string ModuleGuidHeaderTemplate = "Module Guid: {0}";

--- a/test/Pester/CompareCommandHelp.Tests.ps1
+++ b/test/Pester/CompareCommandHelp.Tests.ps1
@@ -5,8 +5,9 @@ Describe "Compare-CommandHelp can find differences" {
     BeforeAll {
         $ch1 = Import-MarkdownCommandHelp "${PSScriptRoot}/assets/get-date.md"
         $ch2 = Import-MarkdownCommandHelp "${PSScriptRoot}/assets/get-date.alt01.md"
-        $result1 = Compare-CommandHelp $ch1 $ch2
+        $result1 = Compare-CommandHelp $ch1 $ch2 -PropertyNamesToExclude @()
         $result2 = Compare-CommandHelp $ch1 $ch2 -PropertyNamesToExclude Diagnostics
+        $result3 = Compare-CommandHelp $ch1 $ch2
     }
 
     It "Should properly identify that the objects are different" {
@@ -34,5 +35,11 @@ Describe "Compare-CommandHelp can find differences" {
         $observed = $result2.split("`n").Where({$_ -match "are not the same|are different"}).foreach({$_.Substring(2).trim().split()[0]})
         $observed | Should -Be $expected
 
+    }
+
+    It "Default excluded properties should be Diagnostics and ParameterNames" {
+        $expected = "M excluding comparison of CommandHelp.Diagnostics","M excluding comparison of CommandHelp.Syntax.ParameterNames"
+        $observed = $result3.split("`n").Where({$_ -match "excluding comparison"})|Sort-Object -Unique
+        $observed | Should -Be $expected
     }
 }

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -48,7 +48,14 @@ Describe "New-CommandHelp tests" {
         }
 
         It "should have the proper number of parameters" {
-            $parameters.Count | Should -Be 17
+            if ($PSVersionTable.PSVersion.Major -eq 5) {
+                $expectedCount = 14
+            }
+            else {
+                $expectedCount = 17
+            }
+
+            $parameters.Count | Should -Be $expectedCount
         }
 
         # list retrieved from get-command
@@ -57,7 +64,6 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'ArgumentList'; Type = 'System.Object[]' },
             @{ Name = 'CommandType'; Type = 'System.Management.Automation.CommandTypes' },
             @{ Name = 'FullyQualifiedModule'; Type = 'Microsoft.PowerShell.Commands.ModuleSpecification[]' },
-            @{ Name = 'FuzzyMinimumDistance'; Type = 'System.UInt32' },
             @{ Name = 'ListImported'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'Module'; Type = 'System.String[]' },
             @{ Name = 'Name'; Type = 'System.String[]' },
@@ -67,9 +73,12 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'ShowCommandInfo'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'Syntax'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'TotalCount'; Type = 'System.Int32' },
-            @{ Name = 'UseAbbreviationExpansion'; Type = 'System.Management.Automation.SwitchParameter' },
-            @{ Name = 'UseFuzzyMatching'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'Verb'; Type = 'System.String[]' }
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
+                @{ Name = 'FuzzyMinimumDistance'; Type = 'System.UInt32' },
+                @{ Name = 'UseAbbreviationExpansion'; Type = 'System.Management.Automation.SwitchParameter' },
+                @{ Name = 'UseFuzzyMatching'; Type = 'System.Management.Automation.SwitchParameter' }
+            }
         ) {
             param ($Name, $type)
             $ch.Parameters.Name | Should -Contain $Name
@@ -100,13 +109,12 @@ Describe "New-CommandHelp tests" {
             [string]($ch.Parameters.Where({$_.name -eq $Name}).Aliases) | Should -Be $alias
         }
 
-        It "Should have the same parameter sets (excluding '(All)')" {
+        It "Should have the same parameter sets (excluding '(All)')" -Skip:($PSVersionTable.PSVersion.Major -eq 5) {
             $expected = $cmd.ParameterSets.Name | Sort-Object
             $observed = $ch.Parameters.ParameterSets.Name | Sort-Object -Unique | Where-Object { $_ -ne "(All)" }
             $observed | Should -Be $expected
         }
-
-        It "Should have the proper parameters in parameterset '<ParameterSetName>'"  -TestCases @(
+        It "Should have the proper parameters in parameterset '<ParameterSetName>'" -Skip:($PSVersionTable.PSVersion.Major -eq 5) -TestCases @(
             @{ ParameterSetName = 'CmdletSet';     Parameters = 'All:ArgumentList:FullyQualifiedModule:ListImported:Module:Noun:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:Verb' }
             @{ ParameterSetName = 'AllCommandSet'; Parameters = 'All:ArgumentList:CommandType:FullyQualifiedModule:FuzzyMinimumDistance:ListImported:Module:Name:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:UseAbbreviationExpansion:UseFuzzyMatching' }
         ) {
@@ -136,7 +144,13 @@ Describe "New-CommandHelp tests" {
         }
 
         It "Should have the proper number of output types" {
-            $ch.outputs.Count | should be 8
+            if ($PSVersionTable.PSVersion.Major -eq 5) {
+                $expectedCount = 9
+            }
+            else {
+                $expectedCount = 8
+            }
+            $ch.outputs.Count | should be $expectedCount
         }
 
         It "Should have the output type '<type>'" -TestCases @(

--- a/test/Pester/DiagnosticMessage.Tests.ps1
+++ b/test/Pester/DiagnosticMessage.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe "Test Diagnostic Messages" {
     BeforeAll {
-        $filePath = Join-Path $PSScriptRoot assets get-date.md
+        $filePath = [io.path]::Combine($PSScriptRoot, "assets", "get-date.md")
         $ch = Import-MarkdownCommandHelp $filePath
     }
 
@@ -46,7 +46,7 @@ Describe "Test Diagnostic Messages" {
 
     Context "Error Conditions" {
         BeforeAll {
-            $errorPath = Join-Path $PSScriptRoot assets get-datebad.md
+            $errorPath = [io.path]::Combine($PSScriptRoot, "assets", "get-datebad.md")
             $errorCh = Import-MarkdownCommandHelp $errorPath
         }
 

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -23,9 +23,9 @@ Describe "Export-MamlCommandHelp tests" {
 
         # this test relies on the previous test to create the file
         It "Should have the proper default encoding" {
-            $bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
+            $bytes = [io.file]::ReadAllBytes($f1)[0,1]
             $bytes | Should -Be 60, 63
-            $bytes = Get-Content -Path $f2 -AsByteStream | Select-Object -First 2
+            $bytes = [io.file]::ReadAllBytes($f2)[0,1]
             $bytes | Should -Be 60, 63
         }
 
@@ -44,9 +44,10 @@ Describe "Export-MamlCommandHelp tests" {
         It "Should create the file with the proper encoding" {
             Remove-Item -Path $outputDirectory -ErrorAction SilentlyContinue -Recurse
             $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -Encoding ([System.Text.Encoding]::Unicode)
-            $bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
+            $bytes = [io.file]::ReadAllBytes($f1)[0,1]
             $bytes | Should -Be 255, 254
-            $bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
+            $bytes = [io.file]::ReadAllBytes($f2)[0,1]
+            #$bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
             $bytes | Should -Be 255, 254
         }
 
@@ -94,7 +95,7 @@ Describe "Export-MamlCommandHelp tests" {
             $xml.SelectNodes('//command:command', $ns).Where({$_.details.name -eq "Invoke-Command"}).Parameters.parameter.Count | Should -Be 37
         }
 
-        It "Should have the proper number of parameters for Out-Null" {
+        It "Should have the proper number of parameters for Out-Null" -skip:($PSVersionTable.PSVersion.Major -eq 5) {
             $xml.SelectNodes('//command:command', $ns).Where({$_.details.name -eq "Out-Null"}).Parameters.parameter.Count | Should -Be 1
         }
 
@@ -102,7 +103,7 @@ Describe "Export-MamlCommandHelp tests" {
             $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).examples.example.Count | Should -Be 10
         }
 
-        It "Should have the proper number of inputs" {
+        It "Should have the proper number of inputs" -skip:($PSVersionTable.PSVersion.Major -eq 5) {
             $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).inputTypes.inputType.Count | Should -Be 1
         }
 

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Export-MamlCommandHelp tests" {
 
         # needed by subesequent tests
         It "Should create a file" {
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory
             $outputDirectory | Should -Exist
             $f1 | Should -Exist
             $f2 | Should -Exist
@@ -30,20 +30,20 @@ Describe "Export-MamlCommandHelp tests" {
         }
 
         It "Should have a warning if the file already exists" {
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory -WarningVariable warnvar
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -WarningVariable warnvar
             $warnvar.Count | Should -Be 2
         }
 
         It "Should not have an error if the file already exists and -Force is used" {
             Start-Sleep -Seconds 5
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory -Force
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -Force
             $fi = Get-ChildItem $f1
             $fi.LastWriteTime | Should -BeGreaterThan (Get-Date).AddSeconds(-5)
         }
 
         It "Should create the file with the proper encoding" {
             Remove-Item -Path $outputDirectory -ErrorAction SilentlyContinue -Recurse
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory -Encoding ([System.Text.Encoding]::Unicode)
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -Encoding ([System.Text.Encoding]::Unicode)
             $bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
             $bytes | Should -Be 255, 254
             $bytes = Get-Content -Path $f1 -AsByteStream | Select-Object -First 2
@@ -52,14 +52,14 @@ Describe "Export-MamlCommandHelp tests" {
 
         It "Using WhatIf should not result in a file" {
             Remove-Item -Path $outputDirectory -Recurse
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory -WhatIf
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -WhatIf
             $outputDirectory | Should -Not -Exist
         }
     }
 
     Context "Content Tests" {
         BeforeAll {
-            $chObjects | Export-MamlCommandHelp -OutputDirectory $outputDirectory -Force
+            $chObjects | Export-MamlCommandHelp -OutputFolder $outputDirectory -Force
             $xml = [xml](Get-Content -Path $f1)
             $namespace = $xml.helpItems.NamespaceURI
             $ns = [System.Xml.XmlNamespaceManager]::new($xml.NameTable)

--- a/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
@@ -40,10 +40,9 @@ Describe "Export-MarkdownCommandHelp" {
             }
 
             $result1 = Export-MarkdownCommandHelp -Command $ch -OutputFolder $outputBaseFolder
-            start-sleep 1
+            "" > $result1.FullName
             $result2 = Export-MarkdownCommandHelp -Command $ch -OutputFolder $outputBaseFolder -Force
             $result1.Length | Should -Be $result2.Length
-            $result1.LastWriteTime | Should -Not -Be $result2.LastWriteTime
         }
 
         It "CommandHelp without modulename should be exported to the OutputFolder" {

--- a/test/Pester/ExportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ExportMarkdownModuleFile.Tests.ps1
@@ -6,6 +6,7 @@ Describe "Export-MarkdownModuleFile" {
         $modFiles = Get-ChildItem -File "${PSScriptRoot}/assets" | Where-Object { $_.extension -eq ".md" -and $_.name -notmatch "-" -and $_.Name -notmatch "Bad.Metadata.Order" }
         $modFileNames = $modFiles.Foreach({$_.Name})
         $modObjects = $modFiles | Import-MarkdownModuleFile
+        $testModuleFile = $modObjects | Where-Object { $_.title -match 'Microsoft.PowerShell.Archive' }
     }
 
     Context "Basic Operation" {
@@ -16,8 +17,8 @@ Describe "Export-MarkdownModuleFile" {
         }
 
         It "Should produce a warning if the file already exists" {
-            $modObjects[1] | Export-MarkdownModuleFile -outputFolder ${TestDrive}
-            $result = $modObjects[1] | Export-MarkdownModuleFile -outputFolder ${TestDrive} 3>&1
+            $testModuleFile | Export-MarkdownModuleFile -outputFolder ${TestDrive}
+            $result = $testModuleFile | Export-MarkdownModuleFile -outputFolder ${TestDrive} 3>&1
             # this is a warning object, make it a string
             $result | Should -BeOfType System.Management.Automation.WarningRecord
             $result.Message | Should -Be "'Microsoft.PowerShell.Archive' exists, skipping. Use -Force to overwrite."

--- a/test/Pester/ExportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ExportMarkdownModuleFile.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Export-MarkdownModuleFile" {
     BeforeAll {
         $modFiles = Get-ChildItem -File "${PSScriptRoot}/assets" | Where-Object { $_.extension -eq ".md" -and $_.name -notmatch "-" -and $_.Name -notmatch "Bad.Metadata.Order" }
         $modFileNames = $modFiles.Foreach({$_.Name})
-        $modObjects = $modFiles | Import-MarkdownModuleFile
+        $modObjects = $modFiles.FullName | Import-MarkdownModuleFile
         $testModuleFile = $modObjects | Where-Object { $_.title -match 'Microsoft.PowerShell.Archive' }
     }
 
@@ -33,7 +33,7 @@ Describe "Export-MarkdownModuleFile" {
     Context "File Contents" {
         BeforeAll {
             $outputFile = $modObjects[3] | Export-MarkdownModuleFile -outputFolder ${TestDrive}
-            $testMF = Import-MarkdownModuleFile $outputFile
+            $testMF = Import-MarkdownModuleFile $outputFile.FullName
         }
 
         # This relies on implementation of IEquatable

--- a/test/Pester/ExportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ExportMarkdownModuleFile.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Export-MarkdownModuleFile" {
 
         # Now check the hard way
         It "Should have the same metadata value for key '<Name>'" -TestCases $(
-            @{ Name = "Download Help Link" }
+            @{ Name = "HelpInfoUri" }
             @{ Name = "Help Version" }
             @{ Name = "Locale" }
             @{ Name = "Module Guid" }

--- a/test/Pester/ExportYamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportYamlCommandHelp.Tests.ps1
@@ -40,7 +40,7 @@ Describe "Export-YamlCommandHelp tests" {
         ) {
             param ($key, $offset)
             $yamlDict.Contains($key) | Should -Be $true
-            $yamlDict.Keys[$offset] | Should -Be $key
+            @($yamlDict.Keys)[$offset] | Should -Be $key
         }
     }
 

--- a/test/Pester/ImportMamlHelp.Tests.ps1
+++ b/test/Pester/ImportMamlHelp.Tests.ps1
@@ -6,25 +6,29 @@ Describe "Import-YamlHelp tests" {
         BeforeAll {
             $mamlFile = "${PSScriptRoot}/assets/Microsoft.PowerShell.Commands.Utility.dll-Help.xml"
             $importedCmds = Import-MamlHelp $mamlFile
-        }
-        It "Can import a MAML file with the proper number of commands" {
-            $expectedCount = (Select-String "<command:command " $mamlFile).Count
-            $importedCmds.Count | Should -Be $expectedCount
+            $cmdlet = $importedCmds.Where({$_.title -eq "add-member"})
         }
 
-        It "Identifies the imported commands" {
-            $expectedNames = Select-String "<command:name>" $mamlFile | foreach-object { $_.Line -replace ".*>(.*)<.*",'$1' }
-            $importedCmds.title | Should -Be $expectedNames
-        }
+        Context "General tests" {
+            It "Can import a MAML file with the proper number of commands" {
+                $expectedCount = (Select-String "<command:command " $mamlFile).Count
+                $importedCmds.Count | Should -Be $expectedCount
+            }
 
-        It "Identifies the command which does not have CmdletBinding" {
-            $importedCmds.Where({!$_.HasCmdletBinding}) | Should -Be "Show-Command"
-        }
+            It "Identifies the imported commands" {
+                $expectedNames = Select-String "<command:name>" $mamlFile | foreach-object { $_.Line -replace ".*>(.*)<.*",'$1' }
+                $importedCmds.title | Should -Be $expectedNames
+            }
 
-        It "Correctly retrieves the synopsis for Add-Member" {
-            # this is the string from the MAML file.
-            $expected = "Adds custom properties and methods to an instance of a PowerShell object."
-            $importedCmds.Where({$_.title -eq "Add-Member"}).Synopsis | Should -Be $expected
+            It "Identifies the command which does not have CmdletBinding" {
+                $importedCmds.Where({!$_.HasCmdletBinding}) | Should -Be "Show-Command"
+            }
+
+            It "Correctly retrieves the synopsis for Add-Member" {
+                # this is the string from the MAML file.
+                $expected = "Adds custom properties and methods to an instance of a PowerShell object."
+                $importedCmds.Where({$_.title -eq "Add-Member"}).Synopsis | Should -Be $expected
+            }
         }
 
         Context "Metadata checks" {
@@ -35,11 +39,10 @@ Describe "Import-YamlHelp tests" {
                 @{ Key = 'Locale'; Value = 'en-US' }
                 @{ Key = 'PlatyPS schema version'; Value = '2024-05-01' }
                 @{ Key = 'HelpUri'; Value = 'https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7.3&WT.mc_id=ps-gethelp' }
-                @{ Key = 'ms.date'; Value = '07/31/2024' }
+                @{ Key = 'ms.date'; Value = Get-Date -f "MM/dd/yyyy" }
                 @{ Key = 'external help file'; Value = 'Microsoft.PowerShell.Commands.Utility.dll-Help.xml' }
             ) {
                 param ([string]$Key, [string]$Value)
-                $cmdlet = $importedCmds.Where({$_.title -eq "add-member"})
                 $cmdlet.Metadata[$key] | Should -Be $Value
             }
         }

--- a/test/Pester/ImportMamlHelp.Tests.ps1
+++ b/test/Pester/ImportMamlHelp.Tests.ps1
@@ -26,5 +26,22 @@ Describe "Import-YamlHelp tests" {
             $expected = "Adds custom properties and methods to an instance of a PowerShell object."
             $importedCmds.Where({$_.title -eq "Add-Member"}).Synopsis | Should -Be $expected
         }
+
+        Context "Metadata checks" {
+            It "has the proper metadata value for '<key>' for the Add-Member cmdlet" -testcases @(
+                @{ Key = 'document type'; Value = 'cmdlet' }
+                @{ Key = 'title'; Value = 'Add-Member' }
+                @{ Key = 'Module Name'; Value = 'Microsoft.PowerShell.Commands.Utility' }
+                @{ Key = 'Locale'; Value = 'en-US' }
+                @{ Key = 'PlatyPS schema version'; Value = '2024-05-01' }
+                @{ Key = 'HelpUri'; Value = 'https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/add-member?view=powershell-7.3&WT.mc_id=ps-gethelp' }
+                @{ Key = 'ms.date'; Value = '07/31/2024' }
+                @{ Key = 'external help file'; Value = 'Microsoft.PowerShell.Commands.Utility.dll-Help.xml' }
+            ) {
+                param ([string]$Key, [string]$Value)
+                $cmdlet = $importedCmds.Where({$_.title -eq "add-member"})
+                $cmdlet.Metadata[$key] | Should -Be $Value
+            }
+        }
     }
 }

--- a/test/Pester/ImportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ImportMarkdownModuleFile.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Import-ModuleFile tests" {
         BeforeAll {
             $mf0 = $modFiles[0] | Import-MarkdownModuleFile
             $testcases = @(
-                @{ PropertyName = "Metadata"; PropertyType = "System.Collections.Generic.SortedDictionary[string,string]" }
+                @{ PropertyName = "Metadata"; PropertyType = "ordered" }
                 @{ PropertyName = "Title"; PropertyType = "String" }
                 @{ PropertyName = "Module"; PropertyType = "String" }
                 @{ PropertyName = "ModuleGuid"; PropertyType = "Guid" }
@@ -100,7 +100,7 @@ Describe "Import-ModuleFile tests" {
         }
 
         It "Should have the proper key '<key>' and value '<value>'" -TestCases $(
-            @{ Key = "Download Help Link"; Value = "https://aka.ms/powershell75-help" }
+            @{ Key = "HelpInfoUri"; Value = "https://aka.ms/powershell75-help" }
             @{ Key = "Help Version"; Value = "7.5.0.0" }
             @{ Key = "Locale"; Value = "en-US" }
             @{ Key = "Module Guid"; Value = "fb6cc51d-c096-4b38-b78d-0fed6277096a" }
@@ -115,12 +115,14 @@ Describe "Import-ModuleFile tests" {
         }
 
         It "The key 'schema' should not be present" {
-            $mf.Metadata.ContainsKey("schema") | Should -Be $false
+            $mf.Metadata.Contains("schema") | Should -Be $false
         }
 
-        It 'The metadata keys are alphabetical upon import' {
+        It 'The metadata keys are alphabetical upon export' {
             # these metadata keys are explicitly not in alpha-order
-            $mf = Import-MarkdownModuleFile "${PSScriptRoot}/assets/Bad.Metadata.Order.md"
+            $badOrder = Import-MarkdownModuleFile "${PSScriptRoot}/assets/Bad.Metadata.Order.md"
+            $outputFile = $badOrder | Export-MarkdownModuleFile -Output $TESTDRIVE
+            $mf = Import-MarkdownModuleFile $outputFile
             $importedKeys = $mf.Metadata.Keys
             $sortedKeys = $mf.Metadata.Keys | Sort-Object
             $importedKeys | Should -Be $sortedKeys

--- a/test/Pester/ImportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ImportMarkdownModuleFile.Tests.ps1
@@ -8,21 +8,21 @@ Describe "Import-ModuleFile tests" {
 
     Context "File creation" {
         It "Should be able to read module files" {
-            $results = $modFiles | Import-MarkdownModuleFile
+            $results = $modFiles.FullName | Import-MarkdownModuleFile
             $results.Count | Should -Be 13
         }
 
         It "Should produce the correct type of object" {
-            $results = $modFiles | Import-MarkdownModuleFile
+            $results = $modFiles.FullName | Import-MarkdownModuleFile
             $results[0] | Should -BeOfType Microsoft.PowerShell.PlatyPS.ModuleFileInfo
         }
     }
 
     Context "Object properties" {
         BeforeAll {
-            $mf0 = $modFiles[0] | Import-MarkdownModuleFile
+            $mf0 = $modFiles[0].FullName | Import-MarkdownModuleFile
             $testcases = @(
-                @{ PropertyName = "Metadata"; PropertyType = "ordered" }
+                @{ PropertyName = "Metadata"; PropertyType = $(if ($PSVersionTable.PSVersion.Major -eq 5) { "System.Collections.Specialized.OrderedDictionary"} else { "ordered" }) }
                 @{ PropertyName = "Title"; PropertyType = "String" }
                 @{ PropertyName = "Module"; PropertyType = "String" }
                 @{ PropertyName = "ModuleGuid"; PropertyType = "Guid" }
@@ -92,7 +92,7 @@ Describe "Import-ModuleFile tests" {
     Context "Metadata content" {
         BeforeAll {
             $cimCmdletFile = $modFiles | Where-Object { $_.Name -eq "CimCmdlets.md" }
-            $mf = Import-MarkdownModuleFile $cimCmdletFile
+            $mf = Import-MarkdownModuleFile $cimCmdletFile.FullName
         }
 
         It "Should have non null metadata" {
@@ -130,7 +130,7 @@ Describe "Import-ModuleFile tests" {
 
         It 'Should add PSVersion schema version if it does not exist' {
             $mFile = $modFiles.Where({$_.name -eq "exchange.md"})
-            $testMF = $mFile | Import-MarkdownModuleFile
+            $testMF = $mFile.FullName | Import-MarkdownModuleFile
             $testMF.Metadata['PlatyPS schema version'] | Should -Be "2024-05-01"
         }
     }

--- a/test/Pester/ImportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ImportMarkdownModuleFile.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Import-ModuleFile tests" {
     Context "File creation" {
         It "Should be able to read module files" {
             $results = $modFiles | Import-MarkdownModuleFile
-            $results.Count | Should -Be 12
+            $results.Count | Should -Be 13
         }
 
         It "Should produce the correct type of object" {
@@ -124,6 +124,12 @@ Describe "Import-ModuleFile tests" {
             $importedKeys = $mf.Metadata.Keys
             $sortedKeys = $mf.Metadata.Keys | Sort-Object
             $importedKeys | Should -Be $sortedKeys
+        }
+
+        It 'Should add PSVersion schema version if it does not exist' {
+            $mFile = $modFiles.Where({$_.name -eq "exchange.md"})
+            $testMF = $mFile | Import-MarkdownModuleFile
+            $testMF.Metadata['PlatyPS schema version'] | Should -Be "2024-05-01"
         }
     }
 }

--- a/test/Pester/InteractiveExperience.Tests.ps1
+++ b/test/Pester/InteractiveExperience.Tests.ps1
@@ -24,7 +24,8 @@ Describe "Interactive experience tests" {
             } 
         ) {
             param ($cmdlet)
-            $result = TabExpansion2 "$cmdlet -Encoding "
+            $cmdString = "$cmdlet -Encoding "
+            $result = TabExpansion2 $cmdString $cmdString.Length
             $result.CompletionMatches.CompletionText | Should -Be $expectedEncoding
         }
     }

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -6,6 +6,8 @@ Describe "Export-MarkdownModuleFile" {
         $idents = Get-ChildItem $PSScriptRoot/assets -filter *.md | Measure-PlatyPSMarkdown
         $goodFile1 = $idents.Where({$_.FilePath -match "get-date.md$"})
         $goodFile2 = $idents.Where({$_.FilePath -match "Compare-CommandHelp.md$"})
+        $mfPath = Import-MarkdownModuleFile $PSScriptRoot/assets/Microsoft.PowerShell.Archive.md |
+            Export-MarkdownModuleFile -outputFolder $TESTDRIVE
     }
 
     It "Should identify all the '<fileType>' assets" -TestCases @(
@@ -30,4 +32,10 @@ Describe "Export-MarkdownModuleFile" {
         ($goodFile2.FileType -band "v2schema") -eq "v2schema" | Should -Be $true
         $goodFile2.DiagnosticMessages[-1].Message | Should -Be "document type found: cmdlet"
     }
+
+    It "Should recognise a V2 module file" {
+        $v2ModuleFile = Measure-PlatyPSMarkdown -Path $mfPath.Fullname
+        $v2ModuleFile.Filetype | Should -Be "ModuleFile, V2Schema"
+    }
+
 }

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -3,7 +3,8 @@
 
 Describe "Export-MarkdownModuleFile" {
     BeforeAll {
-        $idents = Get-ChildItem $PSScriptRoot/assets -filter *.md | Measure-PlatyPSMarkdown
+        $files = Get-ChildItem $PSScriptRoot/assets -filter *.md
+        $idents = $files.FullName | Measure-PlatyPSMarkdown
         $goodFile1 = $idents.Where({$_.FilePath -match "get-date.md$"})
         $goodFile2 = $idents.Where({$_.FilePath -match "Compare-CommandHelp.md$"})
         $mfPath = Import-MarkdownModuleFile $PSScriptRoot/assets/Microsoft.PowerShell.Archive.md |

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -77,10 +77,19 @@ Describe 'New-MarkdownCommandHelp' {
         }
     }
 
-    Context 'from PlatyPS module' {
+    Context 'using module parameter' {
         It 'creates few help files for PlatyPS' {
             $files = New-MarkdownCommandHelp -Module Microsoft.PowerShell.PlatyPS -OutputFolder "$TestDrive/platyPS" -Force
             ($files | Measure-Object).Count | Should -BeGreaterOrEqual 2
+        }
+
+        It 'Will create an object from a module which is not imported' {
+            $moduleName = Microsoft.PowerShell.Archive
+            $files = New-MarkdownCommandHelp -Module $moduleName -OutputFolder "$TestDrive"
+            $files.Count | Should -BeGreaterOrEqual 2
+            $expectedCommandNames = (Get-Module -List $moduleName).ExportedCommands.Keys | Sort-Object
+            $observedCommandNames = $files.foreach({$_.BaseName}) | Sort-Object
+            $observedCommandNames | Should -Be $expectedCommandNames
         }
     }
 
@@ -475,6 +484,7 @@ Write-Host 'Hello World!'
         It "generates a landing page from Module" {
             New-MarkdownCommandHelp -Module Microsoft.PowerShell.PlatyPS -OutputFolder $OutputFolder -WithModulePage -Force
             "$OutputFolderModuleFile" | Should -Exist
+
         }
 
         It 'generates a landing page from module at correct output folder' {

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'New-MarkdownCommandHelp' {
         }
 
         It 'Will create an object from a module which is not imported' {
-            $moduleName = Microsoft.PowerShell.Archive
+            $moduleName = "Microsoft.PowerShell.Archive"
             $files = New-MarkdownCommandHelp -Module $moduleName -OutputFolder "$TestDrive"
             $files.Count | Should -BeGreaterOrEqual 2
             $expectedCommandNames = (Get-Module -List $moduleName).ExportedCommands.Keys | Sort-Object

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -74,7 +74,8 @@ Describe 'New-MarkdownCommandHelp' {
     Context 'encoding' {
         It 'writes appropriate encoding' {
             $file = New-MarkdownCommandHelp -command New-MarkdownCommandHelp -OutputFolder $TestDrive -Force -Encoding ([System.Text.Encoding]::UTF32) -Metadata $defaultMetadata
-            Get-Content -AsByteStream $file | Select-Object -First 4 | Should -Be ([byte[]](255, 254, 0, 0))
+            $bytes = [io.file]::ReadAllBytes($file.fullname)[0..3]
+            $bytes | Should -Be ([byte[]](255, 254, 0, 0))
         }
     }
 
@@ -493,7 +494,7 @@ Write-Host 'Hello World!'
                 Push-Location $TestDrive
                 $files = New-MarkdownCommandHelp -Module Microsoft.PowerShell.PlatyPS -OutputFolder . -WithModulePage -Force
                 $landingPage = $files | Where-Object { $_.Name -eq 'Microsoft.PowerShell.PlatyPS.md' }
-                $landingPage.FullName | Should -BeExactly (Join-Path "$TestDrive" "Microsoft.PowerShell.PlatyPS" "Microsoft.PowerShell.PlatyPS.md")
+                $landingPage.FullName | Should -BeExactly ([io.path]::Combine("$TestDrive","Microsoft.PowerShell.PlatyPS","Microsoft.PowerShell.PlatyPS.md"))
             }
             finally {
                 Pop-Location

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -14,6 +14,7 @@ Describe 'New-MarkdownCommandHelp' {
             schema = "2.0.0"
         }
 
+        $IsWindowsPowerShell = $PSVersionTable.PSVersion.Major -eq 5
         $commonParameterNames = [System.Management.Automation.Internal.CommonParameters].GetProperties().ForEach({$_.Name})
         $ProgressPreference = 'SilentlyContinue'
     }
@@ -83,7 +84,7 @@ Describe 'New-MarkdownCommandHelp' {
             ($files | Measure-Object).Count | Should -BeGreaterOrEqual 2
         }
 
-        It 'Will create an object from a module which is not imported' {
+        It 'Will create an object from a module which is not imported' -skip:$IsWindowsPowerShell {
             $moduleName = "Microsoft.PowerShell.Archive"
             $files = New-MarkdownCommandHelp -Module $moduleName -OutputFolder "$TestDrive"
             $files.Count | Should -BeGreaterOrEqual 2

--- a/test/Pester/Scenarios.NewMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/Scenarios.NewMarkdownCommandHelp.Tests.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Scenario testing" {
+
+    Context "New-MarkdownCommandHelp with module file without additional metadata" {
+        BeforeAll {
+            $moduleName = "Microsoft.PowerShell.Archive"
+            $files = New-MarkdownCommandHelp -Module $moduleName -WithModulePage -output "${TESTDRIVE}/nometadata"
+            $moduleFile = Import-MarkdownModuleFile -Path ($files[2])
+            $commandHelp = $files[0,1] | Import-MarkdownCommandHelp
+            $moduleInfo = Get-Module -List $moduleName
+        }
+
+        It "Should have created 3 files" {
+            $files.Count | Should -Be 3
+        }
+
+        It "Should have created the files in the correct directory" {
+            $files.Directory.Name | Sort-Object -unique | Should -Be $moduleName
+        }
+
+        It "Should have created the correct file '<name>'" -testcases @(
+                @{ name = "Compress-Archive.md"; offset = 0 }
+                @{ name = "Expand-Archive.md"; offset = 1 }
+                @{ name = "${moduleName}.md"; offset = 2 }
+            ) {
+            param ($name, $offset)
+            $files[$offset].Name | Should -Be $name
+        }
+
+        It "The module file should have the correct number of commands" {
+            $moduleFile.CommandGroups[0].Commands.Count | Should -Be 2
+        }
+
+        It "The module file should include the correct command name '<name>'" -testcases @(
+            @{ name = "Compress-Archive"; offset = 0 }
+            @{ name = "Expand-Archive"; offset = 1 }
+        ) {
+            param ($name, $offset)
+            $commandHelp[$offset].title | Should -Be $name
+            $moduleFile.CommandGroups[0].Commands[$offset].name | Should -Be $name
+        }
+
+        It "The metadata should know the proper file content type for '<name>'" -testcases @(
+            @{ name = $files[0].name; metadata = $commandHelp[0].Metadata; filetype = "cmdlet" }
+            @{ name = $files[1].name; metadata = $commandHelp[1].Metadata; filetype = "cmdlet" }
+            @{ name = $files[2].name; metadata = $moduleFile.Metadata; filetype = "module" }
+        ) {
+            param ( $name, $metadata, $filetype )
+            $metadata['document type'] | Should -Be $filetype
+        }
+
+        It "Should have the proper metadata for <property> in the module file " -TestCases @(
+            @{ property = "Help Version"; expectedValue = "1.0.0.0" }
+            @{ property = "HelpInfoUri"; expectedValue = $moduleInfo.HelpInfoUri }
+            @{ property = "Module Guid"; expectedValue = $moduleInfo.Guid.ToString() }
+            @{ property = "PlatyPS schema version"; expectedValue = "2024-05-01" }
+            @{ property = "title"; expectedValue = "Microsoft.PowerShell.Archive Module" }
+        ) {
+            param ($property, $expectedValue)
+            $moduleFile.Metadata[$property] | Should -Be $expectedValue
+        }
+    } 
+
+    Context "New-MarkdownCommandHelp with module file without additional metadata" {
+        BeforeAll {
+            $moduleName = "Microsoft.PowerShell.Archive"
+            $files = New-MarkdownCommandHelp -Module $moduleName -WithModulePage -output "${TESTDRIVE}/addmetadata" -Metadata @{ p1 = 1; p2 = "two"; p3 = "ab","cd","ef"}
+            $moduleFile = Import-MarkdownModuleFile -Path ($files[2])
+            $commandHelp = $files[0,1] | Import-MarkdownCommandHelp
+            $moduleInfo = Get-Module -List $moduleName
+        }
+
+        It "Should have created 3 files" {
+            $files.Count | Should -Be 3
+        }
+
+        It "Should have created the files in the correct directory" {
+            $files.Directory.Name | Sort-Object -unique | Should -Be $moduleName
+        }
+
+        It "Should have created the correct file '<name>'" -testcases @(
+                @{ name = "Compress-Archive.md"; offset = 0 }
+                @{ name = "Expand-Archive.md"; offset = 1 }
+                @{ name = "${moduleName}.md"; offset = 2 }
+            ) {
+            param ($name, $offset)
+            $files[$offset].Name | Should -Be $name
+        }
+
+        It "The module file should have the correct number of commands" {
+            $moduleFile.CommandGroups[0].Commands.Count | Should -Be 2
+        }
+
+        It "The module file should include the correct command name '<name>'" -testcases @(
+            @{ name = "Compress-Archive"; offset = 0 }
+            @{ name = "Expand-Archive"; offset = 1 }
+        ) {
+            param ($name, $offset)
+            $commandHelp[$offset].title | Should -Be $name
+            $moduleFile.CommandGroups[0].Commands[$offset].name | Should -Be $name
+        }
+
+        It "The metadata should know the proper file content type for '<name>'" -testcases @(
+            @{ name = $files[0].name; metadata = $commandHelp[0].Metadata; filetype = "cmdlet" }
+            @{ name = $files[1].name; metadata = $commandHelp[1].Metadata; filetype = "cmdlet" }
+            @{ name = $files[2].name; metadata = $moduleFile.Metadata; filetype = "module" }
+        ) {
+            param ( $name, $metadata, $filetype )
+            $metadata['document type'] | Should -Be $filetype
+        }
+
+        It "Should have the proper metadata for '<property>' in the command help files" -TestCases @(
+            @{ property = "PlatyPS schema version"; expectedValue = "2024-05-01" }
+            @{ property = "p1"; expectedValue = 1 }
+            @{ property = "p2"; expectedValue = "two" }
+            @{ property = "p3"; expectedValue = "ab","cd","ef" }
+        ) {
+            param ($property, $expectedValue)
+            $commandHelp[0].Metadata[$property] | Should -Be $expectedValue
+            $commandHelp[1].Metadata[$property] | Should -Be $expectedValue
+        }
+    }   
+}

--- a/test/Pester/TestMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/TestMarkdownCommandHelp.Tests.ps1
@@ -3,22 +3,22 @@
 
 Describe "Test-MarkdownCommandHelp Tests" {
     It "Returns a boolean" {
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets get-date.md)
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot", "assets", "get-date.md"))
         $result | Should -BeOfType boolean
     }
 
     It "Should report true with a good markdown file" {
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets get-date.md)
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot", "assets","get-date.md"))
         $result | Should -Be $true
     }
 
     It "Should report false with a bad markdown file" {
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets bad-commandhelp.md)
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot","assets","bad-commandhelp.md"))
         $result | Should -Be $false
     }
 
     It "Should report details with the -DetailView parameter" {
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets get-date.md) -DetailView
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot","assets","get-date.md")) -DetailView
         $result | Should -BeOfType Microsoft.PowerShell.PlatyPS.MarkdownCommandHelpValidationResult
         $result.Path | Should -BeOfType string
         $result.Path | Should -Exist
@@ -27,7 +27,7 @@ Describe "Test-MarkdownCommandHelp Tests" {
     }
 
     It "Should report no failures in the details with a good markdown file" {
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets get-date.md) -DetailView
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot","assets","get-date.md")) -DetailView
         $result.Messages | Should -Not -cMatch "FAIL"
     }
 
@@ -44,7 +44,7 @@ Describe "Test-MarkdownCommandHelp Tests" {
         @{ line = 'PASS: RELATED LINKS found.' }
         ) {
         param ($line)
-        $result = Test-MarkdownCommandHelp (Join-Path $PSScriptRoot assets get-date.md) -DetailView
+        $result = Test-MarkdownCommandHelp ([io.path]::Combine("$PSScriptRoot", "assets", "get-date.md")) -DetailView
         $result.Messages | Should -Contain $line
     }
 }

--- a/test/Pester/UpdateCommandHelp.Tests.ps1
+++ b/test/Pester/UpdateCommandHelp.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Tests for Update-CommandHelp" {
         $chUpdate.Outputs.Typename | Should -Be @("System.Diagnostics.Process", "System.IO.FileInfo")
     }
 
-    It "No updates should have no changes" -skip:$IsWindows {
+    It "No updates should have no changes" -skip:($IsWindows -or $PSVersionTable.PSVersion.Major -eq 5) {
         $chCopy = [Microsoft.PowerShell.PlatyPS.Model.CommandHelp]::new($ch)
         $chCopy | Should -Be $ch
         $helpFile = $chCopy | Export-MarkdownCommandHelp -output $TESTDRIVE -Force

--- a/test/Pester/assets/exchange.md
+++ b/test/Pester/assets/exchange.md
@@ -1,0 +1,2904 @@
+---
+Module Name: Exchange PowerShell
+Module Guid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+title: exchange
+---
+
+# Exchange PowerShell
+## Description
+Exchange PowerShell is built on Windows PowerShell technology and provides a powerful command-line interface that enables automation of administrative tasks. The following PowerShell environments are available in Exchange:
+
+- [Exchange Server PowerShell (Exchange Management Shell)](https://learn.microsoft.com/powershell/exchange/exchange-management-shell)
+- [Exchange Online PowerShell](https://learn.microsoft.com/powershell/exchange/exchange-online-powershell)
+- [Security & Compliance PowerShell](https://learn.microsoft.com/powershell/exchange/scc-powershell)
+- [Exchange Online Protection PowerShell](https://learn.microsoft.com/powershell/exchange/exchange-online-protection-powershell)
+
+> [!NOTE]
+> For Exchange Online, Security & Compliance, and Exchange Online Protection, the module from the PowerShell Gallery that you use to connect is [ExchangeOnlineManagement](https://www.powershellgallery.com/packages/ExchangeOnlineManagement/). For more information, see [About the Exchange Online PowerShell module](../../docs-conceptual/exchange-online-powershell-v2.md).
+>
+> For Exchange Server, there is no Microsoft-provided module in the PowerShell Gallery. Instead, to use PowerShell in Exchange, you have the following options:
+>
+> - Use the Exchange Management Shell on an Exchange server or that you've installed locally on your own computer using a **Management tools** only installation of Exchange server. For more information, see [Install the Exchange Server Management Tools](/Exchange/plan-and-deploy/post-installation-tasks/install-management-tools) and [Open the Exchange Management Shell](../../docs-conceptual/open-the-exchange-management-shell.md).
+> - Use remote PowerShell from a Windows PowerShell session. For more information, see [Connect to Exchange servers using remote PowerShell](../../docs-conceptual/connect-to-exchange-servers-using-remote-powershell.md).
+
+## active-directory Cmdlets
+### [Add-ADPermission](Add-ADPermission.md)
+
+### [Dump-ProvisioningCache](Dump-ProvisioningCache.md)
+
+### [Get-ADPermission](Get-ADPermission.md)
+
+### [Get-ADServerSettings](Get-ADServerSettings.md)
+
+### [Get-ADSite](Get-ADSite.md)
+
+### [Get-AdSiteLink](Get-AdSiteLink.md)
+
+### [Get-DomainController](Get-DomainController.md)
+
+### [Get-OrganizationalUnit](Get-OrganizationalUnit.md)
+
+### [Get-Trust](Get-Trust.md)
+
+### [Get-UserPrincipalNamesSuffix](Get-UserPrincipalNamesSuffix.md)
+
+### [Remove-ADPermission](Remove-ADPermission.md)
+
+### [Reset-ProvisioningCache](Reset-ProvisioningCache.md)
+
+### [Set-ADServerSettings](Set-ADServerSettings.md)
+
+### [Set-ADSite](Set-ADSite.md)
+
+### [Set-AdSiteLink](Set-AdSiteLink.md)
+
+## defender-for-office-365 Cmdlets
+### [Disable-AntiPhishRule](Disable-AntiPhishRule.md)
+
+### [Disable-ATPProtectionPolicyRule](Disable-ATPProtectionPolicyRule.md)
+
+### [Disable-SafeAttachmentRule](Disable-SafeAttachmentRule.md)
+
+### [Disable-SafeLinksRule](Disable-SafeLinksRule.md)
+
+### [Enable-AntiPhishRule](Enable-AntiPhishRule.md)
+
+### [Enable-ATPProtectionPolicyRule](Enable-ATPProtectionPolicyRule.md)
+
+### [Enable-SafeAttachmentRule](Enable-SafeAttachmentRule.md)
+
+### [Enable-SafeLinksRule](Enable-SafeLinksRule.md)
+
+### [Get-AntiPhishPolicy](Get-AntiPhishPolicy.md)
+
+### [Get-AntiPhishRule](Get-AntiPhishRule.md)
+
+### [Get-ATPBuiltInProtectionRule](Get-ATPBuiltInProtectionRule.md)
+
+### [Get-AtpPolicyForO365](Get-AtpPolicyForO365.md)
+
+### [Get-ATPProtectionPolicyRule](Get-ATPProtectionPolicyRule.md)
+
+### [Get-ATPTotalTrafficReport](Get-ATPTotalTrafficReport.md)
+
+### [Get-ContentMalwareMdoAggregateReport](Get-ContentMalwareMdoAggregateReport.md)
+
+### [Get-ContentMalwareMdoDetailReport](Get-ContentMalwareMdoDetailReport.md)
+
+### [Get-EmailTenantSettings](Get-EmailTenantSettings.md)
+
+### [Get-MailDetailATPReport](Get-MailDetailATPReport.md)
+
+### [Get-MailTrafficATPReport](Get-MailTrafficATPReport.md)
+
+### [Get-SafeAttachmentPolicy](Get-SafeAttachmentPolicy.md)
+
+### [Get-SafeAttachmentRule](Get-SafeAttachmentRule.md)
+
+### [Get-SafeLinksAggregateReport](Get-SafeLinksAggregateReport.md)
+
+### [Get-SafeLinksDetailReport](Get-SafeLinksDetailReport.md)
+
+### [Get-SafeLinksPolicy](Get-SafeLinksPolicy.md)
+
+### [Get-SafeLinksRule](Get-SafeLinksRule.md)
+
+### [Get-SpoofIntelligenceInsight](Get-SpoofIntelligenceInsight.md)
+
+### [Get-SpoofMailReport](Get-SpoofMailReport.md)
+
+### [New-AntiPhishPolicy](New-AntiPhishPolicy.md)
+
+### [New-AntiPhishRule](New-AntiPhishRule.md)
+
+### [New-ATPBuiltInProtectionRule](New-ATPBuiltInProtectionRule.md)
+
+### [New-ATPProtectionPolicyRule](New-ATPProtectionPolicyRule.md)
+
+### [New-SafeAttachmentPolicy](New-SafeAttachmentPolicy.md)
+
+### [New-SafeAttachmentRule](New-SafeAttachmentRule.md)
+
+### [New-SafeLinksPolicy](New-SafeLinksPolicy.md)
+
+### [New-SafeLinksRule](New-SafeLinksRule.md)
+
+### [Remove-AntiPhishPolicy](Remove-AntiPhishPolicy.md)
+
+### [Remove-AntiPhishRule](Remove-AntiPhishRule.md)
+
+### [Remove-ATPProtectionPolicyRule](Remove-ATPProtectionPolicyRule.md)
+
+### [Remove-SafeAttachmentPolicy](Remove-SafeAttachmentPolicy.md)
+
+### [Remove-SafeAttachmentRule](Remove-SafeAttachmentRule.md)
+
+### [Remove-SafeLinksPolicy](Remove-SafeLinksPolicy.md)
+
+### [Remove-SafeLinksRule](Remove-SafeLinksRule.md)
+
+### [Set-AntiPhishPolicy](Set-AntiPhishPolicy.md)
+
+### [Set-AntiPhishRule](Set-AntiPhishRule.md)
+
+### [Set-ATPBuiltInProtectionRule](Set-ATPBuiltInProtectionRule.md)
+
+### [Set-AtpPolicyForO365](Set-AtpPolicyForO365.md)
+
+### [Set-ATPProtectionPolicyRule](Set-ATPProtectionPolicyRule.md)
+
+### [Set-EmailTenantSettings](Set-EmailTenantSettings.md)
+
+### [Set-SafeAttachmentPolicy](Set-SafeAttachmentPolicy.md)
+
+### [Set-SafeAttachmentRule](Set-SafeAttachmentRule.md)
+
+### [Set-SafeLinksPolicy](Set-SafeLinksPolicy.md)
+
+### [Set-SafeLinksRule](Set-SafeLinksRule.md)
+
+## antispam-antimalware Cmdlets
+### [Add-AttachmentFilterEntry](Add-AttachmentFilterEntry.md)
+
+### [Add-ContentFilterPhrase](Add-ContentFilterPhrase.md)
+
+### [Add-IPAllowListEntry](Add-IPAllowListEntry.md)
+
+### [Add-IPAllowListProvider](Add-IPAllowListProvider.md)
+
+### [Add-IPBlockListEntry](Add-IPBlockListEntry.md)
+
+### [Add-IPBlockListProvider](Add-IPBlockListProvider.md)
+
+### [Delete-QuarantineMessage](Delete-QuarantineMessage.md)
+
+### [Disable-EOPProtectionPolicyRule](Disable-EOPProtectionPolicyRule.md)
+
+### [Disable-HostedContentFilterRule](Disable-HostedContentFilterRule.md)
+
+### [Disable-HostedOutboundSpamFilterRule](Disable-HostedOutboundSpamFilterRule.md)
+
+### [Disable-MalwareFilterRule](Disable-MalwareFilterRule.md)
+
+### [Disable-ReportSubmissionRule](Disable-ReportSubmissionRule.md)
+
+### [Enable-AntispamUpdates](Enable-AntispamUpdates.md)
+
+### [Enable-EOPProtectionPolicyRule](Enable-EOPProtectionPolicyRule.md)
+
+### [Enable-HostedContentFilterRule](Enable-HostedContentFilterRule.md)
+
+### [Enable-HostedOutboundSpamFilterRule](Enable-HostedOutboundSpamFilterRule.md)
+
+### [Enable-MalwareFilterRule](Enable-MalwareFilterRule.md)
+
+### [Export-QuarantineMessage](Export-QuarantineMessage.md)
+
+### [Enable-ReportSubmissionRule](Enable-ReportSubmissionRule.md)
+
+### [Get-AgentLog](Get-AgentLog.md)
+
+### [Get-AggregateZapReport](Get-AggregateZapReport.md)
+
+### [Get-ArcConfig](Get-ArcConfig.md)
+
+### [Get-AttachmentFilterEntry](Get-AttachmentFilterEntry.md)
+
+### [Get-AttachmentFilterListConfig](Get-AttachmentFilterListConfig.md)
+
+### [Get-BlockedConnector](Get-BlockedConnector.md)
+
+### [Get-BlockedSenderAddress](Get-BlockedSenderAddress.md)
+
+### [Get-ConfigAnalyzerPolicyRecommendation](Get-ConfigAnalyzerPolicyRecommendation.md)
+
+### [Get-ContentFilterConfig](Get-ContentFilterConfig.md)
+
+### [Get-ContentFilterPhrase](Get-ContentFilterPhrase.md)
+
+### [Get-DetailZapReport](Get-DetailZapReport.md)
+
+### [Get-DkimSigningConfig](Get-DkimSigningConfig.md)
+
+### [Get-EOPProtectionPolicyRule](Get-EOPProtectionPolicyRule.md)
+
+### [Get-ExoPhishSimOverrideRule](Get-ExoPhishSimOverrideRule.md)
+
+### [Get-ExoSecOpsOverrideRule](Get-ExoSecOpsOverrideRule.md)
+
+### [Get-HostedConnectionFilterPolicy](Get-HostedConnectionFilterPolicy.md)
+
+### [Get-HostedContentFilterPolicy](Get-HostedContentFilterPolicy.md)
+
+### [Get-HostedContentFilterRule](Get-HostedContentFilterRule.md)
+
+### [Get-HostedOutboundSpamFilterPolicy](Get-HostedOutboundSpamFilterPolicy.md)
+
+### [Get-HostedOutboundSpamFilterRule](Get-HostedOutboundSpamFilterRule.md)
+
+### [Get-IPAllowListConfig](Get-IPAllowListConfig.md)
+
+### [Get-IPAllowListEntry](Get-IPAllowListEntry.md)
+
+### [Get-IPAllowListProvider](Get-IPAllowListProvider.md)
+
+### [Get-IPAllowListProvidersConfig](Get-IPAllowListProvidersConfig.md)
+
+### [Get-IPBlockListConfig](Get-IPBlockListConfig.md)
+
+### [Get-IPBlockListEntry](Get-IPBlockListEntry.md)
+
+### [Get-IPBlockListProvider](Get-IPBlockListProvider.md)
+
+### [Get-IPBlockListProvidersConfig](Get-IPBlockListProvidersConfig.md)
+
+### [Get-MailboxJunkEmailConfiguration](Get-MailboxJunkEmailConfiguration.md)
+
+### [Get-MalwareFilteringServer](Get-MalwareFilteringServer.md)
+
+### [Get-MalwareFilterPolicy](Get-MalwareFilterPolicy.md)
+
+### [Get-MalwareFilterRule](Get-MalwareFilterRule.md)
+
+### [Get-PhishSimOverridePolicy](Get-PhishSimOverridePolicy.md)
+
+### [Get-PhishSimOverrideRule](Get-PhishSimOverrideRule.md)
+
+### [Get-QuarantineMessage](Get-QuarantineMessage.md)
+
+### [Get-QuarantineMessageHeader](Get-QuarantineMessageHeader.md)
+
+### [Get-QuarantinePolicy](Get-QuarantinePolicy.md)
+
+### [Get-RecipientFilterConfig](Get-RecipientFilterConfig.md)
+
+### [Get-ReportSubmissionPolicy](Get-ReportSubmissionPolicy.md)
+
+### [Get-ReportSubmissionRule](Get-ReportSubmissionRule.md)
+
+### [Get-SecOpsOverridePolicy](Get-SecOpsOverridePolicy.md)
+
+### [Get-SecOpsOverrideRule](Get-SecOpsOverrideRule.md)
+
+### [Get-SenderFilterConfig](Get-SenderFilterConfig.md)
+
+### [Get-SenderIdConfig](Get-SenderIdConfig.md)
+
+### [Get-SenderReputationConfig](Get-SenderReputationConfig.md)
+
+### [Get-TeamsProtectionPolicy](Get-TeamsProtectionPolicy.md)
+
+### [Get-TeamsProtectionPolicyRule](Get-TeamsProtectionPolicyRule.md)
+
+### [Get-TenantAllowBlockListItems](Get-TenantAllowBlockListItems.md)
+
+### [Get-TenantAllowBlockListSpoofItems](Get-TenantAllowBlockListSpoofItems.md)
+
+### [New-DkimSigningConfig](New-DkimSigningConfig.md)
+
+### [New-EOPProtectionPolicyRule](New-EOPProtectionPolicyRule.md)
+
+### [New-ExoPhishSimOverrideRule](New-ExoPhishSimOverrideRule.md)
+
+### [New-ExoSecOpsOverrideRule](New-ExoSecOpsOverrideRule.md)
+
+### [New-HostedContentFilterPolicy](New-HostedContentFilterPolicy.md)
+
+### [New-HostedContentFilterRule](New-HostedContentFilterRule.md)
+
+### [New-HostedOutboundSpamFilterPolicy](New-HostedOutboundSpamFilterPolicy.md)
+
+### [New-HostedOutboundSpamFilterRule](New-HostedOutboundSpamFilterRule.md)
+
+### [New-MalwareFilterPolicy](New-MalwareFilterPolicy.md)
+
+### [New-MalwareFilterRule](New-MalwareFilterRule.md)
+
+### [New-PhishSimOverridePolicy](New-PhishSimOverridePolicy.md)
+
+### [New-QuarantinePermissions](New-QuarantinePermissions.md)
+
+### [New-QuarantinePolicy](New-QuarantinePolicy.md)
+
+### [New-ReportSubmissionPolicy](New-ReportSubmissionPolicy.md)
+
+### [New-ReportSubmissionRule](New-ReportSubmissionRule.md)
+
+### [New-SecOpsOverridePolicy](New-SecOpsOverridePolicy.md)
+
+### [New-TeamsProtectionPolicy](New-TeamsProtectionPolicy.md)
+
+### [New-TeamsProtectionPolicyRule](New-TeamsProtectionPolicyRule.md)
+
+### [New-TenantAllowBlockListItems](New-TenantAllowBlockListItems.md)
+
+### [New-TenantAllowBlockListSpoofItems](New-TenantAllowBlockListSpoofItems.md)
+
+### [Preview-QuarantineMessage](Preview-QuarantineMessage.md)
+
+### [Release-QuarantineMessage](Release-QuarantineMessage.md)
+
+### [Remove-AttachmentFilterEntry](Remove-AttachmentFilterEntry.md)
+
+### [Remove-BlockedConnector](Remove-BlockedConnector.md)
+
+### [Remove-BlockedSenderAddress](Remove-BlockedSenderAddress.md)
+
+### [Remove-ContentFilterPhrase](Remove-ContentFilterPhrase.md)
+
+### [Remove-EOPProtectionPolicyRule](Remove-EOPProtectionPolicyRule.md)
+
+### [Remove-ExoPhishSimOverrideRule](Remove-ExoPhishSimOverrideRule.md)
+
+### [Remove-ExoSecOpsOverrideRule](Remove-ExoSecOpsOverrideRule.md)
+
+### [Remove-HostedContentFilterPolicy](Remove-HostedContentFilterPolicy.md)
+
+### [Remove-HostedContentFilterRule](Remove-HostedContentFilterRule.md)
+
+### [Remove-HostedOutboundSpamFilterPolicy](Remove-HostedOutboundSpamFilterPolicy.md)
+
+### [Remove-HostedOutboundSpamFilterRule](Remove-HostedOutboundSpamFilterRule.md)
+
+### [Remove-IPAllowListEntry](Remove-IPAllowListEntry.md)
+
+### [Remove-IPAllowListProvider](Remove-IPAllowListProvider.md)
+
+### [Remove-IPBlockListEntry](Remove-IPBlockListEntry.md)
+
+### [Remove-IPBlockListProvider](Remove-IPBlockListProvider.md)
+
+### [Remove-MalwareFilterPolicy](Remove-MalwareFilterPolicy.md)
+
+### [Remove-MalwareFilterRule](Remove-MalwareFilterRule.md)
+
+### [Remove-PhishSimOverridePolicy](Remove-PhishSimOverridePolicy.md)
+
+### [Remove-QuarantinePolicy](Remove-QuarantinePolicy.md)
+
+### [Remove-ReportSubmissionPolicy](Remove-ReportSubmissionPolicy.md)
+
+### [Remove-ReportSubmissionRule](Remove-ReportSubmissionRule.md)
+
+### [Remove-SecOpsOverridePolicy](Remove-SecOpsOverridePolicy.md)
+
+### [Remove-TenantAllowBlockListItems](Remove-TenantAllowBlockListItems.md)
+
+### [Remove-TenantAllowBlockListSpoofItems](Remove-TenantAllowBlockListSpoofItems.md)
+
+### [Rotate-DkimSigningConfig](Rotate-DkimSigningConfig.md)
+
+### [Set-ArcConfig](Set-ArcConfig.md)
+
+### [Set-AttachmentFilterListConfig](Set-AttachmentFilterListConfig.md)
+
+### [Set-ContentFilterConfig](Set-ContentFilterConfig.md)
+
+### [Set-DkimSigningConfig](Set-DkimSigningConfig.md)
+
+### [Set-EOPProtectionPolicyRule](Set-EOPProtectionPolicyRule.md)
+
+### [Set-ExoPhishSimOverrideRule](Set-ExoPhishSimOverrideRule.md)
+
+### [Set-ExoSecOpsOverrideRule](Remove-ExoSecOpsOverrideRule.md)
+
+### [Set-HostedConnectionFilterPolicy](Set-HostedConnectionFilterPolicy.md)
+
+### [Set-HostedContentFilterPolicy](Set-HostedContentFilterPolicy.md)
+
+### [Set-HostedContentFilterRule](Set-HostedContentFilterRule.md)
+
+### [Set-HostedOutboundSpamFilterPolicy](Set-HostedOutboundSpamFilterPolicy.md)
+
+### [Set-HostedOutboundSpamFilterRule](Set-HostedOutboundSpamFilterRule.md)
+
+### [Set-IPAllowListConfig](Set-IPAllowListConfig.md)
+
+### [Set-IPAllowListProvider](Set-IPAllowListProvider.md)
+
+### [Set-IPAllowListProvidersConfig](Set-IPAllowListProvidersConfig.md)
+
+### [Set-IPBlockListConfig](Set-IPBlockListConfig.md)
+
+### [Set-IPBlockListProvider](Set-IPBlockListProvider.md)
+
+### [Set-IPBlockListProvidersConfig](Set-IPBlockListProvidersConfig.md)
+
+### [Set-MailboxJunkEmailConfiguration](Set-MailboxJunkEmailConfiguration.md)
+
+### [Set-MalwareFilteringServer](Set-MalwareFilteringServer.md)
+
+### [Set-MalwareFilterPolicy](Set-MalwareFilterPolicy.md)
+
+### [Set-MalwareFilterRule](Set-MalwareFilterRule.md)
+
+### [Set-PhishSimOverridePolicy](Set-PhishSimOverridePolicy.md)
+
+### [Set-QuarantinePermissions](Set-QuarantinePermissions.md)
+
+### [Set-QuarantinePolicy](Set-QuarantinePolicy.md)
+
+### [Set-RecipientFilterConfig](Set-RecipientFilterConfig.md)
+
+### [Set-ReportSubmissionPolicy](Set-ReportSubmissionPolicy.md)
+
+### [Set-ReportSubmissionRule](Set-ReportSubmissionRule.md)
+
+### [Set-SecOpsOverridePolicy](Set-SecOpsOverridePolicy.md)
+
+### [Set-SenderFilterConfig](Set-SenderFilterConfig.md)
+
+### [Set-SenderIdConfig](Set-SenderIdConfig.md)
+
+### [Set-SenderReputationConfig](Set-SenderReputationConfig.md)
+
+### [Set-TeamsProtectionPolicy](Set-TeamsProtectionPolicy.md)
+
+### [Set-TeamsProtectionPolicyRule](Set-TeamsProtectionPolicyRule.md)
+
+### [Set-TenantAllowBlockListItems](Set-TenantAllowBlockListItems.md)
+
+### [Set-TenantAllowBlockListSpoofItems](Set-TenantAllowBlockListSpoofItems.md)
+
+### [Test-IPAllowListProvider](Test-IPAllowListProvider.md)
+
+### [Test-IPBlockListProvider](Test-IPBlockListProvider.md)
+
+### [Test-SenderId](Test-SenderId.md)
+
+### [Update-SafeList](Update-SafeList.md)
+
+## client-access Cmdlets
+### [Clear-TextMessagingAccount](Clear-TextMessagingAccount.md)
+
+### [Compare-TextMessagingVerificationCode](Compare-TextMessagingVerificationCode.md)
+
+### [Disable-PushNotificationProxy](Disable-PushNotificationProxy.md)
+
+### [Enable-PushNotificationProxy](Enable-PushNotificationProxy.md)
+
+### [Export-AutoDiscoverConfig](Export-AutoDiscoverConfig.md)
+
+### [Get-CASMailbox](Get-CASMailbox.md)
+
+### [Get-CASMailboxPlan](Get-CASMailboxPlan.md)
+
+### [Get-ClientAccessRule](Get-ClientAccessRule.md)
+
+### [Get-ImapSettings](Get-ImapSettings.md)
+
+### [Get-MailboxCalendarConfiguration](Get-MailboxCalendarConfiguration.md)
+
+### [Get-MailboxMessageConfiguration](Get-MailboxMessageConfiguration.md)
+
+### [Get-MailboxRegionalConfiguration](Get-MailboxRegionalConfiguration.md)
+
+### [Get-MailboxSpellingConfiguration](Get-MailboxSpellingConfiguration.md)
+
+### [Get-OutlookProvider](Get-OutlookProvider.md)
+
+### [Get-OwaMailboxPolicy](Get-OwaMailboxPolicy.md)
+
+### [Get-PopSettings](Get-PopSettings.md)
+
+### [Get-TextMessagingAccount](Get-TextMessagingAccount.md)
+
+### [New-ClientAccessRule](New-ClientAccessRule.md)
+
+### [New-OutlookProvider](New-OutlookProvider.md)
+
+### [New-OwaMailboxPolicy](New-OwaMailboxPolicy.md)
+
+### [Remove-ClientAccessRule](Remove-ClientAccessRule.md)
+
+### [Remove-OutlookProvider](Remove-OutlookProvider.md)
+
+### [Remove-OwaMailboxPolicy](Remove-OwaMailboxPolicy.md)
+
+### [Send-TextMessagingVerificationCode](Send-TextMessagingVerificationCode.md)
+
+### [Set-CASMailbox](Set-CASMailbox.md)
+
+### [Set-CASMailboxPlan](Set-CASMailboxPlan.md)
+
+### [Set-ClientAccessRule](Set-ClientAccessRule.md)
+
+### [Set-ImapSettings](Set-ImapSettings.md)
+
+### [Set-MailboxCalendarConfiguration](Set-MailboxCalendarConfiguration.md)
+
+### [Set-MailboxMessageConfiguration](Set-MailboxMessageConfiguration.md)
+
+### [Set-MailboxRegionalConfiguration](Set-MailboxRegionalConfiguration.md)
+
+### [Set-MailboxSpellingConfiguration](Set-MailboxSpellingConfiguration.md)
+
+### [Set-OutlookProvider](Set-OutlookProvider.md)
+
+### [Set-OwaMailboxPolicy](Set-OwaMailboxPolicy.md)
+
+### [Set-PopSettings](Set-PopSettings.md)
+
+### [Set-TextMessagingAccount](Set-TextMessagingAccount.md)
+
+### [Test-CalendarConnectivity](Test-CalendarConnectivity.md)
+
+### [Test-ClientAccessRule](Test-ClientAccessRule.md)
+
+### [Test-EcpConnectivity](Test-EcpConnectivity.md)
+
+### [Test-ImapConnectivity](Test-ImapConnectivity.md)
+
+### [Test-OutlookConnectivity](Test-OutlookConnectivity.md)
+
+### [Test-OutlookWebServices](Test-OutlookWebServices.md)
+
+### [Test-OwaConnectivity](Test-OwaConnectivity.md)
+
+### [Test-PopConnectivity](Test-PopConnectivity.md)
+
+### [Test-PowerShellConnectivity](Test-PowerShellConnectivity.md)
+
+### [Test-WebServicesConnectivity](Test-WebServicesConnectivity.md)
+
+## client-access-servers Cmdlets
+### [Disable-OutlookAnywhere](Disable-OutlookAnywhere.md)
+
+### [Enable-OutlookAnywhere](Enable-OutlookAnywhere.md)
+
+### [Get-ActiveSyncVirtualDirectory](Get-ActiveSyncVirtualDirectory.md)
+
+### [Get-AuthRedirect](Get-AuthRedirect.md)
+
+### [Get-AutodiscoverVirtualDirectory](Get-AutodiscoverVirtualDirectory.md)
+
+### [Get-ClientAccessArray](Get-ClientAccessArray.md)
+
+### [Get-ClientAccessServer](Get-ClientAccessServer.md)
+
+### [Get-ClientAccessService](Get-ClientAccessService.md)
+
+### [Get-EcpVirtualDirectory](Get-EcpVirtualDirectory.md)
+
+### [Get-MapiVirtualDirectory](Get-MapiVirtualDirectory.md)
+
+### [Get-OutlookAnywhere](Get-OutlookAnywhere.md)
+
+### [Get-OwaVirtualDirectory](Get-OwaVirtualDirectory.md)
+
+### [Get-PowerShellVirtualDirectory](Get-PowerShellVirtualDirectory.md)
+
+### [Get-RpcClientAccess](Get-RpcClientAccess.md)
+
+### [Get-WebServicesVirtualDirectory](Get-WebServicesVirtualDirectory.md)
+
+### [New-ActiveSyncVirtualDirectory](New-ActiveSyncVirtualDirectory.md)
+
+### [New-AuthRedirect](New-AuthRedirect.md)
+
+### [New-AutodiscoverVirtualDirectory](New-AutodiscoverVirtualDirectory.md)
+
+### [New-ClientAccessArray](New-ClientAccessArray.md)
+
+### [New-EcpVirtualDirectory](New-EcpVirtualDirectory.md)
+
+### [New-MapiVirtualDirectory](New-MapiVirtualDirectory.md)
+
+### [New-OwaVirtualDirectory](New-OwaVirtualDirectory.md)
+
+### [New-PowerShellVirtualDirectory](New-PowerShellVirtualDirectory.md)
+
+### [New-RpcClientAccess](New-RpcClientAccess.md)
+
+### [New-WebServicesVirtualDirectory](New-WebServicesVirtualDirectory.md)
+
+### [Remove-ActiveSyncVirtualDirectory](Remove-ActiveSyncVirtualDirectory.md)
+
+### [Remove-AuthRedirect](Remove-AuthRedirect.md)
+
+### [Remove-AutodiscoverVirtualDirectory](Remove-AutodiscoverVirtualDirectory.md)
+
+### [Remove-ClientAccessArray](Remove-ClientAccessArray.md)
+
+### [Remove-EcpVirtualDirectory](Remove-EcpVirtualDirectory.md)
+
+### [Remove-MapiVirtualDirectory](Remove-MapiVirtualDirectory.md)
+
+### [Remove-OwaVirtualDirectory](Remove-OwaVirtualDirectory.md)
+
+### [Remove-PowerShellVirtualDirectory](Remove-PowerShellVirtualDirectory.md)
+
+### [Remove-RpcClientAccess](Remove-RpcClientAccess.md)
+
+### [Remove-WebServicesVirtualDirectory](Remove-WebServicesVirtualDirectory.md)
+
+### [Set-ActiveSyncVirtualDirectory](Set-ActiveSyncVirtualDirectory.md)
+
+### [Set-AuthRedirect](Set-AuthRedirect.md)
+
+### [Set-AutodiscoverVirtualDirectory](Set-AutodiscoverVirtualDirectory.md)
+
+### [Set-ClientAccessArray](Set-ClientAccessArray.md)
+
+### [Set-ClientAccessServer](Set-ClientAccessServer.md)
+
+### [Set-ClientAccessService](Set-ClientAccessService.md)
+
+### [Set-EcpVirtualDirectory](Set-EcpVirtualDirectory.md)
+
+### [Set-MapiVirtualDirectory](Set-MapiVirtualDirectory.md)
+
+### [Set-OutlookAnywhere](Set-OutlookAnywhere.md)
+
+### [Set-OwaVirtualDirectory](Set-OwaVirtualDirectory.md)
+
+### [Set-PowerShellVirtualDirectory](Set-PowerShellVirtualDirectory.md)
+
+### [Set-RpcClientAccess](Set-RpcClientAccess.md)
+
+### [Set-WebServicesVirtualDirectory](Set-WebServicesVirtualDirectory.md)
+
+## database-availability-groups Cmdlets
+### [Add-DatabaseAvailabilityGroupServer](Add-DatabaseAvailabilityGroupServer.md)
+
+### [Add-MailboxDatabaseCopy](Add-MailboxDatabaseCopy.md)
+
+### [Get-DatabaseAvailabilityGroup](Get-DatabaseAvailabilityGroup.md)
+
+### [Get-DatabaseAvailabilityGroupNetwork](Get-DatabaseAvailabilityGroupNetwork.md)
+
+### [Get-MailboxDatabaseCopyStatus](Get-MailboxDatabaseCopyStatus.md)
+
+### [Move-ActiveMailboxDatabase](Move-ActiveMailboxDatabase.md)
+
+### [New-DatabaseAvailabilityGroup](New-DatabaseAvailabilityGroup.md)
+
+### [New-DatabaseAvailabilityGroupNetwork](New-DatabaseAvailabilityGroupNetwork.md)
+
+### [Remove-DatabaseAvailabilityGroup](Remove-DatabaseAvailabilityGroup.md)
+
+### [Remove-DatabaseAvailabilityGroupNetwork](Remove-DatabaseAvailabilityGroupNetwork.md)
+
+### [Remove-DatabaseAvailabilityGroupServer](Remove-DatabaseAvailabilityGroupServer.md)
+
+### [Remove-MailboxDatabaseCopy](Remove-MailboxDatabaseCopy.md)
+
+### [Restore-DatabaseAvailabilityGroup](Restore-DatabaseAvailabilityGroup.md)
+
+### [Resume-MailboxDatabaseCopy](Resume-MailboxDatabaseCopy.md)
+
+### [Set-DatabaseAvailabilityGroup](Set-DatabaseAvailabilityGroup.md)
+
+### [Set-DatabaseAvailabilityGroupNetwork](Set-DatabaseAvailabilityGroupNetwork.md)
+
+### [Set-MailboxDatabaseCopy](Set-MailboxDatabaseCopy.md)
+
+### [Start-DatabaseAvailabilityGroup](Start-DatabaseAvailabilityGroup.md)
+
+### [Stop-DatabaseAvailabilityGroup](Stop-DatabaseAvailabilityGroup.md)
+
+### [Suspend-MailboxDatabaseCopy](Suspend-MailboxDatabaseCopy.md)
+
+### [Test-ReplicationHealth](Test-ReplicationHealth.md)
+
+### [Update-MailboxDatabaseCopy](Update-MailboxDatabaseCopy.md)
+
+## devices Cmdlets
+### [Clear-ActiveSyncDevice](Clear-ActiveSyncDevice.md)
+
+### [Clear-MobileDevice](Clear-MobileDevice.md)
+
+### [Export-ActiveSyncLog](Export-ActiveSyncLog.md)
+
+### [Get-ActiveSyncDevice](Get-ActiveSyncDevice.md)
+
+### [Get-ActiveSyncDeviceAccessRule](Get-ActiveSyncDeviceAccessRule.md)
+
+### [Get-ActiveSyncDeviceAutoblockThreshold](Get-ActiveSyncDeviceAutoblockThreshold.md)
+
+### [Get-ActiveSyncDeviceClass](Get-ActiveSyncDeviceClass.md)
+
+### [Get-ActiveSyncDeviceStatistics](Get-ActiveSyncDeviceStatistics.md)
+
+### [Get-ActiveSyncMailboxPolicy](Get-ActiveSyncMailboxPolicy.md)
+
+### [Get-ActiveSyncOrganizationSettings](Get-ActiveSyncOrganizationSettings.md)
+
+### [Get-DeviceConditionalAccessPolicy](Get-DeviceConditionalAccessPolicy.md)
+
+### [Get-DeviceConditionalAccessRule](Get-DeviceConditionalAccessRule.md)
+
+### [Get-DeviceConfigurationPolicy](Get-DeviceConfigurationPolicy.md)
+
+### [Get-DeviceConfigurationRule](Get-DeviceConfigurationRule.md)
+
+### [Get-DevicePolicy](Get-DevicePolicy.md)
+
+### [Get-DeviceTenantPolicy](Get-DeviceTenantPolicy.md)
+
+### [Get-DeviceTenantRule](Get-DeviceTenantRule.md)
+
+### [Get-MobileDevice](Get-MobileDevice.md)
+
+### [Get-MobileDeviceMailboxPolicy](Get-MobileDeviceMailboxPolicy.md)
+
+### [Get-MobileDeviceStatistics](Get-MobileDeviceStatistics.md)
+
+### [New-ActiveSyncDeviceAccessRule](New-ActiveSyncDeviceAccessRule.md)
+
+### [New-ActiveSyncMailboxPolicy](New-ActiveSyncMailboxPolicy.md)
+
+### [New-DeviceConditionalAccessPolicy](New-DeviceConditionalAccessPolicy.md)
+
+### [New-DeviceConditionalAccessRule](New-DeviceConditionalAccessRule.md)
+
+### [New-DeviceConfigurationPolicy](New-DeviceConfigurationPolicy.md)
+
+### [New-DeviceConfigurationRule](New-DeviceConfigurationRule.md)
+
+### [New-DeviceTenantPolicy](New-DeviceTenantPolicy.md)
+
+### [New-DeviceTenantRule](New-DeviceTenantRule.md)
+
+### [New-MobileDeviceMailboxPolicy](New-MobileDeviceMailboxPolicy.md)
+
+### [Remove-ActiveSyncDevice](Remove-ActiveSyncDevice.md)
+
+### [Remove-ActiveSyncDeviceAccessRule](Remove-ActiveSyncDeviceAccessRule.md)
+
+### [Remove-ActiveSyncDeviceClass](Remove-ActiveSyncDeviceClass.md)
+
+### [Remove-ActiveSyncMailboxPolicy](Remove-ActiveSyncMailboxPolicy.md)
+
+### [Remove-DeviceConditionalAccessPolicy](Remove-DeviceConditionalAccessPolicy.md)
+
+### [Remove-DeviceConditionalAccessRule](Remove-DeviceConditionalAccessRule.md)
+
+### [Remove-DeviceConfigurationPolicy](Remove-DeviceConfigurationPolicy.md)
+
+### [Remove-DeviceConfigurationRule](Remove-DeviceConfigurationRule.md)
+
+### [Remove-DeviceTenantPolicy](Remove-DeviceTenantPolicy.md)
+
+### [Remove-DeviceTenantRule](Remove-DeviceTenantRule.md)
+
+### [Remove-MobileDevice](Remove-MobileDevice.md)
+
+### [Remove-MobileDeviceMailboxPolicy](Remove-MobileDeviceMailboxPolicy.md)
+
+### [Set-ActiveSyncDeviceAccessRule](Set-ActiveSyncDeviceAccessRule.md)
+
+### [Set-ActiveSyncDeviceAutoblockThreshold](Set-ActiveSyncDeviceAutoblockThreshold.md)
+
+### [Set-ActiveSyncMailboxPolicy](Set-ActiveSyncMailboxPolicy.md)
+
+### [Set-ActiveSyncOrganizationSettings](Set-ActiveSyncOrganizationSettings.md)
+
+### [Set-DeviceConditionalAccessPolicy](Set-DeviceConditionalAccessPolicy.md)
+
+### [Set-DeviceConditionalAccessRule](Set-DeviceConditionalAccessRule.md)
+
+### [Set-DeviceConfigurationPolicy](Set-DeviceConfigurationPolicy.md)
+
+### [Set-DeviceConfigurationRule](Set-DeviceConfigurationRule.md)
+
+### [Set-DeviceTenantPolicy](Set-DeviceTenantPolicy.md)
+
+### [Set-DeviceTenantRule](Set-DeviceTenantRule.md)
+
+### [Set-MobileDeviceMailboxPolicy](Set-MobileDeviceMailboxPolicy.md)
+
+### [Test-ActiveSyncConnectivity](Test-ActiveSyncConnectivity.md)
+
+## email-addresses-and-address-books Cmdlets
+### [Disable-AddressListPaging](Disable-AddressListPaging.md)
+
+### [Enable-AddressListPaging](Enable-AddressListPaging.md)
+
+### [Get-AddressBookPolicy](Get-AddressBookPolicy.md)
+
+### [Get-AddressList](Get-AddressList.md)
+
+### [Get-DetailsTemplate](Get-DetailsTemplate.md)
+
+### [Get-EmailAddressPolicy](Get-EmailAddressPolicy.md)
+
+### [Get-GlobalAddressList](Get-GlobalAddressList.md)
+
+### [Get-OabVirtualDirectory](Get-OabVirtualDirectory.md)
+
+### [Get-OfflineAddressBook](Get-OfflineAddressBook.md)
+
+### [Move-AddressList](Move-AddressList.md)
+
+### [Move-OfflineAddressBook](Move-OfflineAddressBook.md)
+
+### [New-AddressBookPolicy](New-AddressBookPolicy.md)
+
+### [New-AddressList](New-AddressList.md)
+
+### [New-EmailAddressPolicy](New-EmailAddressPolicy.md)
+
+### [New-GlobalAddressList](New-GlobalAddressList.md)
+
+### [New-OabVirtualDirectory](New-OabVirtualDirectory.md)
+
+### [New-OfflineAddressBook](New-OfflineAddressBook.md)
+
+### [Remove-AddressBookPolicy](Remove-AddressBookPolicy.md)
+
+### [Remove-AddressList](Remove-AddressList.md)
+
+### [Remove-EmailAddressPolicy](Remove-EmailAddressPolicy.md)
+
+### [Remove-GlobalAddressList](Remove-GlobalAddressList.md)
+
+### [Remove-OabVirtualDirectory](Remove-OabVirtualDirectory.md)
+
+### [Remove-OfflineAddressBook](Remove-OfflineAddressBook.md)
+
+### [Restore-DetailsTemplate](Restore-DetailsTemplate.md)
+
+### [Set-AddressBookPolicy](Set-AddressBookPolicy.md)
+
+### [Set-AddressList](Set-AddressList.md)
+
+### [Set-DetailsTemplate](Set-DetailsTemplate.md)
+
+### [Set-EmailAddressPolicy](Set-EmailAddressPolicy.md)
+
+### [Set-GlobalAddressList](Set-GlobalAddressList.md)
+
+### [Set-OabVirtualDirectory](Set-OabVirtualDirectory.md)
+
+### [Set-OfflineAddressBook](Set-OfflineAddressBook.md)
+
+### [Update-AddressList](Update-AddressList.md)
+
+### [Update-EmailAddressPolicy](Update-EmailAddressPolicy.md)
+
+### [Update-GlobalAddressList](Update-GlobalAddressList.md)
+
+### [Update-OfflineAddressBook](Update-OfflineAddressBook.md)
+
+## encryption-and-certificates Cmdlets
+### [Enable-ExchangeCertificate](Enable-ExchangeCertificate.md)
+
+### [Export-ExchangeCertificate](Export-ExchangeCertificate.md)
+
+### [Get-DataEncryptionPolicy](Get-DataEncryptionPolicy.md)
+
+### [Get-ExchangeCertificate](Get-ExchangeCertificate.md)
+
+### [Get-IRMConfiguration](Get-IRMConfiguration.md)
+
+### [Get-M365DataAtRestEncryptionPolicy](Get-M365DataAtRestEncryptionPolicy.md)
+
+### [Get-M365DataAtRestEncryptionPolicyAssignment](Get-M365DataAtRestEncryptionPolicyAssignment.md)
+
+### [Get-MailboxIRMAccess](Get-MailboxIRMAccess.md)
+
+### [Get-OMEConfiguration](Get-OMEConfiguration.md)
+
+### [Get-OMEMessageStatus](Get-OMEMessageStatus.md)
+
+### [Get-RMSTemplate](Get-RMSTemplate.md)
+
+### [Get-SmimeConfig](Get-SmimeConfig.md)
+
+### [Import-ExchangeCertificate](Import-ExchangeCertificate.md)
+
+### [New-DataEncryptionPolicy](New-DataEncryptionPolicy.md)
+
+### [New-ExchangeCertificate](New-ExchangeCertificate.md)
+
+### [New-M365DataAtRestEncryptionPolicy](New-M365DataAtRestEncryptionPolicy.md)
+
+### [New-OMEConfiguration](New-OMEConfiguration.md)
+
+### [Remove-ExchangeCertificate](Remove-ExchangeCertificate.md)
+
+### [Remove-MailboxIRMAccess](Remove-MailboxIRMAccess.md)
+
+### [Remove-OMEConfiguration](Remove-OMEConfiguration.md)
+
+### [Set-DataEncryptionPolicy](Set-DataEncryptionPolicy.md)
+
+### [Set-IRMConfiguration](Set-IRMConfiguration.md)
+
+### [Set-M365DataAtRestEncryptionPolicy](Set-M365DataAtRestEncryptionPolicy.md)
+
+### [Set-M365DataAtRestEncryptionPolicyAssignment](Set-M365DataAtRestEncryptionPolicyAssignment.md)
+
+### [Set-MailboxIRMAccess](Set-MailboxIRMAccess.md)
+
+### [Set-OMEConfiguration](Set-OMEConfiguration.md)
+
+### [Set-OMEMessageRevocation](Set-OMEMessageRevocation.md)
+
+### [Set-RMSTemplate](Set-RMSTemplate.md)
+
+### [Set-SmimeConfig](Set-SmimeConfig.md)
+
+### [Test-IRMConfiguration](Test-IRMConfiguration.md)
+
+## federation-and-hybrid Cmdlets
+### [Add-FederatedDomain](Add-FederatedDomain.md)
+
+### [Disable-RemoteMailbox](Disable-RemoteMailbox.md)
+
+### [Enable-RemoteMailbox](Enable-RemoteMailbox.md)
+
+### [Get-FederatedDomainProof](Get-FederatedDomainProof.md)
+
+### [Get-FederatedOrganizationIdentifier](Get-FederatedOrganizationIdentifier.md)
+
+### [Get-FederationInformation](Get-FederationInformation.md)
+
+### [Get-FederationTrust](Get-FederationTrust.md)
+
+### [Get-HybridConfiguration](Get-HybridConfiguration.md)
+
+### [Get-HybridMailflow](Get-HybridMailflow.md)
+
+### [Get-HybridMailflowDatacenterIPs](Get-HybridMailflowDatacenterIPs.md)
+
+### [Get-IntraOrganizationConfiguration](Get-IntraOrganizationConfiguration.md)
+
+### [Get-IntraOrganizationConnector](Get-IntraOrganizationConnector.md)
+
+### [Get-OnPremisesOrganization](Get-OnPremisesOrganization.md)
+
+### [Get-PendingFederatedDomain](Get-PendingFederatedDomain.md)
+
+### [Get-RemoteMailbox](Get-RemoteMailbox.md)
+
+### [New-FederationTrust](New-FederationTrust.md)
+
+### [New-HybridConfiguration](New-HybridConfiguration.md)
+
+### [New-IntraOrganizationConnector](New-IntraOrganizationConnector.md)
+
+### [New-OnPremisesOrganization](New-OnPremisesOrganization.md)
+
+### [New-RemoteMailbox](New-RemoteMailbox.md)
+
+### [Remove-FederatedDomain](Remove-FederatedDomain.md)
+
+### [Remove-FederationTrust](Remove-FederationTrust.md)
+
+### [Remove-HybridConfiguration](Remove-HybridConfiguration.md)
+
+### [Remove-IntraOrganizationConnector](Remove-IntraOrganizationConnector.md)
+
+### [Remove-OnPremisesOrganization](Remove-OnPremisesOrganization.md)
+
+### [Remove-RemoteMailbox](Remove-RemoteMailbox.md)
+
+### [Set-FederatedOrganizationIdentifier](Set-FederatedOrganizationIdentifier.md)
+
+### [Set-FederationTrust](Set-FederationTrust.md)
+
+### [Set-HybridConfiguration](Set-HybridConfiguration.md)
+
+### [Set-HybridMailflow](Set-HybridMailflow.md)
+
+### [Set-IntraOrganizationConnector](Set-IntraOrganizationConnector.md)
+
+### [Set-OnPremisesOrganization](Set-OnPremisesOrganization.md)
+
+### [Set-PendingFederatedDomain](Set-PendingFederatedDomain.md)
+
+### [Set-RemoteMailbox](Set-RemoteMailbox.md)
+
+### [Test-FederationTrust](Test-FederationTrust.md)
+
+### [Test-FederationTrustCertificate](Test-FederationTrustCertificate.md)
+
+### [Update-HybridConfiguration](Update-HybridConfiguration.md)
+
+### [Update-Recipient](Update-Recipient.md)
+
+## mailbox-databases-and-servers Cmdlets
+### [Clean-MailboxDatabase](Clean-MailboxDatabase.md)
+
+### [Disable-MailboxQuarantine](Disable-MailboxQuarantine.md)
+
+### [Disable-MetaCacheDatabase](Disable-MetaCacheDatabase.md)
+
+### [Dismount-Database](Dismount-Database.md)
+
+### [Enable-MailboxQuarantine](Enable-MailboxQuarantine.md)
+
+### [Enable-MetaCacheDatabase](Enable-MetaCacheDatabase.md)
+
+### [Get-FailedContentIndexDocuments](Get-FailedContentIndexDocuments.md)
+
+### [Get-MailboxDatabase](Get-MailboxDatabase.md)
+
+### [Get-MailboxRepairRequest](Get-MailboxRepairRequest.md)
+
+### [Get-MailboxServer](Get-MailboxServer.md)
+
+### [Get-SearchDocumentFormat](Get-SearchDocumentFormat.md)
+
+### [Get-StoreUsageStatistics](Get-StoreUsageStatistics.md)
+
+### [Mount-Database](Mount-Database.md)
+
+### [Move-DatabasePath](Move-DatabasePath.md)
+
+### [New-MailboxDatabase](New-MailboxDatabase.md)
+
+### [New-MailboxRepairRequest](New-MailboxRepairRequest.md)
+
+### [New-SearchDocumentFormat](New-SearchDocumentFormat.md)
+
+### [Remove-MailboxDatabase](Remove-MailboxDatabase.md)
+
+### [Remove-MailboxRepairRequest](Remove-MailboxRepairRequest.md)
+
+### [Remove-SearchDocumentFormat](Remove-SearchDocumentFormat.md)
+
+### [Remove-StoreMailbox](Remove-StoreMailbox.md)
+
+### [Set-MailboxDatabase](Set-MailboxDatabase.md)
+
+### [Set-MailboxServer](Set-MailboxServer.md)
+
+### [Set-SearchDocumentFormat](Set-SearchDocumentFormat.md)
+
+### [Start-MailboxAssistant](Start-MailboxAssistant.md)
+
+### [Test-AssistantHealth](Test-AssistantHealth.md)
+
+### [Test-ExchangeSearch](Test-ExchangeSearch.md)
+
+### [Test-MRSHealth](Test-MRSHealth.md)
+
+### [Update-DatabaseSchema](Update-DatabaseSchema.md)
+
+### [Update-FileDistributionService](Update-FileDistributionService.md)
+
+### [Update-StoreMailboxState](Update-StoreMailboxState.md)
+
+## mailboxes Cmdlets
+### [Add-MailboxFolderPermission](Add-MailboxFolderPermission.md)
+
+### [Add-MailboxPermission](Add-MailboxPermission.md)
+
+### [Add-RecipientPermission](Add-RecipientPermission.md)
+
+### [Connect-Mailbox](Connect-Mailbox.md)
+
+### [Disable-App](Disable-App.md)
+
+### [Disable-InboxRule](Disable-InboxRule.md)
+
+### [Disable-Mailbox](Disable-Mailbox.md)
+
+### [Disable-ServiceEmailChannel](Disable-ServiceEmailChannel.md)
+
+### [Disable-SweepRule](Disable-SweepRule.md)
+
+### [Enable-App](Enable-App.md)
+
+### [Enable-InboxRule](Enable-InboxRule.md)
+
+### [Enable-Mailbox](Enable-Mailbox.md)
+
+### [Enable-ServiceEmailChannel](Enable-ServiceEmailChannel.md)
+
+### [Enable-SweepRule](Enable-SweepRule.md)
+
+### [Export-MailboxDiagnosticLogs](Export-MailboxDiagnosticLogs.md)
+
+### [Export-RecipientDataProperty](Export-RecipientDataProperty.md)
+
+### [Get-App](Get-App.md)
+
+### [Get-CalendarDiagnosticAnalysis](Get-CalendarDiagnosticAnalysis.md)
+
+### [Get-CalendarDiagnosticLog](Get-CalendarDiagnosticLog.md)
+
+### [Get-CalendarDiagnosticObjects](Get-CalendarDiagnosticObjects.md)
+
+### [Get-CalendarNotification](Get-CalendarNotification.md)
+
+### [Get-CalendarProcessing](Get-CalendarProcessing.md)
+
+### [Get-Clutter](Get-Clutter.md)
+
+### [Get-EventsFromEmailConfiguration](Get-EventsFromEmailConfiguration.md)
+
+### [Get-ExternalInOutlook](Get-ExternalInOutlook.md)
+
+### [Get-FocusedInbox](Get-FocusedInbox.md)
+
+### [Get-InboxRule](Get-InboxRule.md)
+
+### [Get-Mailbox](Get-Mailbox.md)
+
+### [Get-MailboxAutoReplyConfiguration](Get-MailboxAutoReplyConfiguration.md)
+
+### [Get-MailboxCalendarFolder](Get-MailboxCalendarFolder.md)
+
+### [Get-MailboxExportRequest](Get-MailboxExportRequest.md)
+
+### [Get-MailboxExportRequestStatistics](Get-MailboxExportRequestStatistics.md)
+
+### [Get-MailboxFolder](Get-MailboxFolder.md)
+
+### [Get-MailboxFolderPermission](Get-MailboxFolderPermission.md)
+
+### [Get-MailboxFolderStatistics](Get-MailboxFolderStatistics.md)
+
+### [Get-MailboxImportRequest](Get-MailboxImportRequest.md)
+
+### [Get-MailboxImportRequestStatistics](Get-MailboxImportRequestStatistics.md)
+
+### [Get-MailboxLocation](Get-MailboxLocation.md)
+
+### [Get-MailboxPermission](Get-MailboxPermission.md)
+
+### [Get-MailboxPlan](Get-MailboxPlan.md)
+
+### [Get-MailboxRestoreRequest](Get-MailboxRestoreRequest.md)
+
+### [Get-MailboxRestoreRequestStatistics](Get-MailboxRestoreRequestStatistics.md)
+
+### [Get-MailboxSentItemsConfiguration](Get-MailboxSentItemsConfiguration.md)
+
+### [Get-MailboxStatistics](Get-MailboxStatistics.md)
+
+### [Get-MailboxUserConfiguration](Get-MailboxUserConfiguration.md)
+
+### [Get-MessageCategory](Get-MessageCategory.md)
+
+### [Get-Place](Get-Place.md)
+
+### [Get-RecipientPermission](Get-RecipientPermission.md)
+
+### [Get-RecoverableItems](Get-RecoverableItems.md)
+
+### [Get-ResourceConfig](Get-ResourceConfig.md)
+
+### [Get-SweepRule](Get-SweepRule.md)
+
+### [Get-UserPhoto](Get-UserPhoto.md)
+
+### [Import-RecipientDataProperty](Import-RecipientDataProperty.md)
+
+### [New-App](New-App.md)
+
+### [New-InboxRule](New-InboxRule.md)
+
+### [New-Mailbox](New-Mailbox.md)
+
+### [New-MailboxExportRequest](New-MailboxExportRequest.md)
+
+### [New-MailboxFolder](New-MailboxFolder.md)
+
+### [New-MailboxImportRequest](New-MailboxImportRequest.md)
+
+### [New-MailboxRestoreRequest](New-MailboxRestoreRequest.md)
+
+### [New-MailMessage](New-MailMessage.md)
+
+### [New-SiteMailbox](New-SiteMailbox.md)
+
+### [New-SweepRule](New-SweepRule.md)
+
+### [Remove-App](Remove-App.md)
+
+### [Remove-CalendarEvents](Remove-CalendarEvents.md)
+
+### [Remove-InboxRule](Remove-InboxRule.md)
+
+### [Remove-Mailbox](Remove-Mailbox.md)
+
+### [Remove-MailboxExportRequest](Remove-MailboxExportRequest.md)
+
+### [Remove-MailboxFolderPermission](Remove-MailboxFolderPermission.md)
+
+### [Remove-MailboxImportRequest](Remove-MailboxImportRequest.md)
+
+### [Remove-MailboxPermission](Remove-MailboxPermission.md)
+
+### [Remove-MailboxRestoreRequest](Remove-MailboxRestoreRequest.md)
+
+### [Remove-MailboxUserConfiguration](Remove-MailboxUserConfiguration.md)
+
+### [Remove-RecipientPermission](Remove-RecipientPermission.md)
+
+### [Remove-SweepRule](Remove-SweepRule.md)
+
+### [Remove-UserPhoto](Remove-UserPhoto.md)
+
+### [Restore-Mailbox](Restore-Mailbox.md)
+
+### [Restore-RecoverableItems](Restore-RecoverableItems.md)
+
+### [Resume-MailboxExportRequest](Resume-MailboxExportRequest.md)
+
+### [Resume-MailboxImportRequest](Resume-MailboxImportRequest.md)
+
+### [Resume-MailboxRestoreRequest](Resume-MailboxRestoreRequest.md)
+
+### [Search-Mailbox](Search-Mailbox.md)
+
+### [Set-App](Set-App.md)
+
+### [Set-CalendarNotification](Set-CalendarNotification.md)
+
+### [Set-CalendarProcessing](Set-CalendarProcessing.md)
+
+### [Set-Clutter](Set-Clutter.md)
+
+### [Set-EventsFromEmailConfiguration](Set-EventsFromEmailConfiguration.md)
+
+### [Set-ExternalInOutlook](Set-ExternalInOutlook.md)
+
+### [Set-FocusedInbox](Set-FocusedInbox.md)
+
+### [Set-InboxRule](Set-InboxRule.md)
+
+### [Set-Mailbox](Set-Mailbox.md)
+
+### [Set-MailboxAutoReplyConfiguration](Set-MailboxAutoReplyConfiguration.md)
+
+### [Set-MailboxCalendarFolder](Set-MailboxCalendarFolder.md)
+
+### [Set-MailboxExportRequest](Set-MailboxExportRequest.md)
+
+### [Set-MailboxFolderPermission](Set-MailboxFolderPermission.md)
+
+### [Set-MailboxImportRequest](Set-MailboxImportRequest.md)
+
+### [Set-MailboxPlan](Set-MailboxPlan.md)
+
+### [Set-MailboxRestoreRequest](Set-MailboxRestoreRequest.md)
+
+### [Set-MailboxSentItemsConfiguration](Set-MailboxSentItemsConfiguration.md)
+
+### [Set-Place](Set-Place.md)
+
+### [Set-ResourceConfig](Set-ResourceConfig.md)
+
+### [Set-SweepRule](Set-SweepRule.md)
+
+### [Set-UserPhoto](Set-UserPhoto.md)
+
+### [Suspend-MailboxExportRequest](Suspend-MailboxExportRequest.md)
+
+### [Suspend-MailboxImportRequest](Suspend-MailboxImportRequest.md)
+
+### [Suspend-MailboxRestoreRequest](Suspend-MailboxRestoreRequest.md)
+
+### [Test-MAPIConnectivity](Test-MAPIConnectivity.md)
+
+### [Undo-SoftDeletedMailbox](Undo-SoftDeletedMailbox.md)
+
+## mail-flow Cmdlets
+### [Add-ResubmitRequest](Add-ResubmitRequest.md)
+
+### [Disable-TransportAgent](Disable-TransportAgent.md)
+
+### [Enable-TransportAgent](Enable-TransportAgent.md)
+
+### [Export-Message](Export-Message.md)
+
+### [Get-AcceptedDomain](Get-AcceptedDomain.md)
+
+### [Get-AddressRewriteEntry](Get-AddressRewriteEntry.md)
+
+### [Get-DeliveryAgentConnector](Get-DeliveryAgentConnector.md)
+
+### [Get-EdgeSubscription](Get-EdgeSubscription.md)
+
+### [Get-EdgeSyncServiceConfig](Get-EdgeSyncServiceConfig.md)
+
+### [Get-ForeignConnector](Get-ForeignConnector.md)
+
+### [Get-FrontendTransportService](Get-FrontendTransportService.md)
+
+### [Get-InboundConnector](Get-InboundConnector.md)
+
+### [Get-MailboxTransportService](Get-MailboxTransportService.md)
+
+### [Get-Message](Get-Message.md)
+
+### [Get-MessageTrace](Get-MessageTrace.md)
+
+### [Get-MessageTraceDetail](Get-MessageTraceDetail.md)
+
+### [Get-MessageTrackingLog](Get-MessageTrackingLog.md)
+
+### [Get-MessageTrackingReport](Get-MessageTrackingReport.md)
+
+### [Get-NetworkConnectionInfo](Get-NetworkConnectionInfo.md)
+
+### [Get-OutboundConnector](Get-OutboundConnector.md)
+
+### [Get-Queue](Get-Queue.md)
+
+### [Get-QueueDigest](Get-QueueDigest.md)
+
+### [Get-ReceiveConnector](Get-ReceiveConnector.md)
+
+### [Get-RemoteDomain](Get-RemoteDomain.md)
+
+### [Get-ResubmitRequest](Get-ResubmitRequest.md)
+
+### [Get-RoutingGroupConnector](Get-RoutingGroupConnector.md)
+
+### [Get-SendConnector](Get-SendConnector.md)
+
+### [Get-SystemMessage](Get-SystemMessage.md)
+
+### [Get-TransportAgent](Get-TransportAgent.md)
+
+### [Get-TransportConfig](Get-TransportConfig.md)
+
+### [Get-TransportPipeline](Get-TransportPipeline.md)
+
+### [Get-TransportServer](Get-TransportServer.md)
+
+### [Get-TransportService](Get-TransportService.md)
+
+### [Get-X400AuthoritativeDomain](Get-X400AuthoritativeDomain.md)
+
+### [Install-TransportAgent](Install-TransportAgent.md)
+
+### [New-AcceptedDomain](New-AcceptedDomain.md)
+
+### [New-AddressRewriteEntry](New-AddressRewriteEntry.md)
+
+### [New-DeliveryAgentConnector](New-DeliveryAgentConnector.md)
+
+### [New-EdgeSubscription](New-EdgeSubscription.md)
+
+### [New-EdgeSyncServiceConfig](New-EdgeSyncServiceConfig.md)
+
+### [New-ForeignConnector](New-ForeignConnector.md)
+
+### [New-InboundConnector](New-InboundConnector.md)
+
+### [New-OutboundConnector](New-OutboundConnector.md)
+
+### [New-ReceiveConnector](New-ReceiveConnector.md)
+
+### [New-RemoteDomain](New-RemoteDomain.md)
+
+### [New-RoutingGroupConnector](New-RoutingGroupConnector.md)
+
+### [New-SendConnector](New-SendConnector.md)
+
+### [New-SystemMessage](New-SystemMessage.md)
+
+### [New-X400AuthoritativeDomain](New-X400AuthoritativeDomain.md)
+
+### [Redirect-Message](Redirect-Message.md)
+
+### [Remove-AcceptedDomain](Remove-AcceptedDomain.md)
+
+### [Remove-AddressRewriteEntry](Remove-AddressRewriteEntry.md)
+
+### [Remove-DeliveryAgentConnector](Remove-DeliveryAgentConnector.md)
+
+### [Remove-EdgeSubscription](Remove-EdgeSubscription.md)
+
+### [Remove-ForeignConnector](Remove-ForeignConnector.md)
+
+### [Remove-InboundConnector](Remove-InboundConnector.md)
+
+### [Remove-Message](Remove-Message.md)
+
+### [Remove-OutboundConnector](Remove-OutboundConnector.md)
+
+### [Remove-ReceiveConnector](Remove-ReceiveConnector.md)
+
+### [Remove-RemoteDomain](Remove-RemoteDomain.md)
+
+### [Remove-ResubmitRequest](Remove-ResubmitRequest.md)
+
+### [Remove-RoutingGroupConnector](Remove-RoutingGroupConnector.md)
+
+### [Remove-SendConnector](Remove-SendConnector.md)
+
+### [Remove-SystemMessage](Remove-SystemMessage.md)
+
+### [Remove-X400AuthoritativeDomain](Remove-X400AuthoritativeDomain.md)
+
+### [Resume-Message](Resume-Message.md)
+
+### [Resume-Queue](Resume-Queue.md)
+
+### [Retry-Queue](Retry-Queue.md)
+
+### [Search-MessageTrackingReport](Search-MessageTrackingReport.md)
+
+### [Set-AcceptedDomain](Set-AcceptedDomain.md)
+
+### [Set-AddressRewriteEntry](Set-AddressRewriteEntry.md)
+
+### [Set-DeliveryAgentConnector](Set-DeliveryAgentConnector.md)
+
+### [Set-EdgeSyncServiceConfig](Set-EdgeSyncServiceConfig.md)
+
+### [Set-ForeignConnector](Set-ForeignConnector.md)
+
+### [Set-FrontendTransportService](Set-FrontendTransportService.md)
+
+### [Set-InboundConnector](Set-InboundConnector.md)
+
+### [Set-MailboxTransportService](Set-MailboxTransportService.md)
+
+### [Set-OutboundConnector](Set-OutboundConnector.md)
+
+### [Set-ReceiveConnector](Set-ReceiveConnector.md)
+
+### [Set-RemoteDomain](Set-RemoteDomain.md)
+
+### [Set-ResubmitRequest](Set-ResubmitRequest.md)
+
+### [Set-RoutingGroupConnector](Set-RoutingGroupConnector.md)
+
+### [Set-SendConnector](Set-SendConnector.md)
+
+### [Set-SystemMessage](Set-SystemMessage.md)
+
+### [Set-TransportAgent](Set-TransportAgent.md)
+
+### [Set-TransportConfig](Set-TransportConfig.md)
+
+### [Set-TransportServer](Set-TransportServer.md)
+
+### [Set-TransportService](Set-TransportService.md)
+
+### [Set-X400AuthoritativeDomain](Set-X400AuthoritativeDomain.md)
+
+### [Start-EdgeSynchronization](Start-EdgeSynchronization.md)
+
+### [Start-HistoricalSearch](Start-HistoricalSearch.md)
+
+### [Stop-HistoricalSearch](Stop-HistoricalSearch.md)
+
+### [Suspend-Message](Suspend-Message.md)
+
+### [Suspend-Queue](Suspend-Queue.md)
+
+### [Test-EdgeSynchronization](Test-EdgeSynchronization.md)
+
+### [Test-Mailflow](Test-Mailflow.md)
+
+### [Test-SmtpConnectivity](Test-SmtpConnectivity.md)
+
+### [Uninstall-TransportAgent](Uninstall-TransportAgent.md)
+
+### [Validate-OutboundConnector](Validate-OutboundConnector.md)
+
+## move-and-migration Cmdlets
+### [Complete-MigrationBatch](Complete-MigrationBatch.md)
+
+### [Export-MigrationReport](Export-MigrationReport.md)
+
+### [Get-MigrationBatch](Get-MigrationBatch.md)
+
+### [Get-MigrationConfig](Get-MigrationConfig.md)
+
+### [Get-MigrationEndpoint](Get-MigrationEndpoint.md)
+
+### [Get-MigrationStatistics](Get-MigrationStatistics.md)
+
+### [Get-MigrationUser](Get-MigrationUser.md)
+
+### [Get-MigrationUserStatistics](Get-MigrationUserStatistics.md)
+
+### [Get-MoveRequest](Get-MoveRequest.md)
+
+### [Get-MoveRequestStatistics](Get-MoveRequestStatistics.md)
+
+### [Get-PublicFolderMailboxMigrationRequest](Get-PublicFolderMailboxMigrationRequest.md)
+
+### [Get-PublicFolderMailboxMigrationRequestStatistics](Get-PublicFolderMailboxMigrationRequestStatistics.md)
+
+### [Get-PublicFolderMigrationRequest](Get-PublicFolderMigrationRequest.md)
+
+### [Get-PublicFolderMigrationRequestStatistics](Get-PublicFolderMigrationRequestStatistics.md)
+
+### [Get-PublicFolderMoveRequest](Get-PublicFolderMoveRequest.md)
+
+### [Get-PublicFolderMoveRequestStatistics](Get-PublicFolderMoveRequestStatistics.md)
+
+### [New-MigrationBatch](New-MigrationBatch.md)
+
+### [New-MigrationEndpoint](New-MigrationEndpoint.md)
+
+### [New-MoveRequest](New-MoveRequest.md)
+
+### [New-PublicFolderMigrationRequest](New-PublicFolderMigrationRequest.md)
+
+### [New-PublicFolderMoveRequest](New-PublicFolderMoveRequest.md)
+
+### [Remove-MigrationBatch](Remove-MigrationBatch.md)
+
+### [Remove-MigrationEndpoint](Remove-MigrationEndpoint.md)
+
+### [Remove-MigrationUser](Remove-MigrationUser.md)
+
+### [Remove-MoveRequest](Remove-MoveRequest.md)
+
+### [Remove-PublicFolderMailboxMigrationRequest](Remove-PublicFolderMailboxMigrationRequest.md)
+
+### [Remove-PublicFolderMigrationRequest](Remove-PublicFolderMigrationRequest.md)
+
+### [Remove-PublicFolderMoveRequest](Remove-PublicFolderMoveRequest.md)
+
+### [Resume-MoveRequest](Resume-MoveRequest.md)
+
+### [Resume-PublicFolderMigrationRequest](Resume-PublicFolderMigrationRequest.md)
+
+### [Resume-PublicFolderMoveRequest](Resume-PublicFolderMoveRequest.md)
+
+### [Set-MigrationBatch](Set-MigrationBatch.md)
+
+### [Set-MigrationConfig](Set-MigrationConfig.md)
+
+### [Set-MigrationEndpoint](Set-MigrationEndpoint.md)
+
+### [Set-MigrationUser](Set-MigrationUser.md)
+
+### [Set-MoveRequest](Set-MoveRequest.md)
+
+### [Set-PublicFolderMigrationRequest](Set-PublicFolderMigrationRequest.md)
+
+### [Set-PublicFolderMoveRequest](Set-PublicFolderMoveRequest.md)
+
+### [Start-MigrationBatch](Start-MigrationBatch.md)
+
+### [Start-MigrationUser](Start-MigrationUser.md)
+
+### [Stop-MigrationBatch](Stop-MigrationBatch.md)
+
+### [Stop-MigrationUser](Stop-MigrationUser.md)
+
+### [Suspend-MoveRequest](Suspend-MoveRequest.md)
+
+### [Suspend-PublicFolderMailboxMigrationRequest](Suspend-PublicFolderMailboxMigrationRequest.md)
+
+### [Suspend-PublicFolderMigrationRequest](Suspend-PublicFolderMigrationRequest.md)
+
+### [Suspend-PublicFolderMoveRequest](Suspend-PublicFolderMoveRequest.md)
+
+### [Test-MigrationServerAvailability](Test-MigrationServerAvailability.md)
+
+## organization Cmdlets
+### [Disable-CmdletExtensionAgent](Disable-CmdletExtensionAgent.md)
+
+### [Enable-CmdletExtensionAgent](Enable-CmdletExtensionAgent.md)
+
+### [Enable-OrganizationCustomization](Enable-OrganizationCustomization.md)
+
+### [Get-AccessToCustomerDataRequest](Get-AccessToCustomerDataRequest.md)
+
+### [Get-ApplicationAccessPolicy](Get-ApplicationAccessPolicy.md)
+
+### [Get-AuthConfig](Get-AuthConfig.md)
+
+### [Get-AuthenticationPolicy](Get-AuthenticationPolicy.md)
+
+### [Get-AuthServer](Get-AuthServer.md)
+
+### [Get-CmdletExtensionAgent](Get-CmdletExtensionAgent.md)
+
+### [Get-ExchangeAssistanceConfig](Get-ExchangeAssistanceConfig.md)
+
+### [Get-ExchangeDiagnosticInfo](Get-ExchangeDiagnosticInfo.md)
+
+### [Get-ExchangeServer](Get-ExchangeServer.md)
+
+### [Get-ExchangeServerAccessLicense](Get-ExchangeServerAccessLicense.md)
+
+### [Get-ExchangeServerAccessLicenseUser](Get-ExchangeServerAccessLicenseUser.md)
+
+### [Get-ExchangeSettings](Get-ExchangeSettings.md)
+
+### [Get-Notification](Get-Notification.md)
+
+### [Get-OrganizationConfig](Get-OrganizationConfig.md)
+
+### [Get-PartnerApplication](Get-PartnerApplication.md)
+
+### [Get-PerimeterConfig](Get-PerimeterConfig.md)
+
+### [Get-ServicePrincipal](Get-ServicePrincipal.md)
+
+### [Get-SettingOverride](Get-SettingOverride.md)
+
+### [New-ApplicationAccessPolicy](New-ApplicationAccessPolicy.md)
+
+### [New-AuthenticationPolicy](New-AuthenticationPolicy.md)
+
+### [New-AuthServer](New-AuthServer.md)
+
+### [New-ExchangeSettings](New-ExchangeSettings.md)
+
+### [New-PartnerApplication](New-PartnerApplication.md)
+
+### [New-ServicePrincipal](New-ServicePrincipal.md)
+
+### [New-SettingOverride](New-SettingOverride.md)
+
+### [Remove-ApplicationAccessPolicy](Remove-ApplicationAccessPolicy.md)
+
+### [Remove-AuthenticationPolicy](Remove-AuthenticationPolicy.md)
+
+### [Remove-AuthServer](Remove-AuthServer.md)
+
+### [Remove-PartnerApplication](Remove-PartnerApplication.md)
+
+### [Remove-ServicePrincipal](Remove-ServicePrincipal.md)
+
+### [Remove-SettingOverride](Remove-SettingOverride.md)
+
+### [Set-AccessToCustomerDataRequest](Set-AccessToCustomerDataRequest.md)
+
+### [Set-ApplicationAccessPolicy](Set-ApplicationAccessPolicy.md)
+
+### [Set-AuthConfig](Set-AuthConfig.md)
+
+### [Set-AuthenticationPolicy](Set-AuthenticationPolicy.md)
+
+### [Set-AuthServer](Set-AuthServer.md)
+
+### [Set-CmdletExtensionAgent](Set-CmdletExtensionAgent.md)
+
+### [Set-ExchangeAssistanceConfig](Set-ExchangeAssistanceConfig.md)
+
+### [Set-ExchangeServer](Set-ExchangeServer.md)
+
+### [Set-ExchangeSettings](Set-ExchangeSettings.md)
+
+### [Set-Notification](Set-Notification.md)
+
+### [Set-OrganizationConfig](Set-OrganizationConfig.md)
+
+### [Set-PartnerApplication](Set-PartnerApplication.md)
+
+### [Set-PerimeterConfig](Set-PerimeterConfig.md)
+
+### [Set-ServicePrincipal](Set-ServicePrincipal.md)
+
+### [Set-SettingOverride](Set-SettingOverride.md)
+
+### [Test-ApplicationAccessPolicy](Test-ApplicationAccessPolicy.md)
+
+### [Test-OAuthConnectivity](Test-OAuthConnectivity.md)
+
+### [Test-ServicePrincipalAuthorization](Test-ServicePrincipalAuthorization.md)
+
+### [Test-SystemHealth](Test-SystemHealth.md)
+
+### [Update-ExchangeHelp](Update-ExchangeHelp.md)
+
+## policy-and-compliance Cmdlets
+### [Disable-JournalArchiving](Disable-JournalArchiving.md)
+
+### [Disable-JournalRule](Disable-JournalRule.md)
+
+### [Disable-OutlookProtectionRule](Disable-OutlookProtectionRule.md)
+
+### [Disable-TransportRule](Disable-TransportRule.md)
+
+### [Enable-JournalRule](Enable-JournalRule.md)
+
+### [Enable-OutlookProtectionRule](Enable-OutlookProtectionRule.md)
+
+### [Enable-TransportRule](Enable-TransportRule.md)
+
+### [Execute-AzureADLabelSync](Execute-AzureADLabelSync.md)
+
+### [Export-JournalRuleCollection](Export-JournalRuleCollection.md)
+
+### [Export-TransportRuleCollection](Export-TransportRuleCollection.md)
+
+### [Get-ActivityAlert](Get-ActivityAlert.md)
+
+### [Get-AdministrativeUnit](Get-AdministrativeUnit.md)
+
+### [Get-AutoSensitivityLabelPolicy](Get-AutoSensitivityLabelPolicy.md)
+
+### [Get-AutoSensitivityLabelRule](Get-AutoSensitivityLabelRule.md)
+
+### [Get-EtrLimits](Get-EtrLimits.md)
+
+### [Get-ExoInformationBarrierPolicy](Get-ExoInformationBarrierPolicy.md)
+
+### [Get-ExoInformationBarrierSegment](Get-ExoInformationBarrierSegment.md)
+
+### [Get-ExoInformationBarrierRelationship](Get-ExoInformationBarrierRelationship.md)
+
+### [Get-InformationBarrierPoliciesApplicationStatus](Get-InformationBarrierPoliciesApplicationStatus.md)
+
+### [Get-InformationBarrierPolicy](Get-InformationBarrierPolicy.md)
+
+### [Get-InformationBarrierRecipientStatus](Get-InformationBarrierRecipientStatus.md)
+
+### [Get-JournalRule](Get-JournalRule.md)
+
+### [Get-Label](Get-Label.md)
+
+### [Get-LabelPolicy](Get-LabelPolicy.md)
+
+### [Get-MessageClassification](Get-MessageClassification.md)
+
+### [Get-OrganizationSegment](Get-OrganizationSegment.md)
+
+### [Get-OutlookProtectionRule](Get-OutlookProtectionRule.md)
+
+### [Get-ProtectionAlert](Get-ProtectionAlert.md)
+
+### [Get-ReviewItems](Get-ReviewItems.md)
+
+### [Get-SupervisoryReviewPolicyV2](Get-SupervisoryReviewPolicyV2.md)
+
+### [Get-SupervisoryReviewRule](Get-SupervisoryReviewRule.md)
+
+### [Get-TransportRule](Get-TransportRule.md)
+
+### [Get-TransportRuleAction](Get-TransportRuleAction.md)
+
+### [Get-TransportRulePredicate](Get-TransportRulePredicate.md)
+
+### [Import-JournalRuleCollection](Import-JournalRuleCollection.md)
+
+### [Import-TransportRuleCollection](Import-TransportRuleCollection.md)
+
+### [Install-UnifiedCompliancePrerequisite](Install-UnifiedCompliancePrerequisite.md)
+
+### [New-ActivityAlert](New-ActivityAlert.md)
+
+### [New-AutoSensitivityLabelPolicy](New-AutoSensitivityLabelPolicy.md)
+
+### [New-AutoSensitivityLabelRule](New-AutoSensitivityLabelRule.md)
+
+### [New-InformationBarrierPolicy](New-InformationBarrierPolicy.md)
+
+### [New-JournalRule](New-JournalRule.md)
+
+### [New-Label](New-Label.md)
+
+### [New-LabelPolicy](New-LabelPolicy.md)
+
+### [New-MessageClassification](New-MessageClassification.md)
+
+### [New-OrganizationSegment](New-OrganizationSegment.md)
+
+### [New-OutlookProtectionRule](New-OutlookProtectionRule.md)
+
+### [New-ProtectionAlert](New-ProtectionAlert.md)
+
+### [New-SupervisoryReviewPolicyV2](New-SupervisoryReviewPolicyV2.md)
+
+### [New-SupervisoryReviewRule](New-SupervisoryReviewRule.md)
+
+### [New-TransportRule](New-TransportRule.md)
+
+### [Remove-ActivityAlert](Remove-ActivityAlert.md)
+
+### [Remove-AutoSensitivityLabelPolicy](Remove-AutoSensitivityLabelPolicy.md)
+
+### [Remove-AutoSensitivityLabelRule](Remove-AutoSensitivityLabelRule.md)
+
+### [Remove-InformationBarrierPolicy](Remove-InformationBarrierPolicy.md)
+
+### [Remove-JournalRule](Remove-JournalRule.md)
+
+### [Remove-Label](Remove-Label.md)
+
+### [Remove-LabelPolicy](Remove-LabelPolicy.md)
+
+### [Remove-MessageClassification](Remove-MessageClassification.md)
+
+### [Remove-OrganizationSegment](Remove-OrganizationSegment.md)
+
+### [Remove-OutlookProtectionRule](Remove-OutlookProtectionRule.md)
+
+### [Remove-ProtectionAlert](Remove-ProtectionAlert.md)
+
+### [Remove-RecordLabel](Remove-RecordLabel.md)
+
+### [Remove-SupervisoryReviewPolicyV2](Remove-SupervisoryReviewPolicyV2.md)
+
+### [Remove-TransportRule](Remove-TransportRule.md)
+
+### [Set-ActivityAlert](Set-ActivityAlert.md)
+
+### [Set-AutoSensitivityLabelPolicy](Set-AutoSensitivityLabelPolicy.md)
+
+### [Set-AutoSensitivityLabelRule](Set-AutoSensitivityLabelRule.md)
+
+### [Set-InformationBarrierPolicy](Set-InformationBarrierPolicy.md)
+
+### [Set-JournalRule](Set-JournalRule.md)
+
+### [Set-Label](Set-Label.md)
+
+### [Set-LabelPolicy](Set-LabelPolicy.md)
+
+### [Set-MessageClassification](Set-MessageClassification.md)
+
+### [Set-OrganizationSegment](Set-OrganizationSegment.md)
+
+### [Set-OutlookProtectionRule](Set-OutlookProtectionRule.md)
+
+### [Set-ProtectionAlert](Set-ProtectionAlert.md)
+
+### [Set-SupervisoryReviewPolicyV2](Set-SupervisoryReviewPolicyV2.md)
+
+### [Set-SupervisoryReviewRule](Set-SupervisoryReviewRule.md)
+
+### [Set-TransportRule](Set-TransportRule.md)
+
+### [Start-InformationBarrierPoliciesApplication](Start-InformationBarrierPoliciesApplication.md)
+
+### [Stop-InformationBarrierPoliciesApplication](Stop-InformationBarrierPoliciesApplication.md)
+
+### [Test-ArchiveConnectivity](Test-ArchiveConnectivity.md)
+
+## policy-and-compliance-audit Cmdlets
+### [Get-AdminAuditLogConfig](Get-AdminAuditLogConfig.md)
+
+### [Get-AuditConfig](Get-AuditConfig.md)
+
+### [Get-AuditConfigurationPolicy](Get-AuditConfigurationPolicy.md)
+
+### [Get-AuditConfigurationRule](Get-AuditConfigurationRule.md)
+
+### [Get-AuditLogSearch](Get-AuditLogSearch.md)
+
+### [Get-MailboxAuditBypassAssociation](Get-MailboxAuditBypassAssociation.md)
+
+### [Get-UnifiedAuditLogRetentionPolicy](Get-UnifiedAuditLogRetentionPolicy.md)
+
+### [New-AdminAuditLogSearch](New-AdminAuditLogSearch.md)
+
+### [New-AuditConfigurationPolicy](New-AuditConfigurationPolicy.md)
+
+### [New-AuditConfigurationRule](New-AuditConfigurationRule.md)
+
+### [New-MailboxAuditLogSearch](New-MailboxAuditLogSearch.md)
+
+### [New-UnifiedAuditLogRetentionPolicy](New-UnifiedAuditLogRetentionPolicy.md)
+
+### [Remove-AuditConfigurationPolicy](Remove-AuditConfigurationPolicy.md)
+
+### [Remove-AuditConfigurationRule](Remove-AuditConfigurationRule.md)
+
+### [Remove-UnifiedAuditLogRetentionPolicy](Remove-UnifiedAuditLogRetentionPolicy.md)
+
+### [Search-AdminAuditLog](Search-AdminAuditLog.md)
+
+### [Search-MailboxAuditLog](Search-MailboxAuditLog.md)
+
+### [Search-UnifiedAuditLog](Search-UnifiedAuditLog.md)
+
+### [Set-AdminAuditLogConfig](Set-AdminAuditLogConfig.md)
+
+### [Set-AuditConfig](Set-AuditConfig.md)
+
+### [Set-AuditConfigurationRule](Set-AuditConfigurationRule.md)
+
+### [Set-MailboxAuditBypassAssociation](Set-MailboxAuditBypassAssociation.md)
+
+### [Set-UnifiedAuditLogRetentionPolicy](Set-UnifiedAuditLogRetentionPolicy.md)
+
+### [Write-AdminAuditLog](Write-AdminAuditLog.md)
+
+## policy-and-compliance-content-search Cmdlets
+### [Get-ComplianceSearch](Get-ComplianceSearch.md)
+
+### [Get-ComplianceSearchAction](Get-ComplianceSearchAction.md)
+
+### [Get-ComplianceSecurityFilter](Get-ComplianceSecurityFilter.md)
+
+### [Get-MailboxSearch](Get-MailboxSearch.md)
+
+### [Invoke-ComplianceSearchActionStep](Invoke-ComplianceSearchActionStep.md)
+
+### [New-ComplianceSearch](New-ComplianceSearch.md)
+
+### [New-ComplianceSearchAction](New-ComplianceSearchAction.md)
+
+### [New-ComplianceSecurityFilter](New-ComplianceSecurityFilter.md)
+
+### [New-MailboxSearch](New-MailboxSearch.md)
+
+### [Remove-ComplianceSearch](Remove-ComplianceSearch.md)
+
+### [Remove-ComplianceSearchAction](Remove-ComplianceSearchAction.md)
+
+### [Remove-ComplianceSecurityFilter](Remove-ComplianceSecurityFilter.md)
+
+### [Remove-MailboxSearch](Remove-MailboxSearch.md)
+
+### [Set-ComplianceSearch](Set-ComplianceSearch.md)
+
+### [Set-ComplianceSearchAction](Set-ComplianceSearchAction.md)
+
+### [Set-ComplianceSecurityFilter](Set-ComplianceSecurityFilter.md)
+
+### [Set-MailboxSearch](Set-MailboxSearch.md)
+
+### [Start-ComplianceSearch](Start-ComplianceSearch.md)
+
+### [Start-MailboxSearch](Start-MailboxSearch.md)
+
+### [Stop-ComplianceSearch](Stop-ComplianceSearch.md)
+
+### [Stop-MailboxSearch](Stop-MailboxSearch.md)
+
+## policy-and-compliance-dlp Cmdlets
+### [Export-ActivityExplorerData](Export-ActivityExplorerData.md)
+
+### [Export-DlpPolicyCollection](Export-DlpPolicyCollection.md)
+
+### [Get-ClassificationRuleCollection](Get-ClassificationRuleCollection.md)
+
+### [Get-DataClassification](Get-DataClassification.md)
+
+### [Get-DataClassificationConfig](Get-DataClassificationConfig.md)
+
+### [Get-DlpCompliancePolicy](Get-DlpCompliancePolicy.md)
+
+### [Get-DlpComplianceRule](Get-DlpComplianceRule.md)
+
+### [Get-DlpDetailReport](Get-DlpDetailReport.md)
+
+### [Get-DlpDetectionsReport](Get-DlpDetectionsReport.md)
+
+### [Get-DlpEdmSchema](Get-DlpEdmSchema.md)
+
+### [Get-DlpIncidentDetailReport](Get-DlpIncidentDetailReport.md)
+
+### [Get-DlpKeywordDictionary](Get-DlpKeywordDictionary.md)
+
+### [Get-DlpPolicy](Get-DlpPolicy.md)
+
+### [Get-DlpPolicyTemplate](Get-DlpPolicyTemplate.md)
+
+### [Get-DlpSensitiveInformationType](Get-DlpSensitiveInformationType.md)
+
+### [Get-DlpSensitiveInformationTypeRulePackage](Get-DlpSensitiveInformationTypeRulePackage.md)
+
+### [Get-DlpSiDetectionsReport](Get-DlpSiDetectionsReport.md)
+
+### [Get-PolicyConfig](Get-PolicyConfig.md)
+
+### [Get-PolicyTipConfig](Get-PolicyTipConfig.md)
+
+### [Import-DlpPolicyCollection](Import-DlpPolicyCollection.md)
+
+### [Import-DlpPolicyTemplate](Import-DlpPolicyTemplate.md)
+
+### [New-ClassificationRuleCollection](New-ClassificationRuleCollection.md)
+
+### [New-DataClassification](New-DataClassification.md)
+
+### [New-DlpCompliancePolicy](New-DlpCompliancePolicy.md)
+
+### [New-DlpComplianceRule](New-DlpComplianceRule.md)
+
+### [New-DlpEdmSchema](New-DlpEdmSchema.md)
+
+### [New-DlpFingerprint](New-DlpFingerprint.md)
+
+### [New-DlpKeywordDictionary](New-DlpKeywordDictionary.md)
+
+### [New-DlpPolicy](New-DlpPolicy.md)
+
+### [New-DlpSensitiveInformationType](New-DlpSensitiveInformationType.md)
+
+### [New-DlpSensitiveInformationTypeRulePackage](New-DlpSensitiveInformationTypeRulePackage.md)
+
+### [New-Fingerprint](New-Fingerprint.md)
+
+### [New-PolicyTipConfig](New-PolicyTipConfig.md)
+
+### [Remove-ClassificationRuleCollection](Remove-ClassificationRuleCollection.md)
+
+### [Remove-DataClassification](Remove-DataClassification.md)
+
+### [Remove-DlpCompliancePolicy](Remove-DlpCompliancePolicy.md)
+
+### [Remove-DlpComplianceRule](Remove-DlpComplianceRule.md)
+
+### [Remove-DlpEdmSchema](Remove-DlpEdmSchema.md)
+
+### [Remove-DlpKeywordDictionary](Remove-DlpKeywordDictionary.md)
+
+### [Remove-DlpPolicy](Remove-DlpPolicy.md)
+
+### [Remove-DlpPolicyTemplate](Remove-DlpPolicyTemplate.md)
+
+### [Remove-DlpSensitiveInformationType](Remove-DlpSensitiveInformationType.md)
+
+### [Remove-DlpSensitiveInformationTypeRulePackage](Remove-DlpSensitiveInformationTypeRulePackage.md)
+
+### [Remove-PolicyTipConfig](Remove-PolicyTipConfig.md)
+
+### [Set-ClassificationRuleCollection](Set-ClassificationRuleCollection.md)
+
+### [Set-DataClassification](Set-DataClassification.md)
+
+### [Set-DlpCompliancePolicy](Set-DlpCompliancePolicy.md)
+
+### [Set-DlpComplianceRule](Set-DlpComplianceRule.md)
+
+### [Set-DlpEdmSchema](Set-DlpEdmSchema.md)
+
+### [Set-DlpKeywordDictionary](Set-DlpKeywordDictionary.md)
+
+### [Set-DlpPolicy](Set-DlpPolicy.md)
+
+### [Set-DlpSensitiveInformationType](Set-DlpSensitiveInformationType.md)
+
+### [Set-DlpSensitiveInformationTypeRulePackage](Set-DlpSensitiveInformationTypeRulePackage.md)
+
+### [Set-PolicyConfig](Set-PolicyConfig.md)
+
+### [Set-PolicyTipConfig](Set-PolicyTipConfig.md)
+
+### [Test-DataClassification](Test-DataClassification.md)
+
+### [Test-TextExtraction](Test-TextExtraction.md)
+
+## policy-and-compliance-ediscovery Cmdlets
+### [Add-ComplianceCaseMember](Add-ComplianceCaseMember.md)
+
+### [Add-eDiscoveryCaseAdmin](Add-eDiscoveryCaseAdmin.md)
+
+### [Get-CaseHoldPolicy](Get-CaseHoldPolicy.md)
+
+### [Get-CaseHoldRule](Get-CaseHoldRule.md)
+
+### [Get-ComplianceCase](Get-ComplianceCase.md)
+
+### [Get-ComplianceCaseMember](Get-ComplianceCaseMember.md)
+
+### [Get-eDiscoveryCaseAdmin](Get-eDiscoveryCaseAdmin.md)
+
+### [New-CaseHoldPolicy](New-CaseHoldPolicy.md)
+
+### [New-CaseHoldRule](New-CaseHoldRule.md)
+
+### [New-ComplianceCase](New-ComplianceCase.md)
+
+### [Remove-CaseHoldPolicy](Remove-CaseHoldPolicy.md)
+
+### [Remove-CaseHoldRule](Remove-CaseHoldRule.md)
+
+### [Remove-ComplianceCase](Remove-ComplianceCase.md)
+
+### [Remove-ComplianceCaseMember](Remove-ComplianceCaseMember.md)
+
+### [Remove-eDiscoveryCaseAdmin](Remove-eDiscoveryCaseAdmin.md)
+
+### [Set-CaseHoldPolicy](Set-CaseHoldPolicy.md)
+
+### [Set-CaseHoldRule](Set-CaseHoldRule.md)
+
+### [Set-ComplianceCase](Set-ComplianceCase.md)
+
+### [Update-ComplianceCaseMember](Update-ComplianceCaseMember.md)
+
+### [Update-eDiscoveryCaseAdmin](Update-eDiscoveryCaseAdmin.md)
+
+## policy-and-compliance-retention Cmdlets
+### [Enable-ComplianceTagStorage](Enable-ComplianceTagStorage.md)
+
+### [Export-ContentExplorerData](Export-ContentExplorerData.md)
+
+### [Export-FilePlanProperty](Export-FilePlanProperty.md)
+
+### [Get-AdaptiveScope](Get-AdaptiveScope.md)
+
+### [Get-AppRetentionCompliancePolicy](Get-AppRetentionCompliancePolicy.md)
+
+### [Get-AppRetentionComplianceRule](Get-AppRetentionComplianceRule.md)
+
+### [Get-ComplianceRetentionEvent](Get-ComplianceRetentionEvent.md)
+
+### [Get-ComplianceRetentionEventType](Get-ComplianceRetentionEventType.md)
+
+### [Get-ComplianceTag](Get-ComplianceTag.md)
+
+### [Get-ComplianceTagStorage](Get-ComplianceTagStorage.md)
+
+### [Get-DataRetentionReport](Get-DataRetentionReport.md)
+
+### [Get-FilePlanPropertyAuthority](Get-FilePlanPropertyAuthority.md)
+
+### [Get-FilePlanPropertyCategory](Get-FilePlanPropertyCategory.md)
+
+### [Get-FilePlanPropertyCitation](Get-FilePlanPropertyCitation.md)
+
+### [Get-FilePlanPropertyDepartment](Get-FilePlanPropertyDepartment.md)
+
+### [Get-FilePlanPropertyReferenceId](Get-FilePlanPropertyReferenceId.md)
+
+### [Get-FilePlanPropertyStructure](Get-FilePlanPropertyStructur.md)
+
+### [Get-FilePlanPropertySubCategory](Get-FilePlanPropertySubCategory.md)
+
+### [Get-HoldCompliancePolicy](Get-HoldCompliancePolicy.md)
+
+### [Get-HoldComplianceRule](Get-HoldComplianceRule.md)
+
+### [Get-ManagedContentSettings](Get-ManagedContentSettings.md)
+
+### [Get-ManagedFolder](Get-ManagedFolder.md)
+
+### [Get-ManagedFolderMailboxPolicy](Get-ManagedFolderMailboxPolicy.md)
+
+### [Get-RecordReviewNotificationTemplateConfig](Get-RecordReviewNotificationTemplateConfig.md)
+
+### [Get-RegulatoryComplianceUI](Get-RegulatoryComplianceUI.md)
+
+### [Get-RetentionCompliancePolicy](Get-RetentionCompliancePolicy.md)
+
+### [Get-RetentionComplianceRule](Get-RetentionComplianceRule.md)
+
+### [Get-RetentionEvent](Get-RetentionEvent.md)
+
+### [Get-RetentionPolicy](Get-RetentionPolicy.md)
+
+### [Get-RetentionPolicyTag](Get-RetentionPolicyTag.md)
+
+### [Import-FilePlanProperty](Import-FilePlanProperty.md)
+
+### [Invoke-HoldRemovalAction](Invoke-HoldRemovalAction.md)
+
+### [New-AdaptiveScope](New-AdaptiveScope.md)
+
+### [New-AppRetentionCompliancePolicy](New-AppRetentionCompliancePolicy.md)
+
+### [New-AppRetentionComplianceRule](New-AppRetentionComplianceRule.md)
+
+### [New-ComplianceRetentionEvent](New-ComplianceRetentionEvent.md)
+
+### [New-ComplianceRetentionEventType](New-ComplianceRetentionEventType.md)
+
+### [New-ComplianceTag](New-ComplianceTag.md)
+
+### [New-FilePlanPropertyAuthority](New-FilePlanPropertyAuthority.md)
+
+### [New-FilePlanPropertyCategory](New-FilePlanPropertyCategory.md)
+
+### [New-FilePlanPropertyCitation](New-FilePlanPropertyCitation.md)
+
+### [New-FilePlanPropertyDepartment](New-FilePlanPropertyDepartment.md)
+
+### [New-FilePlanPropertyReferenceId](New-FilePlanPropertyReferenceId.md)
+
+### [New-FilePlanPropertySubCategory](New-FilePlanPropertySubCategory.md)
+
+### [New-HoldCompliancePolicy](New-HoldCompliancePolicy.md)
+
+### [New-HoldComplianceRule](New-HoldComplianceRule.md)
+
+### [New-ManagedContentSettings](New-ManagedContentSettings.md)
+
+### [New-ManagedFolder](New-ManagedFolder.md)
+
+### [New-ManagedFolderMailboxPolicy](New-ManagedFolderMailboxPolicy.md)
+
+### [New-RetentionCompliancePolicy](New-RetentionCompliancePolicy.md)
+
+### [New-RetentionComplianceRule](New-RetentionComplianceRule.md)
+
+### [New-RetentionPolicy](New-RetentionPolicy.md)
+
+### [New-RetentionPolicyTag](New-RetentionPolicyTag.md)
+
+### [Remove-AdaptiveScope](Remove-AdaptiveScope.md)
+
+### [Remove-AppRetentionCompliancePolicy](Remove-AppRetentionCompliancePolicy.md)
+
+### [Remove-AppRetentionComplianceRule](Remove-AppRetentionComplianceRule.md)
+
+### [Remove-ComplianceRetentionEventType](Remove-ComplianceRetentionEventType.md)
+
+### [Remove-ComplianceTag](Remove-ComplianceTag.md)
+
+### [Remove-FilePlanPropertyAuthority](Remove-FilePlanPropertyAuthority.md)
+
+### [Remove-FilePlanPropertyCategory](Remove-FilePlanPropertyCategory.md)
+
+### [Remove-FilePlanPropertyCitation](Remove-FilePlanPropertyCitation.md)
+
+### [Remove-FilePlanPropertyDepartment](Remove-FilePlanPropertyDepartment.md)
+
+### [Remove-FilePlanPropertyReferenceId](Remove-FilePlanPropertyReferenceId.md)
+
+### [Remove-FilePlanPropertySubCategory](Remove-FilePlanPropertySubCategor.md)
+
+### [Remove-HoldCompliancePolicy](Remove-HoldCompliancePolicy.md)
+
+### [Remove-HoldComplianceRule](Remove-HoldComplianceRule.md)
+
+### [Remove-ManagedContentSettings](Remove-ManagedContentSettings.md)
+
+### [Remove-ManagedFolder](Remove-ManagedFolder.md)
+
+### [Remove-ManagedFolderMailboxPolicy](Remove-ManagedFolderMailboxPolicy.md)
+
+### [Remove-RetentionCompliancePolicy](Remove-RetentionCompliancePolicy.md)
+
+### [Remove-RetentionComplianceRule](Remove-RetentionComplianceRule.md)
+
+### [Remove-RetentionPolicy](Remove-RetentionPolicy.md)
+
+### [Remove-RetentionPolicyTag](Remove-RetentionPolicyTag.md)
+
+### [Set-AdaptiveScope](Set-AdaptiveScope.md)
+
+### [Set-AppRetentionCompliancePolicy](Set-AppRetentionCompliancePolicy.md)
+
+### [Set-AppRetentionComplianceRule](Set-AppRetentionComplianceRule.md)
+
+### [Set-ComplianceRetentionEventType](Set-ComplianceRetentionEventType.md)
+
+### [Set-ComplianceTag](Set-ComplianceTag.md)
+
+### [Set-FilePlanPropertyAuthority](Set-FilePlanPropertyAuthorit.md)
+
+### [Set-FilePlanPropertyCategory](Set-FilePlanPropertyCategory.md)
+
+### [Set-FilePlanPropertyCitation](Set-FilePlanPropertyCitation.md)
+
+### [Set-FilePlanPropertyDepartment](Set-FilePlanPropertyDepartment.md)
+
+### [Set-FilePlanPropertyReferenceId](Set-FilePlanPropertyReferenceId.md)
+
+### [Set-FilePlanPropertySubCategory](Set-FilePlanPropertySubCategory.md)
+
+### [Set-HoldCompliancePolicy](Set-HoldCompliancePolicy.md)
+
+### [Set-HoldComplianceRule](Set-HoldComplianceRule.md)
+
+### [Set-ManagedContentSettings](Set-ManagedContentSettings.md)
+
+### [Set-ManagedFolder](Set-ManagedFolder.md)
+
+### [Set-ManagedFolderMailboxPolicy](Set-ManagedFolderMailboxPolicy.md)
+
+### [Set-RecordReviewNotificationTemplateConfig](Set-RecordReviewNotificationTemplateConfig.md)
+
+### [Set-RegulatoryComplianceUI](Set-RegulatoryComplianceUI.md)
+
+### [Set-RetentionCompliancePolicy](Set-RetentionCompliancePolicy.md)
+
+### [Set-RetentionComplianceRule](Set-RetentionComplianceRule.md)
+
+### [Set-RetentionPolicy](Set-RetentionPolicy.md)
+
+### [Set-RetentionPolicyTag](Set-RetentionPolicyTag.md)
+
+### [Start-ManagedFolderAssistant](Start-ManagedFolderAssistant.md)
+
+### [Start-RetentionAutoTagLearning](Start-RetentionAutoTagLearning.md)
+
+### [Stop-ManagedFolderAssistant](Stop-ManagedFolderAssistant.md)
+
+### [Validate-RetentionRuleQuery](Validate-RetentionRuleQuery.md)
+
+## powershell-v3-module Cmdlets
+### [Add-VivaModuleFeaturePolicy](Add-VivaModuleFeaturePolicy.md)
+
+### [Connect-ExchangeOnline](Connect-ExchangeOnline.md)
+
+### [Connect-IPPSSession](Connect-IPPSSession.md)
+
+### [Disconnect-ExchangeOnline](Disconnect-ExchangeOnline.md)
+
+### [Get-ConnectionInformation](Get-ConnectionInformation.md)
+
+### [Get-DefaultTenantBriefingConfig](Get-DefaultTenantBriefingConfig.md)
+
+### [Get-DefaultTenantMyAnalyticsFeatureConfig](Get-DefaultTenantMyAnalyticsFeatureConfig.md)
+
+### [Get-EXOCasMailbox](Get-EXOCasMailbox.md)
+
+### [Get-EXOMailbox](Get-EXOMailbox.md)
+
+### [Get-EXOMailboxFolderPermission](Get-EXOMailboxFolderPermission.md)
+
+### [Get-EXOMailboxFolderStatistics](Get-EXOMailboxFolderStatistics.md)
+
+### [Get-EXOMailboxPermission](Get-EXOMailboxPermission.md)
+
+### [Get-EXOMailboxStatistics](Get-EXOMailboxStatistics.md)
+
+### [Get-EXOMobileDeviceStatistics](Get-EXOMobileDeviceStatistics.md)
+
+### [Get-EXORecipient](Get-EXORecipient.md)
+
+### [Get-EXORecipientPermission](Get-EXORecipientPermission.md)
+
+### [Get-MyAnalyticsFeatureConfig](Get-MyAnalyticsFeatureConfig.md)
+
+### [Get-UserBriefingConfig](Get-UserBriefingConfig.md)
+
+### [Get-VivaInsightsSettings](Get-VivaInsightsSettings.md)
+
+### [Get-VivaModuleFeature](Get-VivaModuleFeature.md)
+
+### [Get-VivaModuleFeatureEnablement](Get-VivaModuleFeatureEnablement.md)
+
+### [Get-VivaModuleFeaturePolicy](Get-VivaModuleFeaturePolicy.md)
+
+### [Remove-VivaModuleFeaturePolicy](Remove-VivaModuleFeaturePolicy.md)
+
+### [Set-DefaultTenantBriefingConfig](Set-DefaultTenantBriefingConfig.md)
+
+### [Set-DefaultTenantMyAnalyticsFeatureConfig](Set-DefaultTenantMyAnalyticsFeatureConfig.md)
+
+### [Set-MyAnalyticsFeatureConfig](Set-MyAnalyticsFeatureConfig.md)
+
+### [Set-UserBriefingConfig](Set-UserBriefingConfig.md)
+
+### [Set-VivaInsightsSettings](Set-VivaInsightsSettings.md)
+
+### [Update-VivaModuleFeaturePolicy](Update-VivaModuleFeaturePolicy.md)
+
+## reporting Cmdlets
+### [Get-CompromisedUserAggregateReport](Get-CompromisedUserAggregateReport.md)
+
+### [Get-CompromisedUserDetailReport](Get-CompromisedUserDetailReport.md)
+
+### [Get-ConnectionByClientTypeDetailReport](Get-ConnectionByClientTypeDetailReport.md)
+
+### [Get-ConnectionByClientTypeReport](Get-ConnectionByClientTypeReport.md)
+
+### [Get-CsActiveUserReport](Get-CsActiveUserReport.md)
+
+### [Get-CsAVConferenceTimeReport](Get-CsAVConferenceTimeReport.md)
+
+### [Get-CsClientDeviceDetailReport](Get-CsClientDeviceDetailReport.md)
+
+### [Get-CsClientDeviceReport](Get-CsClientDeviceReport.md)
+
+### [Get-CsConferenceReport](Get-CsConferenceReport.md)
+
+### [Get-CsP2PAVTimeReport](Get-CsP2PAVTimeReport.md)
+
+### [Get-CsP2PSessionReport](Get-CsP2PSessionReport.md)
+
+### [Get-CsPSTNConferenceTimeReport](Get-CsPSTNConferenceTimeReport.md)
+
+### [Get-CsPSTNUsageDetailReport](Get-CsPSTNUsageDetailReport.md)
+
+### [Get-CsUserActivitiesReport](Get-CsUserActivitiesReport.md)
+
+### [Get-CsUsersBlockedReport](Get-CsUsersBlockedReport.md)
+
+### [Get-GroupActivityReport](Get-GroupActivityReport.md)
+
+### [Get-HistoricalSearch](Get-HistoricalSearch.md)
+
+### [Get-LicenseVsUsageSummaryReport](Get-LicenseVsUsageSummaryReport.md)
+
+### [Get-LogonStatistics](Get-LogonStatistics.md)
+
+### [Get-MailboxActivityReport](Get-MailboxActivityReport.md)
+
+### [Get-MailboxUsageDetailReport](Get-MailboxUsageDetailReport.md)
+
+### [Get-MailboxUsageReport](Get-MailboxUsageReport.md)
+
+### [Get-MailDetailDlpPolicyReport](Get-MailDetailDlpPolicyReport.md)
+
+### [Get-MailDetailEncryptionReport](Get-MailDetailEncryptionReport.md)
+
+### [Get-MailDetailTransportRuleReport](Get-MailDetailTransportRuleReport.md)
+
+### [Get-MailFilterListReport](Get-MailFilterListReport.md)
+
+### [Get-MailflowStatusReport](Get-MailflowStatusReport.md)
+
+### [Get-MailTrafficEncryptionReport](Get-MailTrafficEncryptionReport.md)
+
+### [Get-MailTrafficPolicyReport](Get-MailTrafficPolicyReport.md)
+
+### [Get-MailTrafficSummaryReport](Get-MailTrafficSummaryReport.md)
+
+### [Get-MxRecordReport](Get-MxRecordReport.md)
+
+### [Get-O365ClientBrowserDetailReport](Get-O365ClientBrowserDetailReport.md)
+
+### [Get-O365ClientBrowserReport](Get-O365ClientBrowserReport.md)
+
+### [Get-O365ClientOSDetailReport](Get-O365ClientOSDetailReport.md)
+
+### [Get-O365ClientOSReport](Get-O365ClientOSReport.md)
+
+### [Get-OutboundConnectorReport](Get-OutboundConnectorReport.md)
+
+### [Get-RecipientStatisticsReport](Get-RecipientStatisticsReport.md)
+
+### [Get-ReportExecutionInstance](Get-ReportExecutionInstance.md)
+
+### [Get-SCInsights](Get-SCInsights.md)
+
+### [Get-ServiceDeliveryReport](Get-ServiceDeliveryReport.md)
+
+### [Get-SPOActiveUserReport](Get-SPOActiveUserReport.md)
+
+### [Get-SPOSkyDriveProDeployedReport](Get-SPOSkyDriveProDeployedReport.md)
+
+### [Get-SPOSkyDriveProStorageReport](Get-SPOSkyDriveProStorageReport.md)
+
+### [Get-SPOTeamSiteDeployedReport](Get-SPOTeamSiteDeployedReport.md)
+
+### [Get-SPOTeamSiteStorageReport](Get-SPOTeamSiteStorageReport.md)
+
+### [Get-SPOTenantStorageMetricReport](Get-SPOTenantStorageMetricReport.md)
+
+### [Get-StaleMailboxDetailReport](Get-StaleMailboxDetailReport.md)
+
+### [Get-StaleMailboxReport](Get-StaleMailboxReport.md)
+
+### [Get-SupervisoryReviewActivity](Get-SupervisoryReviewActivity.md)
+
+### [Get-SupervisoryReviewOverallProgressReport](Get-SupervisoryReviewOverallProgressReport.md)
+
+### [Get-SupervisoryReviewPolicyReport](Get-SupervisoryReviewPolicyReport.md)
+
+### [Get-SupervisoryReviewReport](Get-SupervisoryReviewReport.md)
+
+### [Get-SupervisoryReviewTopCasesReport](Get-SupervisoryReviewTopCasesReport.md)
+
+### [Test-Message](Test-Message.md)
+
+## role-based-access-control Cmdlets
+### [Add-ManagementRoleEntry](Add-ManagementRoleEntry.md)
+
+### [Add-RoleGroupMember](Add-RoleGroupMember.md)
+
+### [Get-ManagementRole](Get-ManagementRole.md)
+
+### [Get-ManagementRoleAssignment](Get-ManagementRoleAssignment.md)
+
+### [Get-ManagementRoleEntry](Get-ManagementRoleEntry.md)
+
+### [Get-ManagementScope](Get-ManagementScope.md)
+
+### [Get-RoleAssignmentPolicy](Get-RoleAssignmentPolicy.md)
+
+### [Get-RoleGroup](Get-RoleGroup.md)
+
+### [Get-RoleGroupMember](Get-RoleGroupMember.md)
+
+### [New-ManagementRole](New-ManagementRole.md)
+
+### [New-ManagementRoleAssignment](New-ManagementRoleAssignment.md)
+
+### [New-ManagementScope](New-ManagementScope.md)
+
+### [New-RoleAssignmentPolicy](New-RoleAssignmentPolicy.md)
+
+### [New-RoleGroup](New-RoleGroup.md)
+
+### [Remove-ManagementRole](Remove-ManagementRole.md)
+
+### [Remove-ManagementRoleAssignment](Remove-ManagementRoleAssignment.md)
+
+### [Remove-ManagementRoleEntry](Remove-ManagementRoleEntry.md)
+
+### [Remove-ManagementScope](Remove-ManagementScope.md)
+
+### [Remove-RoleAssignmentPolicy](Remove-RoleAssignmentPolicy.md)
+
+### [Remove-RoleGroup](Remove-RoleGroup.md)
+
+### [Remove-RoleGroupMember](Remove-RoleGroupMember.md)
+
+### [Set-ManagementRoleAssignment](Set-ManagementRoleAssignment.md)
+
+### [Set-ManagementRoleEntry](Set-ManagementRoleEntry.md)
+
+### [Set-ManagementScope](Set-ManagementScope.md)
+
+### [Set-RoleAssignmentPolicy](Set-RoleAssignmentPolicy.md)
+
+### [Set-RoleGroup](Set-RoleGroup.md)
+
+### [Update-RoleGroupMember](Update-RoleGroupMember.md)
+
+## server-health-and-performance Cmdlets
+### [Add-GlobalMonitoringOverride](Add-GlobalMonitoringOverride.md)
+
+### [Add-ServerMonitoringOverride](Add-ServerMonitoringOverride.md)
+
+### [Get-AvailabilityReportOutage](Get-AvailabilityReportOutage.md)
+
+### [Get-EventLogLevel](Get-EventLogLevel.md)
+
+### [Get-GlobalMonitoringOverride](Get-GlobalMonitoringOverride.md)
+
+### [Get-HealthReport](Get-HealthReport.md)
+
+### [Get-MonitoringItemHelp](Get-MonitoringItemHelp.md)
+
+### [Get-MonitoringItemIdentity](Get-MonitoringItemIdentity.md)
+
+### [Get-ServerComponentState](Get-ServerComponentState.md)
+
+### [Get-ServerHealth](Get-ServerHealth.md)
+
+### [Get-ServerMonitoringOverride](Get-ServerMonitoringOverride.md)
+
+### [Get-ThrottlingPolicy](Get-ThrottlingPolicy.md)
+
+### [Get-ThrottlingPolicyAssociation](Get-ThrottlingPolicyAssociation.md)
+
+### [Invoke-MonitoringProbe](Invoke-MonitoringProbe.md)
+
+### [New-AvailabilityReportOutage](New-AvailabilityReportOutage.md)
+
+### [New-ThrottlingPolicy](New-ThrottlingPolicy.md)
+
+### [Remove-AvailabilityReportOutage](Remove-AvailabilityReportOutage.md)
+
+### [Remove-GlobalMonitoringOverride](Remove-GlobalMonitoringOverride.md)
+
+### [Remove-ServerMonitoringOverride](Remove-ServerMonitoringOverride.md)
+
+### [Remove-ThrottlingPolicy](Remove-ThrottlingPolicy.md)
+
+### [Set-AvailabilityReportOutage](Set-AvailabilityReportOutage.md)
+
+### [Set-EventLogLevel](Set-EventLogLevel.md)
+
+### [Set-ServerComponentState](Set-ServerComponentState.md)
+
+### [Set-ServerMonitor](Set-ServerMonitor.md)
+
+### [Set-ThrottlingPolicy](Set-ThrottlingPolicy.md)
+
+### [Set-ThrottlingPolicyAssociation](Set-ThrottlingPolicyAssociation.md)
+
+### [Test-ServiceHealth](Test-ServiceHealth.md)
+
+## sharing-and-collaboration Cmdlets
+### [Add-AvailabilityAddressSpace](Add-AvailabilityAddressSpace.md)
+
+### [Add-PublicFolderAdministrativePermission](Add-PublicFolderAdministrativePermission.md)
+
+### [Add-PublicFolderClientPermission](Add-PublicFolderClientPermission.md)
+
+### [Disable-MailPublicFolder](Disable-MailPublicFolder.md)
+
+### [Enable-MailPublicFolder](Enable-MailPublicFolder.md)
+
+### [Get-AvailabilityAddressSpace](Get-AvailabilityAddressSpace.md)
+
+### [Get-AvailabilityConfig](Get-AvailabilityConfig.md)
+
+### [Get-MailPublicFolder](Get-MailPublicFolder.md)
+
+### [Get-OrganizationRelationship](Get-OrganizationRelationship.md)
+
+### [Get-PublicFolder](Get-PublicFolder.md)
+
+### [Get-PublicFolderAdministrativePermission](Get-PublicFolderAdministrativePermission.md)
+
+### [Get-PublicFolderClientPermission](Get-PublicFolderClientPermission.md)
+
+### [Get-PublicFolderDatabase](Get-PublicFolderDatabase.md)
+
+### [Get-PublicFolderItemStatistics](Get-PublicFolderItemStatistics.md)
+
+### [Get-PublicFolderMailboxDiagnostics](Get-PublicFolderMailboxDiagnostics.md)
+
+### [Get-PublicFolderStatistics](Get-PublicFolderStatistics.md)
+
+### [Get-SharingPolicy](Get-SharingPolicy.md)
+
+### [Get-SiteMailbox](Get-SiteMailbox.md)
+
+### [Get-SiteMailboxDiagnostics](Get-SiteMailboxDiagnostics.md)
+
+### [Get-SiteMailboxProvisioningPolicy](Get-SiteMailboxProvisioningPolicy.md)
+
+### [New-AvailabilityConfig](New-AvailabilityConfig.md)
+
+### [New-OrganizationRelationship](New-OrganizationRelationship.md)
+
+### [New-PublicFolder](New-PublicFolder.md)
+
+### [New-PublicFolderDatabase](New-PublicFolderDatabase.md)
+
+### [New-PublicFolderDatabaseRepairRequest](New-PublicFolderDatabaseRepairRequest.md)
+
+### [New-SharingPolicy](New-SharingPolicy.md)
+
+### [New-SiteMailboxProvisioningPolicy](New-SiteMailboxProvisioningPolicy.md)
+
+### [New-SyncMailPublicFolder](New-SyncMailPublicFolder.md)
+
+### [Remove-AvailabilityAddressSpace](Remove-AvailabilityAddressSpace.md)
+
+### [Remove-AvailabilityConfig](Remove-AvailabilityConfig.md)
+
+### [Remove-OrganizationRelationship](Remove-OrganizationRelationship.md)
+
+### [Remove-PublicFolder](Remove-PublicFolder.md)
+
+### [Remove-PublicFolderAdministrativePermission](Remove-PublicFolderAdministrativePermission.md)
+
+### [Remove-PublicFolderClientPermission](Remove-PublicFolderClientPermission.md)
+
+### [Remove-PublicFolderDatabase](Remove-PublicFolderDatabase.md)
+
+### [Remove-SharingPolicy](Remove-SharingPolicy.md)
+
+### [Remove-SiteMailboxProvisioningPolicy](Remove-SiteMailboxProvisioningPolicy.md)
+
+### [Remove-SyncMailPublicFolder](Remove-SyncMailPublicFolder.md)
+
+### [Resume-PublicFolderReplication](Resume-PublicFolderReplication.md)
+
+### [Set-AvailabilityConfig](Set-AvailabilityConfig.md)
+
+### [Set-MailPublicFolder](Set-MailPublicFolder.md)
+
+### [Set-OrganizationRelationship](Set-OrganizationRelationship.md)
+
+### [Set-PublicFolder](Set-PublicFolder.md)
+
+### [Set-PublicFolderDatabase](Set-PublicFolderDatabase.md)
+
+### [Set-SharingPolicy](Set-SharingPolicy.md)
+
+### [Set-SiteMailbox](Set-SiteMailbox.md)
+
+### [Set-SiteMailboxProvisioningPolicy](Set-SiteMailboxProvisioningPolicy.md)
+
+### [Suspend-PublicFolderReplication](Suspend-PublicFolderReplication.md)
+
+### [Test-OrganizationRelationship](Test-OrganizationRelationship.md)
+
+### [Test-SiteMailbox](Test-SiteMailbox.md)
+
+### [Update-PublicFolder](Update-PublicFolder.md)
+
+### [Update-PublicFolderHierarchy](Update-PublicFolderHierarchy.md)
+
+### [Update-PublicFolderMailbox](Update-PublicFolderMailbox.md)
+
+### [Update-SiteMailbox](Update-SiteMailbox.md)
+
+## unified-messaging Cmdlets
+### [Disable-UMAutoAttendant](Disable-UMAutoAttendant.md)
+
+### [Disable-UMCallAnsweringRule](Disable-UMCallAnsweringRule.md)
+
+### [Disable-UMIPGateway](Disable-UMIPGateway.md)
+
+### [Disable-UMMailbox](Disable-UMMailbox.md)
+
+### [Disable-UMServer](Disable-UMServer.md)
+
+### [Disable-UMService](Disable-UMService.md)
+
+### [Enable-UMAutoAttendant](Enable-UMAutoAttendant.md)
+
+### [Enable-UMCallAnsweringRule](Enable-UMCallAnsweringRule.md)
+
+### [Enable-UMIPGateway](Enable-UMIPGateway.md)
+
+### [Enable-UMMailbox](Enable-UMMailbox.md)
+
+### [Enable-UMServer](Enable-UMServer.md)
+
+### [Enable-UMService](Enable-UMService.md)
+
+### [Export-UMCallDataRecord](Export-UMCallDataRecord.md)
+
+### [Export-UMPrompt](Export-UMPrompt.md)
+
+### [Get-OnlineMeetingConfiguration](Get-OnlineMeetingConfiguration.md)
+
+### [Get-UMActiveCalls](Get-UMActiveCalls.md)
+
+### [Get-UMAutoAttendant](Get-UMAutoAttendant.md)
+
+### [Get-UMCallAnsweringRule](Get-UMCallAnsweringRule.md)
+
+### [Get-UMCallDataRecord](Get-UMCallDataRecord.md)
+
+### [Get-UMCallRouterSettings](Get-UMCallRouterSettings.md)
+
+### [Get-UMCallSummaryReport](Get-UMCallSummaryReport.md)
+
+### [Get-UMDialPlan](Get-UMDialPlan.md)
+
+### [Get-UMHuntGroup](Get-UMHuntGroup.md)
+
+### [Get-UMIPGateway](Get-UMIPGateway.md)
+
+### [Get-UMMailbox](Get-UMMailbox.md)
+
+### [Get-UMMailboxPIN](Get-UMMailboxPIN.md)
+
+### [Get-UMMailboxPolicy](Get-UMMailboxPolicy.md)
+
+### [Get-UmServer](Get-UmServer.md)
+
+### [Get-UMService](Get-UMService.md)
+
+### [Import-UMPrompt](Import-UMPrompt.md)
+
+### [New-UMAutoAttendant](New-UMAutoAttendant.md)
+
+### [New-UMCallAnsweringRule](New-UMCallAnsweringRule.md)
+
+### [New-UMDialPlan](New-UMDialPlan.md)
+
+### [New-UMHuntGroup](New-UMHuntGroup.md)
+
+### [New-UMIPGateway](New-UMIPGateway.md)
+
+### [New-UMMailboxPolicy](New-UMMailboxPolicy.md)
+
+### [Remove-UMAutoAttendant](Remove-UMAutoAttendant.md)
+
+### [Remove-UMCallAnsweringRule](Remove-UMCallAnsweringRule.md)
+
+### [Remove-UMDialPlan](Remove-UMDialPlan.md)
+
+### [Remove-UMHuntGroup](Remove-UMHuntGroup.md)
+
+### [Remove-UMIPGateway](Remove-UMIPGateway.md)
+
+### [Remove-UMMailboxPolicy](Remove-UMMailboxPolicy.md)
+
+### [Set-UMAutoAttendant](Set-UMAutoAttendant.md)
+
+### [Set-UMCallAnsweringRule](Set-UMCallAnsweringRule.md)
+
+### [Set-UMCallRouterSettings](Set-UMCallRouterSettings.md)
+
+### [Set-UMDialPlan](Set-UMDialPlan.md)
+
+### [Set-UMIPGateway](Set-UMIPGateway.md)
+
+### [Set-UMMailbox](Set-UMMailbox.md)
+
+### [Set-UMMailboxPIN](Set-UMMailboxPIN.md)
+
+### [Set-UMMailboxPolicy](Set-UMMailboxPolicy.md)
+
+### [Set-UmServer](Set-UmServer.md)
+
+### [Set-UMService](Set-UMService.md)
+
+### [Test-UMConnectivity](Test-UMConnectivity.md)
+
+## users-and-groups Cmdlets
+### [Add-DistributionGroupMember](Add-DistributionGroupMember.md)
+
+### [Add-UnifiedGroupLinks](Add-UnifiedGroupLinks.md)
+
+### [Disable-DistributionGroup](Disable-DistributionGroup.md)
+
+### [Disable-MailContact](Disable-MailContact.md)
+
+### [Disable-MailUser](Disable-MailUser.md)
+
+### [Enable-DistributionGroup](Enable-DistributionGroup.md)
+
+### [Enable-MailContact](Enable-MailContact.md)
+
+### [Enable-MailUser](Enable-MailUser.md)
+
+### [Get-Contact](Get-Contact.md)
+
+### [Get-DistributionGroup](Get-DistributionGroup.md)
+
+### [Get-DistributionGroupMember](Get-DistributionGroupMember.md)
+
+### [Get-DynamicDistributionGroup](Get-DynamicDistributionGroup.md)
+
+### [Get-DynamicDistributionGroupMember](Get-DynamicDistributionGroupMember.md)
+
+### [Get-EligibleDistributionGroupForMigration](Get-EligibleDistributionGroupForMigration.md)
+
+### [Get-Group](Get-Group.md)
+
+### [Get-LinkedUser](Get-LinkedUser.md)
+
+### [Get-MailContact](Get-MailContact.md)
+
+### [Get-MailUser](Get-MailUser.md)
+
+### [Get-Recipient](Get-Recipient.md)
+
+### [Get-SecurityPrincipal](Get-SecurityPrincipal.md)
+
+### [Get-UnifiedGroup](Get-UnifiedGroup.md)
+
+### [Get-UnifiedGroupLinks](Get-UnifiedGroupLinks.md)
+
+### [Get-User](Get-User.md)
+
+### [New-DistributionGroup](New-DistributionGroup.md)
+
+### [New-DynamicDistributionGroup](New-DynamicDistributionGroup.md)
+
+### [New-MailContact](New-MailContact.md)
+
+### [New-MailUser](New-MailUser.md)
+
+### [New-UnifiedGroup](New-UnifiedGroup.md)
+
+### [Remove-DistributionGroup](Remove-DistributionGroup.md)
+
+### [Remove-DistributionGroupMember](Remove-DistributionGroupMember.md)
+
+### [Remove-DynamicDistributionGroup](Remove-DynamicDistributionGroup.md)
+
+### [Remove-MailContact](Remove-MailContact.md)
+
+### [Remove-MailUser](Remove-MailUser.md)
+
+### [Remove-UnifiedGroup](Remove-UnifiedGroup.md)
+
+### [Remove-UnifiedGroupLinks](Remove-UnifiedGroupLinks.md)
+
+### [Set-Contact](Set-Contact.md)
+
+### [Set-DistributionGroup](Set-DistributionGroup.md)
+
+### [Set-DynamicDistributionGroup](Set-DynamicDistributionGroup.md)
+
+### [Set-Group](Set-Group.md)
+
+### [Set-LinkedUser](Set-LinkedUser.md)
+
+### [Set-MailContact](Set-MailContact.md)
+
+### [Set-MailUser](Set-MailUser.md)
+
+### [Set-UnifiedGroup](Set-UnifiedGroup.md)
+
+### [Set-User](Set-User.md)
+
+### [Undo-SoftDeletedUnifiedGroup](Undo-SoftDeletedUnifiedGroup.md)
+
+### [Update-DistributionGroupMember](Update-DistributionGroupMember.md)
+
+### [Upgrade-DistributionGroup](Upgrade-DistributionGroup.md)

--- a/test/Pester/assets/get-date.alt23.md
+++ b/test/Pester/assets/get-date.alt23.md
@@ -15,7 +15,7 @@ Gets the current date and time.
 
 ## SYNTAX
 
-### Date (Default)
+### DateAndFormat (Default)
 
 ```
 Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
@@ -23,7 +23,7 @@ Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-
  [-Format <String>] [-AsUTC] [<CommonParameters>]
 ```
 
-### DateUFormat
+### DateAndUFormat
 
 ```
 Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
@@ -31,7 +31,7 @@ Get-Date [[-Date] <DateTime>] [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-
  -UFormat <String> [<CommonParameters>]
 ```
 
-### UnixTimeSeconds
+### UnixTimeSecondsAndFormat
 
 ```
 Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
@@ -39,7 +39,7 @@ Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>
  [-Format <String>] [-AsUTC] [<CommonParameters>]
 ```
 
-### UnixTimeSecondsUFormat
+### UnixTimeSecondsAndUFormat
 
 ```
 Get-Date -UnixTimeSeconds <Int64> [-Year <Int32>] [-Month <Int32>] [-Day <Int32>] [-Hour <Int32>]
@@ -162,9 +162,9 @@ The Gregorian calendar has 365 days, except for leap years that have 366 days. F
 `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
 is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
 
-### Example 6: Check if a date is adjusted for daylight savings time
+### Example 6: Check if a date is adjusted for daylight saving time
 
-This example uses a boolean method to verify if a date is adjusted by daylight savings time.
+This example uses a boolean method to verify if a date is adjusted by daylight saving time.
 
 ```powershell
 $DST = Get-Date
@@ -176,7 +176,7 @@ True
 ```
 
 A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-to test if the date is adjusted for daylight savings time.
+to test if the date is adjusted for daylight saving time.
 
 ### Example 7: Convert the current time to UTC time
 
@@ -295,7 +295,7 @@ Accept wildcard characters: False
 
 ### -Date
 
-Specifies a date and time. Time is optional and if not specified, returns 00:00:00.
+SSSSSSpecifies a date and time. Time is optional and if not specified, returns 00:00:00.
 
 Enter the date and time in a format that is standard for the system locale.
 
@@ -528,7 +528,7 @@ Accept wildcard characters: False
 
 ### -Year
 
-SSSSpecifies the year that is displayed. Enter a value from 1 to 9999.
+Specifies the year that is displayed. Enter a value from 1 to 9999.
 
 ```yaml
 Type: System.Int32


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- updates to helpinfouri and helpuri.
  - Be sure that they go in the right file.
- Set diagnostics and ParameterNames as skipped property names for Compare-CommandHelp.
- fix issue in Measure-PlatyPSMarkdown.
  - It was not identifying a V2 module file.
  - Add a test for same.
- Change parameter name to from OutputDirectory to OutputFolder for Export-MamlCommandHelp.
- Be sure to save command help notes as AlertSet.
- Be sure to create metadata when importing MAML file.
- Add metadata during import of MAML file.
- Refactor a number of files.
  - Change metadata dictionary to be <string,object> rather than <string,string>.
  - Add handling of HelpUri and HelpInfoUri to new-markdowncommandhelp (transform settings does not preserve these).
  - Update metadata serializer to handle arrays in flow format.
  - Add a reasonable implementation of ToString for DiagnosticMessages to improve formatting.
- Be sure to include aliases in commandhelp.
- Add support for metadata as a paragraph in addition to normal handling.
- Add a number of diagnostic messages throughout.
- Change alias boilerplate to appear only if the ALIAS header was missing. This means that the first conversion from V1 -> V2 will include boilerplate, but V2 -> V2 will not.
- Don't add empty lines for the description of ModuleCommands, only if description is present.
- Add a number of format entries for DiagnosticMessage, Iditify, Diagnostics (now a custom format).
- Add Update-MarkdownModuleFile, Measure-PlatyPSMarkdown (identify what kind of markdown we have).
- Fix issue with module parsing when schema was not present.
  - Fix up tests for same and add exchange module file (for tests against multiple command groups.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
