### PR TITLE
Next set of fixes for OPS

### DIFF
--- a/src/Command/CompareCommandHelpCommand.cs
+++ b/src/Command/CompareCommandHelpCommand.cs
@@ -4,13 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
 using System.Management.Automation;
 using Microsoft.PowerShell.PlatyPS.Model;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerShell.PlatyPS
 {

--- a/src/Command/CompareCommandHelpCommand.cs
+++ b/src/Command/CompareCommandHelpCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PlatyPS
         public CommandHelp? DifferenceCommandHelp { get; set; }
 
         [Parameter]
-        public string[] PropertyNamesToExclude { get; set; } = new string[] { "Diagnostics", "ParameterNames" };
+        public string[] PropertyNamesToExclude { get; set; } = new string[] { "Diagnostics", "ParameterNames", "AliasHeaderFound" };
 
         List<String> DiagnosticMessages = new();
 

--- a/src/Command/ConvertToCommandHelpCommand.cs
+++ b/src/Command/ConvertToCommandHelpCommand.cs
@@ -19,7 +19,6 @@ namespace Microsoft.PowerShell.PlatyPS
 #region cmdlet parameters
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         [ValidateNotNullOrEmpty]
-        [StringToCommandInfoTransformation]
         public CommandInfo[] CommandInfo { get; set; } = new CommandInfo[0];
 #endregion
 

--- a/src/Command/ConvertToCommandHelpCommand.cs
+++ b/src/Command/ConvertToCommandHelpCommand.cs
@@ -2,15 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
-using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS

--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -54,30 +54,42 @@ namespace Microsoft.PowerShell.PlatyPS
 
         protected override void EndProcessing()
         {
+            bool outputDirectoryCheck = true;
             if (ShouldProcess(OutputFolder))
             {
                 outputDirectory = PathUtils.CreateOrGetOutputDirectory(this, OutputFolder, Force);
             }
             else
             {
-                // Just report on the creation of the base directory.
-                return;
+                outputDirectoryCheck = false;
             }
 
-            if (outputDirectory is null)
+            if (outputDirectoryCheck && outputDirectory is null)
             {
-                ThrowTerminatingError(new ErrorRecord(new InvalidOperationException("file is null"), "fileInfo is null", ErrorCategory.InvalidOperation, OutputFolder));
-                throw new InvalidOperationException("fileInfo is null"); // not reached
+                ThrowTerminatingError(new ErrorRecord(new InvalidOperationException("outputDirectory is null"), "OutputFolderNotFound", ErrorCategory.InvalidOperation, OutputFolder));
             }
 
+            // emit a MAML file for each group of CommandHelp objects
             var helpGroup = _commandHelps.GroupBy(c => c.ModuleName);
-
             foreach(var group in helpGroup)
             {
                 string moduleName = group.First().ModuleName;
+                string helpFileName = $"{moduleName}-Help.xml";
+
+                if (!ShouldProcess(helpFileName))
+                {
+                    continue;
+                }
+
+                var moduleMamlBasePath = Path.Combine(outputDirectory?.FullName, moduleName);
+                var moduleMamlPath = Path.Combine(moduleMamlBasePath, helpFileName);
                 var helpInfos = MamlConversionHelper.ConvertCommandHelpToMamlHelpItems(group.ToList<CommandHelp>());
                 // Convert the command help to MAML and write the file
-                var moduleMamlPath = Path.Combine(outputDirectory.FullName, $"{moduleName}-Help.xml");
+                if (!Directory.Exists(moduleMamlBasePath))
+                {
+                    Directory.CreateDirectory(moduleMamlBasePath);
+                }
+
                 if (File.Exists(moduleMamlPath) && ! Force)
                 {
                     WriteWarning(string.Format(Model.Constants.skippingMessageFmt, moduleMamlPath));

--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using Microsoft.PowerShell.Commands;
 using Microsoft.PowerShell.PlatyPS.MAML;
 using Microsoft.PowerShell.PlatyPS.Model;
-using System.Management.Automation.Language;
 
 namespace Microsoft.PowerShell.PlatyPS
 {

--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -77,8 +77,6 @@ namespace Microsoft.PowerShell.PlatyPS
                 string moduleName = group.First().ModuleName;
                 var helpInfos = MamlConversionHelper.ConvertCommandHelpToMamlHelpItems(group.ToList<CommandHelp>());
                 // Convert the command help to MAML and write the file
-                // var moduleDirectory = Path.Combine(outputDirectory.FullName, moduleName);
-                // Directory.CreateDirectory(moduleDirectory);
                 var moduleMamlPath = Path.Combine(outputDirectory.FullName, $"{moduleName}-Help.xml");
                 if (File.Exists(moduleMamlPath) && ! Force)
                 {

--- a/src/Command/ExportMarkdownHelpCommand.cs
+++ b/src/Command/ExportMarkdownHelpCommand.cs
@@ -3,15 +3,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Language;
-using System.Management.Automation.Runspaces;
-
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 

--- a/src/Command/ExportMarkdownModuleFileCommand.cs
+++ b/src/Command/ExportMarkdownModuleFileCommand.cs
@@ -3,15 +3,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Language;
-using System.Management.Automation.Runspaces;
-
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 

--- a/src/Command/ExportMarkdownModuleFileCommand.cs
+++ b/src/Command/ExportMarkdownModuleFileCommand.cs
@@ -38,22 +38,22 @@ namespace Microsoft.PowerShell.PlatyPS
 
         #endregion
 
-        private string fullPath = string.Empty;
+        private string basePath = string.Empty;
 
         protected override void BeginProcessing()
         {
-            fullPath = this.SessionState.Path.GetUnresolvedProviderPathFromPSPath(OutputFolder);
+            basePath = this.SessionState.Path.GetUnresolvedProviderPathFromPSPath(OutputFolder);
 
-            if (File.Exists(fullPath))
+            if (File.Exists(basePath))
             {
-                var exception = new InvalidOperationException(string.Format(Microsoft_PowerShell_PlatyPS_Resources.PathIsNotFolder, fullPath));
-                ErrorRecord err = new ErrorRecord(exception, "PathIsNotFolder", ErrorCategory.InvalidOperation, fullPath);
+                var exception = new InvalidOperationException(string.Format(Microsoft_PowerShell_PlatyPS_Resources.PathIsNotFolder, basePath));
+                ErrorRecord err = new ErrorRecord(exception, "PathIsNotFolder", ErrorCategory.InvalidOperation, basePath);
                 ThrowTerminatingError(err);
             }
 
-            if (!Directory.Exists(fullPath) && ShouldProcess(fullPath))
+            if (!Directory.Exists(basePath) && ShouldProcess(basePath))
             {
-                Directory.CreateDirectory(fullPath);
+                Directory.CreateDirectory(basePath);
             }
         }
 
@@ -66,10 +66,16 @@ namespace Microsoft.PowerShell.PlatyPS
                     continue;
                 }
 
-                var markdownPath = Path.Combine($"{fullPath}", $"{moduleFile.Module}.md");
+                // Module files should also go into a directory structure.
+                var moduleFolder = Path.Combine($"{basePath}", $"{moduleFile.Module}");
+                if (!Directory.Exists(moduleFolder))
+                {
+                    Directory.CreateDirectory(moduleFolder);
+                }
+
+                var markdownPath = Path.Combine($"{moduleFolder}", $"{moduleFile.Module}.md");
                 if (new FileInfo(markdownPath).Exists && ! Force)
                 {
-                    // should be error?
                     WriteWarning(string.Format(Constants.skippingMessageFmt, moduleFile.Module));
                 }
                 else

--- a/src/Command/ExportYamlCommandHelp.cs
+++ b/src/Command/ExportYamlCommandHelp.cs
@@ -66,7 +66,18 @@ namespace Microsoft.PowerShell.PlatyPS
         {
             foreach (CommandHelp ch in CommandHelp)
             {
-                var yamlPath = Path.Combine($"{fullPath}", $"{ch.Title}.yml");
+                if (! ShouldProcess(ch.ToString()))
+                {
+                    continue;
+                }
+
+                var yamlBasePath = Path.Combine($"{fullPath}", $"{ch.ModuleName}");
+                if (! Directory.Exists(yamlBasePath))
+                {
+                    Directory.CreateDirectory(yamlBasePath);
+                }
+
+                var yamlPath = Path.Combine($"{yamlBasePath}", $"{ch.Title}.yml");
                 if (new FileInfo(yamlPath).Exists && ! Force)
                 {
                     // should be error?

--- a/src/Command/ExportYamlCommandHelp.cs
+++ b/src/Command/ExportYamlCommandHelp.cs
@@ -3,12 +3,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.ObjectModel;
-using System.Globalization;
 using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-
 using Microsoft.PowerShell.PlatyPS.YamlWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 

--- a/src/Command/ImportMamlCommand.cs
+++ b/src/Command/ImportMamlCommand.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-
-using Microsoft.PowerShell.PlatyPS;
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS

--- a/src/Command/ImportMarkdownCommand.cs
+++ b/src/Command/ImportMarkdownCommand.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS

--- a/src/Command/ImportModuleFileCommand.cs
+++ b/src/Command/ImportModuleFileCommand.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS

--- a/src/Command/ImportYamlModuleFileCommand.cs
+++ b/src/Command/ImportYamlModuleFileCommand.cs
@@ -49,7 +49,6 @@ namespace Microsoft.PowerShell.PlatyPS
             // These should be resolved paths, whether -LiteralPath was used or not.
             foreach (string path in resolvedPaths)
             {
-
                 if (AsDictionary)
                 {
                     if (YamlUtils.TryGetOrderedDictionaryFromText(File.ReadAllText(path), out var dictionaryResult))
@@ -69,7 +68,8 @@ namespace Microsoft.PowerShell.PlatyPS
                 }
                 else
                 {
-                    WriteError(new ErrorRecord(deserializationError, "ImportYamlModuleFile,FailedToConvertYamltoModuleFileInfo", ErrorCategory.InvalidOperation, path));
+                    var wrappedException = new InvalidDataException($"Could not parse file as a module file. '{path}'", deserializationError);
+                    WriteError(new ErrorRecord(wrappedException, "ImportYamlModuleFile,FailedToConvertYamltoModuleFileInfo", ErrorCategory.InvalidOperation, path));
                 }
             }
         }

--- a/src/Command/ImportYamlModuleFileCommand.cs
+++ b/src/Command/ImportYamlModuleFileCommand.cs
@@ -5,12 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using System.Runtime.Serialization;
-using Microsoft.PowerShell.PlatyPS;
 using Microsoft.PowerShell.PlatyPS.Model;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
@@ -57,13 +52,13 @@ namespace Microsoft.PowerShell.PlatyPS
 
                 if (AsDictionary)
                 {
-                    if (YamlUtils.TryGetMetadataFromText(File.ReadAllText(path), out var dictionaryResult))
+                    if (YamlUtils.TryGetOrderedDictionaryFromText(File.ReadAllText(path), out var dictionaryResult))
                     {
                         WriteObject(dictionaryResult);
                     }
                     else
                     {
-                        WriteError(new ErrorRecord(new SerializationException("DeserializationError"), "ImportYamlModuleFile,FailedToConvertYamlToDictionary", ErrorCategory.InvalidOperation, path));
+                        WriteError(new ErrorRecord(new InvalidOperationException("DeserializationError"), "ImportYamlModuleFile,FailedToConvertYamlToDictionary", ErrorCategory.InvalidOperation, path));
                     }
                     continue;
                 }

--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using Microsoft.PowerShell.Commands;
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
@@ -65,8 +62,6 @@ namespace Microsoft.PowerShell.PlatyPS
 
         [Parameter]
         public SwitchParameter AbbreviateParameterTypename { get; set; }
-
-        public PSSession? Session { get; set; }
 
         #endregion
 
@@ -144,7 +139,6 @@ namespace Microsoft.PowerShell.PlatyPS
                         ModuleName = cmd.ModuleName is null ? string.Empty : cmd.ModuleName,
                         ModuleGuid = cmd.Module?.Guid is null ? Guid.Empty : cmd.Module.Guid,
                         OnlineVersionUrl = HelpUri,
-                        Session = Session,
                         UseFullTypeName = ! AbbreviateParameterTypename
                     };
 

--- a/src/Command/TestMarkdownCommandHelp.cs
+++ b/src/Command/TestMarkdownCommandHelp.cs
@@ -2,41 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Management.Automation;
-using System.Text;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
-    public class MarkdownCommandHelpValidationResult
-    {
-        public string Path { get; set; }
-        public bool IsValid { get; set; }
-        public List<string> Messages { get; set; }
-        public MarkdownCommandHelpValidationResult()
-        {
-            Path = string.Empty;
-            IsValid = true;
-            Messages = new List<string>();
-        }
-
-        public MarkdownCommandHelpValidationResult(string path, bool isValid, List<string> messages)
-        {
-            Path = path;
-            IsValid = isValid;
-            Messages = messages;
-        }
-
-        public override string ToString()
-        {
-            return $"Path: {Path}, IsValid: {IsValid}";
-        }
-
-    }
-
-
     [Cmdlet(VerbsDiagnostic.Test, "MarkdownCommandHelp")]
     [OutputType(typeof(bool))]
     [OutputType(typeof(MarkdownCommandHelpValidationResult))]

--- a/src/Command/Update-CommandHelp.cs
+++ b/src/Command/Update-CommandHelp.cs
@@ -2,19 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Drawing.Text;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
 using System.Text;
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS

--- a/src/Command/Update-CommandHelp.cs
+++ b/src/Command/Update-CommandHelp.cs
@@ -112,6 +112,9 @@ namespace Microsoft.PowerShell.PlatyPS
             }
             syntaxDiagnostics.ForEach(d => helpCopy.Diagnostics.TryAddDiagnostic(d));
 
+            // Alias - there are no aliases to be found in the cmdlet, but we shouldn't add the boiler plate.
+            helpCopy.AliasHeaderFound = true;
+
             // Parameters
             if (TryGetMergedParameters(helpCopy.Parameters, fromCmdlet.Parameters, out var mergedParametersList, out var paramDiagnostics))
             {

--- a/src/Command/Update-MarkdownCommandHelp.cs
+++ b/src/Command/Update-MarkdownCommandHelp.cs
@@ -2,17 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Drawing.Text;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
 using System.Text;
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;

--- a/src/Command/Update-MarkdownCommandHelp.cs
+++ b/src/Command/Update-MarkdownCommandHelp.cs
@@ -79,6 +79,19 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 try
                 {
+                    var identity = MarkdownProbe.Identify(path);
+                    if (! identity.IsCommandHelp())
+                    {
+                        WriteError(
+                            new ErrorRecord(
+                                new ArgumentException($"'{path}' is not a CommandHelp file."),
+                                "UpdateMarkdownHelpCommand,InvalidCommandHelpFile",
+                                ErrorCategory.InvalidData,
+                                identity)
+                        );
+                        continue;
+                    }
+
                     var commandHelpObject = MarkdownConverter.GetCommandHelpFromMarkdownFile(path);
                     var commandName = commandHelpObject.Title;
                     var cmdInfo = SessionState.InvokeCommand.GetCmdlet(commandName);
@@ -117,7 +130,6 @@ namespace Microsoft.PowerShell.PlatyPS
                         var cmdWrt = new CommandHelpMarkdownWriter(settings);
                         var helpPath = cmdWrt.Write(mergedCommandHelp, null).FullName;
 
-                        /// JWT - actually pass back the new fileinfo
                         if (PassThru)
                         {
                             WriteObject(this.InvokeProvider.Item.Get(helpPath));

--- a/src/Command/UpdateMarkdownModuleFile.cs
+++ b/src/Command/UpdateMarkdownModuleFile.cs
@@ -120,6 +120,11 @@ namespace Microsoft.PowerShell.PlatyPS
                 );
             }
 
+            if (! ShouldProcess(resolvedModuleFilePath))
+            {
+                return;
+            }
+
             // work on a copy of the original
             var newModuleFile = new ModuleFileInfo(mf);
             // Remove all of the command groups, we only use what was provided by the user.
@@ -159,7 +164,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     var moduleCommandInfo = new ModuleCommandInfo()
                     {
                         Name = cmdHelp.Title,
-                        Link = $"{cmdHelp.Title}.md", // JWT - should this be a property of the command help object?
+                        Link = $"{cmdHelp.Title}.md",
                         Description = cmdHelp.Synopsis,
                     };
 

--- a/src/Command/UpdateMarkdownModuleFile.cs
+++ b/src/Command/UpdateMarkdownModuleFile.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 ThrowTerminatingError(
                     new ErrorRecord(
-                        new ArgumentException($"{resolvedModuleFilePath}"),
+                        new ArgumentException($"'{resolvedModuleFilePath}' is not a module file."),
                         "UpdateMarkdownModuleFile,InvalidModuleFile",
                         ErrorCategory.InvalidData,
                         identity)

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -4,21 +4,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Management.Automation;
-using System.Management.Automation.Language;
-using Microsoft.PowerShell.PlatyPS.Model;
 using System.Collections.Specialized;
-using YamlDotNet.Core.Tokens;
-// using System.Net.Configuration;
-using Microsoft.PowerShell.Commands;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
+using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.PowerShell.PlatyPS.Model;
+using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.PowerShell.PlatyPS
 {

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -376,7 +376,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
         internal static OrderedDictionary DeserializeMetadataText(string metadataBlock)
         {
-            if (YamlUtils.TryGetMetadataFromText(metadataBlock, out OrderedDictionary md))
+            if (YamlUtils.TryGetOrderedDictionaryFromText(metadataBlock, out OrderedDictionary md))
             {
                 return md;
             }

--- a/src/Common/YamlLayoutSerializer.cs
+++ b/src/Common/YamlLayoutSerializer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
         public object ReadYaml(IParser parser, Type type)
         {
-            throw new NotImplementedException("no");
+            throw new NotImplementedException();
         }
 
         public void WriteYaml(IEmitter emitter, object? value, Type type)

--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -688,16 +688,16 @@ namespace Microsoft.PowerShell.PlatyPS
             return od;
         }
 
-        internal static bool TryGetMetadataFromText(string text, out OrderedDictionary metadata)
+        internal static bool TryGetOrderedDictionaryFromText(string text, out OrderedDictionary oDictionary)
         {
             try
             {
-                metadata = deserializer.Deserialize<OrderedDictionary>(text);
+                oDictionary = deserializer.Deserialize<OrderedDictionary>(text);
                 return true;
             }
             catch
             {
-                metadata = new();
+                oDictionary = new();
                 return false;
             }
         }

--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -4,16 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Management.Automation.Runspaces;
-using System.Runtime.InteropServices;
-using Markdig.Parsers;
-using Microsoft.PowerShell.PlatyPS;
 using Microsoft.PowerShell.PlatyPS.Model;
-using YamlDotNet;
-using YamlDotNet.Core.Tokens;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -213,6 +205,10 @@ namespace Microsoft.PowerShell.PlatyPS
             if (dictionary["notes"] is string notes)
             {
                 help.Notes = notes;
+            }
+            else
+            {
+                help.Notes = string.Empty;
             }
 
             help.Syntax.AddRange(GetSyntaxFromDictionary(dictionary));
@@ -653,6 +649,13 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 sp.IsPositional = true;
                 sp.Position = position.ToString();
+                position++;
+            }
+            else if (pName.StartsWith("[") && pName.EndsWith("]")) // [-Thing] <type> mandatory, positional
+            {
+                sp.IsPositional = true;
+                sp.Position = position.ToString();
+                sp.IsMandatory = true;
                 position++;
             }
             else // [-Thing <type>] optional, but named

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         private static CommandExample ConvertExample(Example example, int exampleNumber)
         {
             var newExample = new CommandExample();
-            newExample.Title = string.Format($"--------- Example {exampleNumber}: {example.Title} ---------");
+            newExample.Title = string.Format($"--------- {example.Title} ---------");
             foreach(string s in example.Remarks.Split(new string[] { "\n\n" }, StringSplitOptions.None))
             {
                 newExample.Description.Add(s.Trim());

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -365,7 +365,7 @@ namespace Microsoft.PowerShell.PlatyPS
         internal static OrderedDictionary ConvertTextToOrderedDictionary(string text)
         {
             // Try to get the metadata via the yaml deserializer
-            if (YamlUtils.TryGetMetadataFromText(text, out OrderedDictionary md))
+            if (YamlUtils.TryGetOrderedDictionaryFromText(text, out OrderedDictionary md))
             {
                 return md;
             }

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -1,26 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// using Markdig.Extensions.CustomContainers;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
-// using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
 using Microsoft.PowerShell.PlatyPS.Model;
-using System.CodeDom;
-// using System.Management.Automation.Language;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
-
     /// <summary>
     /// A class to represent a parse error.
     /// This might occur at any time, but especially when invalid yaml is included in the markdown.

--- a/src/MarkdownReader/MarkdownCommandHelpValidationResult.cs
+++ b/src/MarkdownReader/MarkdownCommandHelpValidationResult.cs
@@ -1,0 +1,34 @@
+ // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.PowerShell.PlatyPS
+{
+    public class MarkdownCommandHelpValidationResult
+    {
+        public string Path { get; set; }
+        public bool IsValid { get; set; }
+        public List<string> Messages { get; set; }
+        public MarkdownCommandHelpValidationResult()
+        {
+            Path = string.Empty;
+            IsValid = true;
+            Messages = new List<string>();
+        }
+
+        public MarkdownCommandHelpValidationResult(string path, bool isValid, List<string> messages)
+        {
+            Path = path;
+            IsValid = isValid;
+            Messages = messages;
+        }
+
+        public override string ToString()
+        {
+            return $"Path: {Path}, IsValid: {IsValid}";
+        }
+
+    }
+}

--- a/src/MarkdownReader/MarkdownProbe.cs
+++ b/src/MarkdownReader/MarkdownProbe.cs
@@ -2,28 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using Markdig.Syntax;
-using Markdig.Syntax.Inlines;
-using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
-using Microsoft.PowerShell.PlatyPS.Model;
-using System.CodeDom;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
-
     /// <summary>
-    /// A class to represent a parse error.
-    /// This might occur at any time, but especially when invalid yaml is included in the markdown.
+    /// A class used for probing markdown to determine its characteristics.
     /// </summary>
     public class MarkdownProbe
     {
+        /// <summary>
+        /// Identify the type of platyps file based on the path.
+        /// </summary>
+        /// <param name="path">The path to a markdown file.</param>
+        /// <returns>MarkdownProbeInfo</returns>
         public static MarkdownProbeInfo Identify(string path)
         {
             return new MarkdownProbeInfo(path);

--- a/src/MarkdownReader/MarkdownProbeInfo.cs
+++ b/src/MarkdownReader/MarkdownProbeInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.PlatyPS
         /// The path to the markdown file
         /// </summary>
         public string FilePath { get; set; }
-        
+
         /// <summary>
         /// The title of the markdown file.
         /// This might be null if the file cannot be identified

--- a/src/MarkdownReader/MarkdownProbeInfo.cs
+++ b/src/MarkdownReader/MarkdownProbeInfo.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// using Markdig.Extensions.CustomContainers;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
-using System.Runtime.Remoting.Messaging;
-using System.Text;
 using Microsoft.PowerShell.PlatyPS.Model;
-using YamlDotNet.Core;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
@@ -21,9 +17,9 @@ namespace Microsoft.PowerShell.PlatyPS
         ModuleFile      = 1 << 0x03,
         ConceptualTopic = 1 << 0x04,
         AboutTopic      = 1 << 0x05,
-        UnknownSchema   = 1 << 0x10,
-        V1Schema        = 1 << 0x20,
-        V2Schema        = 1 << 0x30,
+        UnknownSchema   = 1 << 0x11,
+        V1Schema        = 1 << 0x12,
+        V2Schema        = 1 << 0x13,
     }
 
     /// <summary>
@@ -32,53 +28,91 @@ namespace Microsoft.PowerShell.PlatyPS
     ///
     public class MarkdownProbeInfo
     {
+        /// <summary>
+        /// The path to the markdown file
+        /// </summary>
         public string FilePath { get; set; }
+        
+        /// <summary>
+        /// The title of the markdown file.
+        /// This might be null if the file cannot be identified
+        /// </summary>
         public string? Title { get; set; }
 
+        /// <summary>
+        /// The type of the markdown file.
+        /// </summary>
         public MarkdownFileType FileType { get; set; }
 
+        /// <summary>
+        /// The parsed markdown content.
+        /// </summary>
         public ParsedMarkdownContent MarkdownContent { get; set; }
 
+        /// <summary>
+        /// The metadata of the file if it can be determined.
+        /// </summary>
         public OrderedDictionary? MetaData { get; set; }
 
+        /// <summary>
+        /// The diagnostic messages created during the probe.
+        /// </summary>
         public List<DiagnosticMessage> DiagnosticMessages { get; set; }
 
+        /// <summary>
+        /// The constructor of the probe information.
+        /// </summary>
+        /// <param name="filePath"></param>
         public MarkdownProbeInfo(string filePath)
         {
             FilePath = filePath;
             DiagnosticMessages = new();
             MarkdownContent = ParsedMarkdownContent.ParseFile(filePath);
             MetaData = MarkdownConverter.GetMetadata(MarkdownContent.Ast);
-            GetContentType();
+            DetermineContentType();
         }
 
+        /// <summary>
+        /// A helper method to easily determine if this is a module file.
+        /// </summary>
+        /// <returns>boolean true if the file has been determined to be a module file, false if not.</returns>
         public bool IsModuleFile()
         {
             return (FileType & MarkdownFileType.ModuleFile) == MarkdownFileType.ModuleFile;
         }
 
+        /// <summary>
+        /// A helper method to easily determine if this is a command help file.
+        /// </summary>
+        /// <returns>boolean true if the file has been determined to be a command help file, false if not.</returns>
         public bool IsCommandHelp()
         {
             return (FileType & MarkdownFileType.CommandHelp) == MarkdownFileType.CommandHelp;
         }
 
-        private void GetContentType()
+        /// <summary>
+        /// Determine the content type by looking at various properties.
+        /// This method inspects the metadata, if it exists, as well as the markdown content.
+        /// </summary>
+        private void DetermineContentType()
         {
             FileType = MarkdownFileType.Unknown;
             if (MetaData is not null && MetaData.Contains("title"))
             {
                 Title = MetaData["title"].ToString();
-                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Found metadata and title", DiagnosticSeverity.Information, "GetContentType", -1));
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Found metadata and title", DiagnosticSeverity.Information, "DetermineContentType", -1));
             }
             else if (MetaData is null)
             {
                 Title = "unknown";
-                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "metadata is null", DiagnosticSeverity.Information, "GetContentType", -1));
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "metadata is null", DiagnosticSeverity.Information, "DetermineContentType", -1));
+                SearchElements();
+                return;
             }
             else
             {
                 Title = "unknown";
-                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title not found", DiagnosticSeverity.Information, "GetContentType", -1));
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title not found", DiagnosticSeverity.Information, "DetermineContentType", -1));
             }
 
             if (MetaData is not null)
@@ -88,84 +122,86 @@ namespace Microsoft.PowerShell.PlatyPS
                     var documentType = MetaData["document type"];
                     if (documentType is not null && string.Compare(documentType.ToString(), "cmdlet", true) == 0)
                     {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: cmdlet", DiagnosticSeverity.Information, "GetContentType", -1));
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: cmdlet", DiagnosticSeverity.Information, "DetermineContentType", -1));
                         FileType = (MarkdownFileType.CommandHelp|MarkdownFileType.V2Schema);
                     }
                     else if (documentType is not null && string.Compare(documentType.ToString(), "module", true) == 0)
                     {
                         FileType = (MarkdownFileType.ModuleFile|MarkdownFileType.V2Schema);
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: modulefile", DiagnosticSeverity.Information, "GetContentType", -1));
+                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type found: modulefile", DiagnosticSeverity.Information, "DetermineContentType", -1));
                     }
                 }
                 else // hunt for more information
                 {
-                    DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type not found, searching elements", DiagnosticSeverity.Information, "GetContentType", -1));
-                    var synopsisIndex = MarkdownContent.FindHeader(2, "SYNOPSIS") != -1;
-                    var syntaxIndex = MarkdownContent.FindHeader(2, "SYNTAX") != -1;
-                    var exampleIndex = MarkdownContent.FindHeader(2, "EXAMPLES") != -1;
-                    var hasModuleGuid = MetaData.Contains("Module Guid");
-                    if (synopsisIndex && syntaxIndex && exampleIndex)
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "synopsis/syntax/examples all found", DiagnosticSeverity.Information, "GetContentType", -1));
-                        FileType = MarkdownFileType.CommandHelp;
-                    }
-                    else if (hasModuleGuid)
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "module guid found", DiagnosticSeverity.Information, "GetContentType", -1));
-                        FileType = MarkdownFileType.ModuleFile;
-                    }
-                    else if (Title.StartsWith("about", true, CultureInfo.InvariantCulture))
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title starts with 'about'", DiagnosticSeverity.Information, "GetContentType", -1));
-                        FileType = MarkdownFileType.AboutTopic;
-                    }
-                    else
-                    {
-                        List<string> missingElements = new();
-                        if (! synopsisIndex)
-                        {
-                            missingElements.Add("SYNOPSIS");
-                        }
-
-                        if (! syntaxIndex)
-                        {
-                            missingElements.Add("SYNTAX");
-                        }
-
-                        if (! exampleIndex)
-                        {
-                            missingElements.Add("EXAMPLES");
-                        }
-
-                        if (! hasModuleGuid)
-                        {
-                            missingElements.Add("ModuleGuid");
-                        }
-
-                        string message = string.Format("Cannot determine file type: missing element(s): {0}", string.Join(", ", missingElements));
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, message, DiagnosticSeverity.Information, "GetContentType", -1));
-                    }
-
-                    if(MetaData.Contains("PlatyPS schema version"))
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version found - marking as v2", DiagnosticSeverity.Information, "GetContentType", -1));
-                        FileType |= MarkdownFileType.V2Schema;
-                    }
-                    else if (FileType == MarkdownFileType.AboutTopic)
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "no schema for about topics", DiagnosticSeverity.Information, "GetContentType", -1));
-                    }
-                    else if (FileType != MarkdownFileType.Unknown)
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version not found - marking as v1", DiagnosticSeverity.Information, "GetContentType", -1));
-                        FileType |= MarkdownFileType.V1Schema;
-                    }
-                    else if (FileType == MarkdownFileType.Unknown)
-                    {
-                        DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Could not determine schema version", DiagnosticSeverity.Warning, "GetContentType", -1));
-                        FileType |= MarkdownFileType.UnknownSchema;
-                    }
+                    DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "document type not found, searching elements", DiagnosticSeverity.Information, "DetermineContentType", -1));
+                    SearchElements();
                 }
+            }
+        }
+
+        private void SearchElements()
+        {
+            var synopsisIndex = MarkdownContent.FindHeader(2, "SYNOPSIS") != -1;
+            var syntaxIndex = MarkdownContent.FindHeader(2, "SYNTAX") != -1;
+            var exampleIndex = MarkdownContent.FindHeader(2, "EXAMPLES") != -1;
+            var hasModuleGuid = MetaData?.Contains("Module Guid") ?? false;
+
+            if (synopsisIndex && syntaxIndex && exampleIndex)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "synopsis/syntax/examples all found", DiagnosticSeverity.Information, "SearchElements", -1));
+                FileType = MarkdownFileType.CommandHelp;
+            }
+            else if (hasModuleGuid)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "module guid found", DiagnosticSeverity.Information, "SearchElements", -1));
+                FileType = MarkdownFileType.ModuleFile;
+            }
+            else if (Title?.StartsWith("about", true, CultureInfo.InvariantCulture) ?? false)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "title starts with 'about'", DiagnosticSeverity.Information, "SearchElements", -1));
+                FileType = MarkdownFileType.AboutTopic;
+            }
+            else
+            {
+                List<string> missingElements = new();
+                if (! synopsisIndex)
+                {
+                    missingElements.Add("SYNOPSIS");
+                }
+                if (! syntaxIndex)
+                {
+                    missingElements.Add("SYNTAX");
+                }
+                if (! exampleIndex)
+                {
+                    missingElements.Add("EXAMPLES");
+                }
+                if (! hasModuleGuid)
+                {
+                    missingElements.Add("ModuleGuid");
+                }
+                string message = string.Format("Cannot determine file type: missing element(s): {0}", string.Join(", ", missingElements));
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, message, DiagnosticSeverity.Information, "SearchElements", -1));
+            }
+
+            if(MetaData?.Contains("PlatyPS schema version") ?? false)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version found - marking as v2", DiagnosticSeverity.Information, "SearchElements", -1));
+                FileType |= MarkdownFileType.V2Schema;
+            }
+            else if (FileType == MarkdownFileType.AboutTopic)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "no schema for about topics", DiagnosticSeverity.Information, "SearchElements", -1));
+            }
+            else if (FileType != MarkdownFileType.Unknown)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "PlatyPS schema version not found - marking as v1", DiagnosticSeverity.Information, "SearchElements", -1));
+                FileType |= MarkdownFileType.V1Schema;
+            }
+            else if (FileType == MarkdownFileType.Unknown)
+            {
+                DiagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Identify, "Could not determine schema version", DiagnosticSeverity.Warning, "SearchElements", -1));
+                FileType |= MarkdownFileType.UnknownSchema;
             }
         }
     }

--- a/src/MarkdownReader/ModuleCommandGroup.cs
+++ b/src/MarkdownReader/ModuleCommandGroup.cs
@@ -3,22 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-// using System.Collections.Specialized;
-// using System.Collections.ObjectModel;
-// using System.Globalization;
-// using System.IO;
 using System.Linq;
-// using System.Text;
-// using System.Text.RegularExpressions;
-// using Markdig.Syntax;
-// using Markdig.Syntax.Inlines;
-// using Microsoft.PowerShell.PlatyPS.MarkdownWriter;
-// using Microsoft.PowerShell.PlatyPS.Model;
-// using YamlDotNet;
-// using YamlDotNet.Serialization;
-// using System.Management.Automation;
-// using System.Security.Cryptography;
-// using System.Data.Common;
 
 namespace Microsoft.PowerShell.PlatyPS
 {

--- a/src/Model/Parameter.cs
+++ b/src/Model/Parameter.cs
@@ -72,6 +72,10 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             DefaultValue = parameter.DefaultValue;
             Description = parameter.Description;
             HelpMessage = parameter.HelpMessage;
+            SupportsWildcards = parameter.SupportsWildcards;
+            IsDynamic = parameter.IsDynamic;
+            DontShow = parameter.DontShow;
+            VariableLength = parameter.VariableLength;
         }
 
         public void AddRequiredParameterSetsRange(bool required, IEnumerable<string> parameterSetNames)

--- a/src/Model/SyntaxParameter.cs
+++ b/src/Model/SyntaxParameter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text;
 
 namespace Microsoft.PowerShell.PlatyPS.Model
@@ -38,6 +39,16 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             IsMandatory = isMandatory;
             IsPositional = isPositional;
             IsSwitchParameter = isSwitchParameter;
+        }
+
+        public SyntaxParameter(Parameter p)
+        {
+            ParameterName = p.Name;
+            ParameterType = p.Type;
+            // IsMandatory = p.ParameterSets.First().IsRequired;
+            // Position = p.ParameterSets.First().Position;
+            // IsSwitchParameter = string.Compare(ParameterType, "SwitchParameter", true) == 0;
+            // IsPositional = Int32.TryParse(Position, out var _) ? true : false;
         }
 
         /// <summary>

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -422,6 +422,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 while (reader.ReadToNextSibling(Constants.MamlCommandParameterTag))
                 {
                     var parameter = ReadParameter(reader.ReadSubtree(), parameterSetCount: -1);
+                    syntaxItem.SyntaxParameters.Add(new SyntaxParameter(parameter));
                     try
                     {
                         // This may possibly throw because the position is duplicated.
@@ -430,6 +431,7 @@ namespace Microsoft.PowerShell.PlatyPS
                         // In this case, we will try to add the parameter with a negative position to show we
                         // could not assign it appropriately.
                         syntaxItem.AddParameter(parameter);
+                        syntaxItem.SyntaxParameters.Add(new SyntaxParameter(parameter));
                     }
                     catch
                     {

--- a/test/Pester/CompareCommandHelp.Tests.ps1
+++ b/test/Pester/CompareCommandHelp.Tests.ps1
@@ -38,7 +38,9 @@ Describe "Compare-CommandHelp can find differences" {
     }
 
     It "Default excluded properties should be Diagnostics and ParameterNames" {
-        $expected = "M excluding comparison of CommandHelp.Diagnostics","M excluding comparison of CommandHelp.Syntax.ParameterNames"
+        $expected = "M excluding comparison of CommandHelp.AliasHeaderFound",
+                    "M excluding comparison of CommandHelp.Diagnostics",
+                    "M excluding comparison of CommandHelp.Syntax.ParameterNames"
         $observed = $result3.split("`n").Where({$_ -match "excluding comparison"})|Sort-Object -Unique
         $observed | Should -Be $expected
     }

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe "New-CommandHelp tests" {
     BeforeAll {
-        $result = New-CommandHelp New-CommandHelp
+        $result = New-CommandHelp (Get-Command New-CommandHelp)
         $commonParameters = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
             'OutBuffer', 'OutVariable', 'PipelineVariable', 'ProgressAction', 'Verbose', 'WarningAction', 'WarningVariable'
     }

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -7,8 +7,8 @@ Describe "Export-MamlCommandHelp tests" {
         $markdownFiles = 'get-date.md', 'Import-Module.md', 'Invoke-Command.md', 'Out-Null.md'
         $chObjects = $markdownFiles | Foreach-Object { Import-MarkdownCommandHelp  (Join-Path $assetDir $_) }
         $outputDirectory = Join-Path $TESTDRIVE MamlBase
-        $f1 = "$outputDirectory/Microsoft.PowerShell.Core-Help.xml"
-        $f2 = "$outputDirectory/Microsoft.PowerShell.Utility-Help.xml"
+        $f1 = "$outputDirectory/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core-Help.xml"
+        $f2 = "$outputDirectory/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility-Help.xml"
     }
 
     Context "Basic Operations" {

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -123,5 +123,11 @@ Describe "Export-MamlCommandHelp tests" {
             $observedStr = ($observed -join "") -replace "[`n`r ]"
             $observedStr | Should -Be $expectedStr
         }
+
+        It "Should have proper titles for examples" {
+            $expected = $chObjects.Where({$_.title -eq "Get-Date"}).Examples.Title.Foreach({"--------- ${_} ---------"})
+            $observed = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).examples.example.title
+            $observed | Should -Be $expected
+        }
     }
 }

--- a/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
@@ -69,6 +69,21 @@ Describe "Export-MarkdownCommandHelp" {
 
     }
 
+    Context "File Content - Alias" {
+        BeforeAll {
+            $chCopy = [Microsoft.PowerShell.PlatyPS.Model.CommandHelp]::new($ch)
+            $chCopy.AliasHeaderFound = $true
+        }
+
+        It "Should not add alias boiler plate" {
+            $ch.AliasHeaderFound | Should -Be $false
+            $noAlias = $chCopy | Export-MarkdownCommandHelp -OutputFolder $outputBaseFolder
+            $observed = $noAlias | Import-MarkdownCommandHelp
+            $observed.Alias.Count | Should -Be 0
+            $observed.AliasHeaderFound | Should -Be $true
+        }
+    }
+
     Context "File Content - Metadata" {
         BeforeAll {
             $ch | Export-MarkdownCommandHelp -OutputFolder $outputBaseFolder

--- a/test/Pester/ExportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ExportMarkdownModuleFile.Tests.ps1
@@ -12,7 +12,8 @@ Describe "Export-MarkdownModuleFile" {
     Context "Basic Operation" {
         It "Should be able to export a module file" {
             $null = $modObjects[0] | Export-MarkdownModuleFile -outputFolder ${TestDrive}
-            $expectedFile = "${TestDrive}/" + $modObjects[0].Module + ".md"
+            $moduleName = $modObjects[0].Module
+            $expectedFile = "${TestDrive}/${moduleName}/${moduleName}.md"
             $expectedFile | Should -Exist
         }
 

--- a/test/Pester/ExportYamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportYamlCommandHelp.Tests.ps1
@@ -9,8 +9,8 @@ Describe "Export-YamlCommandHelp tests" {
         $testMDFile = "$TestDrive/Get-Date.md"
         Get-Content $markdownFile | Set-Content "$testMDFile"
         $ch = Import-MarkdownCommandHelp $testMDFile
-        $ch | Export-YamlCommandHelp -outputfolder $TESTDRIVE -Force
-        $outputFile = "$TESTDRIVE/Get-Date.yml"
+        $yamlFilePath = $ch | Export-YamlCommandHelp -outputfolder $TESTDRIVE -Force
+        $outputFile = $yamlFilePath.FullName
         Import-Module "$PSScriptRoot/PlatyPS.Test.psm1"
         $yamlDict = Import-CommandYaml $outputFile -PreserveOrder
     }

--- a/test/Pester/ExportYamlModuleFile.Tests.ps1
+++ b/test/Pester/ExportYamlModuleFile.Tests.ps1
@@ -8,12 +8,16 @@ Describe "Export-YamlModuleFile tests" {
     }
 
     Context "Basic tests" {
-        It "Can export yaml module file '<name>'" -TestCases @(
+        It "Can export yaml module file '<name>' in the proper location" -TestCases @(
             $moduleFileList.ForEach({@{ name = ([io.path]::GetFileName($_)); path = "$_" }})
         )  {
             param ($path, $name)
             $outputFile = Import-MarkdownModuleFile -Path $path | Export-YamlModuleFile -OutputFolder ${TestDrive}
             $outputFile | Should -Exist
+            $moduleName = [io.path]::GetFileNameWithoutExtension($outputFile.FullName)
+            $moduleFile = [io.path]::GetFileName($outputFile.FullName)
+            $expectedLocation = [io.Path]::Combine($TestDrive, $moduleName, $moduleFile)
+            $outputFile.FullName | Should -Be $expectedLocation
         }
 
         It "Will add additional metadata if supplied" {

--- a/test/Pester/MarkdownYaml.Tests.ps1
+++ b/test/Pester/MarkdownYaml.Tests.ps1
@@ -3,6 +3,7 @@
 
 Describe "Create valid yaml" {
     BeforeAll {
+        $moduleName = "Microsoft.PowerShell.Core"
         New-Item -Type Directory -Path "${TESTDRIVE}/markdown"
         New-Item -Type Directory -Path "${TESTDRIVE}/yaml"
         New-Item -Type Directory -Path "${TESTDRIVE}/psdocs"
@@ -12,7 +13,7 @@ Describe "Create valid yaml" {
             push-location "${TESTDRIVE}/psdocs"
             try {
                 git clone "https://github.com/PowerShell/PowerShell-Docs"
-                push-location "PowerShell-Docs/reference/7.4/Microsoft.PowerShell.Core"
+                push-location "PowerShell-Docs/reference/7.4/${moduleName}"
                 $mdfiles = Get-ChildItem -filter *.md | Where-Object { $verbs.Verb -Contains ($_.name.split("-")[0]) }
                 Copy-Item $mdfiles "${TESTDRIVE}/markdown"
             }
@@ -41,7 +42,7 @@ Describe "Create valid yaml" {
         }
 
         try {
-            $yamlFilePath = Join-Path "${TESTDRIVE}/yaml" $yamlFileName
+            $yamlFilePath = [io.path]::Combine("${TESTDRIVE}/yaml", $moduleName, $yamlFileName)
             $result = $yamlFilePath | Import-CommandYaml
             $result | Should -Not -BeNullOrEmpty
             $result.GetType().Name | Should -Be "hashtable"

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Export-MarkdownModuleFile" {
         @{ fileType = "CommandHelp"; expectedCount = 32 }
         @{ fileType = "ModuleFile"; expectedCount = 14 }
         @{ fileType = "V1Schema"; expectedCount = 45 }
-        @{ fileType = "V2Schema"; expectedCount = 2 }
+        @{ fileType = "V2Schema"; expectedCount = 1 }
     ) {
         param ($fileType, $expectedCount)
         $idents.Where({($_.FileType -band $fileType) -eq $fileType}).Count | Should -Be $expectedCount
@@ -24,7 +24,7 @@ Describe "Export-MarkdownModuleFile" {
 
     It "Should have proper diagnostics for get-date.md" {
         $goodFile1.DiagnosticMessages.Count | Should -Be 4
-        $goodFile1.FileType -band "v1schema" -eq "v1schema" | Should -Be $true
+        $goodFile1.FileType | Should -match "v1schema"
         $goodFile1.DiagnosticMessages[-1].Message | Should -Match "PlatyPS.*schema.*marking as v1"
     }
 

--- a/test/Pester/UpdateCommandHelp.Tests.ps1
+++ b/test/Pester/UpdateCommandHelp.Tests.ps1
@@ -84,4 +84,9 @@ Describe "Tests for Update-CommandHelp" {
         $chUpdate | Should -Be $ch
     }
 
+    It "Should not update the aliases element with boiler plate" {
+        $ch = Update-CommandHelp -Path ([io.path]::Combine($PSScriptRoot, "assets", "get-date.md"))
+        $ch.AliasHeaderFound | Should -Be $true
+    }
+
 }

--- a/test/Pester/UpdateMarkdownModuleFile.tests.ps1
+++ b/test/Pester/UpdateMarkdownModuleFile.tests.ps1
@@ -26,7 +26,8 @@ Describe "Update-MarkdownModuleFile tests" {
         $mfDescription = "This is a test description for a module file"
         $mf.Description = $mfDescription
         $mf.Metadata['ms.date'] = "01/01/2002"
-        $null = $mf | Export-MarkdownModuleFile -outputfolder "${testDrive}/testModule" -Force
+        # $null = $mf | Export-MarkdownModuleFile -outputfolder "${testDrive}/testModule" -Force
+        $null = $mf | Export-MarkdownModuleFile -outputfolder "${testDrive}" -Force
         remove-module $testModule
     }
 
@@ -97,5 +98,16 @@ Describe "Update-MarkdownModuleFile tests" {
             $observedModuleFileInfo | Should -BeGreaterThan $moduleFileInfoReference
             $observedBackupModuleFileInfo | Should -BeGreaterOrEqual $backupModuleFileInfoReference
         }
+
+        It "will remove incorrect metadata entry 'HelpUri'" {
+            $mf = Import-MarkdownModuleFile -Path $moduleFilePath -ErrorAction Stop
+            $mf.Metadata.Contains('HelpUri') | Should -Be $false
+        }
+
+        It "will contain correct metadata entry 'HelpInfoUri'" {
+            $mf = Import-MarkdownModuleFile -Path $moduleFilePath -ErrorAction Stop
+            $mf.Metadata.Contains('HelpInfoUri') | Should -Be $true
+        }
+
     }
 }

--- a/test/Pester/UpdateMarkdownModuleFile.tests.ps1
+++ b/test/Pester/UpdateMarkdownModuleFile.tests.ps1
@@ -31,6 +31,30 @@ Describe "Update-MarkdownModuleFile tests" {
         remove-module $testModule
     }
 
+    Context "General Tests" {
+        BeforeAll {
+            $testDirectory = Join-Path $TESTDRIVE generaltests
+            New-Item -ItemType Directory -Path $testDirectory
+            $getdateCH = Import-MarkdownCommandHelp "${PSScriptRoot}/assets/get-date.md"
+            $modFilePath = Copy-Item -PassThru -Path "${PSScriptRoot}/assets/Microsoft.PowerShell.Utility.md" -Destination $testDirectory
+        }
+
+        It "will not update a module file when -WhatIf is used" {
+            $getdateCH | Update-MarkdownModuleFile -Path $modFilePath -WhatIf
+            (Get-Item $modFilePath).Length | Should -Be $modFilePath.Length
+        }
+
+        It "will update a module file when -WhatIf is not used" {
+            $getdateCH | Update-MarkdownModuleFile -Path $modFilePath
+            (Get-Item $modFilePath).Length | Should -Not -Be $modFilePath.Length
+        }
+
+        It "Will have the new content in the module file" {
+            $mf = Import-MarkdownModuleFile -Path $modFilePath
+            $mf.CommandGroups.Commands.Count | Should -Be 1
+        }
+    }
+
     Context "Setup tests" {
         BeforeAll {
             $lmf = Import-MarkdownModuleFile "${testDrive}/testModule/testModule.md"
@@ -108,6 +132,5 @@ Describe "Update-MarkdownModuleFile tests" {
             $mf = Import-MarkdownModuleFile -Path $moduleFilePath -ErrorAction Stop
             $mf.Metadata.Contains('HelpInfoUri') | Should -Be $true
         }
-
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- Make sure all export commands create a module directory.
  - Fix up tests to prove it.
  - Fix up code for ShouldProcess.
- Remove extraneous comments, spaces, and using statements
- Fixes to Export-YamlModuleFile.
  - Be sure to output the yaml module file in the proper location.
  - Add test for same.
  - Add support for ShouldProcess.
- Be sure to copy all the properties when calling the constructor of a parameter.
  - Add test to update-commandhelp to validate it.
- Improve error message for Import-YamlModuleFile if the file is not a module file.
  - Be sure to set AliasHeaderFound to true to avoid emitting the boilerplate for alias when updating command help.
  - When importing yaml command help set the notes to an empty string if it is null.
  - Fix tests for Export-MarkdownCommandHelp.
  - Add additional tests for HelpUri to ensure it is not in the Update-MarkdownModule file output.
  - Check to be sure that HelpInfoUri _is_ present.
- Add AliasHeaderFound to skipped properties for compare tests.
- Set AliasHeaderFound to true in update command help.
  - This ensures that we won't put the boiler plate in for aliases.
  - Add test for same.
  - Also use PowerShellAPI helper to get cmdinfo to improve reliability.
- Add module directory to Export-MarkdownModuleFile.
  - Adjust tests for new behavior.
- Add AliasHeaderFound to skipped properties for compare.
  - This member is also not used for equality.
- Fix maml writer to not duplicate the example title.
  - Add test for same.
- remove stringtocommand transform attribute.
  - It wasn't very stable, and the failure modes were opaque to the user.
  - Fix bug in ProbeInfo enum for identifying file type.
  - Add summaries for members.
- Refactor ValidationResult into MarkdownReader.
  - Isolate cmdlets from any specific serialization/deserialization.
- SyntaxParameter constructor from Parameter incomplete.
  - Improve error messages for update cmdlets.
  - Add identity check to Update-MarkdownCommandHelp.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
