### PR TITLE
Fix for alias scanning, and other miscellaneous fixes

### DIFF
--- a/src/Command/Update-CommandHelp.cs
+++ b/src/Command/Update-CommandHelp.cs
@@ -113,7 +113,13 @@ namespace Microsoft.PowerShell.PlatyPS
             syntaxDiagnostics.ForEach(d => helpCopy.Diagnostics.TryAddDiagnostic(d));
 
             // Alias - there are no aliases to be found in the cmdlet, but we shouldn't add the boiler plate.
+            // If the boiler plate is found, we'll clear the aliases.
             helpCopy.AliasHeaderFound = true;
+            if (helpCopy.Aliases.Any(s => s.IndexOf(Constants.AliasMessage2, StringComparison.OrdinalIgnoreCase) >= 0))
+            {
+                helpCopy.Aliases?.Clear();
+            }
+
 
             // Parameters
             if (TryGetMergedParameters(helpCopy.Parameters, fromCmdlet.Parameters, out var mergedParametersList, out var paramDiagnostics))

--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -185,33 +185,55 @@ namespace Microsoft.PowerShell.PlatyPS
             if (dictionary["metadata"] is IDictionary<object, object> metadata)
             {
                 help.Metadata = GetMetadataFromDictionary(metadata);
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.General, "Found Metadata", DiagnosticSeverity.Information, "yaml metadata", -1);
             }
 
             if (dictionary["synopsis"] is string synopsis)
             {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Synopsis, $"Synopsis length: {synopsis.Length} ", DiagnosticSeverity.Information, "yaml synopsis", -1);
                 help.Synopsis = synopsis;
+            }
+            else
+            {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Synopsis, "No synopsis", DiagnosticSeverity.Warning, "yaml synopsis", -1);
             }
 
             if (dictionary["title"] is string title)
             {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.General, $"Title length: {title.Length} ", DiagnosticSeverity.Information, "yaml title", -1);
                 help.Title = title;
+            }
+            else
+            {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.General, "No title", DiagnosticSeverity.Warning, "yaml title", -1);
             }
 
             if (dictionary["description"] is string description)
             {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Description, $"Description length: {description.Length} ", DiagnosticSeverity.Information, "yaml description", -1);
                 help.Description = description;
+            }
+            else
+            {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Description, "No description", DiagnosticSeverity.Warning, "yaml description", -1);
             }
 
             if (dictionary["notes"] is string notes)
             {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Notes, $"notes length: {notes.Length} ", DiagnosticSeverity.Information, "yaml notes", -1);
                 help.Notes = notes;
             }
             else
             {
+                help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.Notes, "No description", DiagnosticSeverity.Information, "yaml notes", -1);
                 help.Notes = string.Empty;
             }
 
             help.Syntax.AddRange(GetSyntaxFromDictionary(dictionary));
+            if (help.Aliases is not null)
+            {
+                help.Aliases.AddRange(GetAliasesFromDictionary(dictionary));
+            }
             help.Examples?.AddRange(GetExamplesFromDictionary(dictionary));
             help.Parameters.AddRange(GetParametersFromDictionary(dictionary));
             help.Inputs.AddRange(GetInputsFromDictionary(dictionary));
@@ -225,9 +247,6 @@ namespace Microsoft.PowerShell.PlatyPS
             if (help.Metadata is not null)
             {
                 help.ModuleGuid = help.Metadata.Contains("ModuleGuid") ? new Guid(help.Metadata["ModuleGuid"].ToString()) : null;
-                // help.ExternalHelpFile = help.Metadata.Contains("external help file") ? help.Metadata["external help file"].ToString() : string.Empty;
-                // help.OnlineVersionUrl = help.Metadata.Contains("HelpUri") ? help.Metadata["HelpUri"].ToString() : string.Empty;
-                // help.SchemaVersion = help.Metadata.Contains("PlatyPS schema version") ? help.Metadata["PlatyPS schema version"].ToString() : string.Empty;
                 help.ModuleName = help.Metadata.Contains("Module Name") ? help.Metadata["Module Name"].ToString() : string.Empty;
             }
 
@@ -557,6 +576,19 @@ namespace Microsoft.PowerShell.PlatyPS
                 }
             }
             return links;
+        }
+
+        private static List<string> GetAliasesFromDictionary(OrderedDictionary dictionary)
+        {
+            List<string> aliases = new();
+            if (dictionary["aliases"] is List<object> aliasList)
+            {
+                foreach(var alias in aliasList)
+                {
+                    aliases.Add(alias.ToString());
+                }
+            }
+            return aliases;
         }
 
         private static List<Example> GetExamplesFromDictionary(OrderedDictionary dictionary)

--- a/src/Model/SyntaxItem.cs
+++ b/src/Model/SyntaxItem.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
             if (positionList.Count > 0)
             {
-                sortedList.AddRange(positionList.OrderBy(p => int.Parse(p.Position)));
+                sortedList.AddRange(positionList.OrderBy(p => int.TryParse(p.Position, out var pos) ? pos : int.MaxValue));
             }
 
             if (mandatoryList.Count > 0)

--- a/src/YamlWriter/CommandHelpYamlWriter.cs
+++ b/src/YamlWriter/CommandHelpYamlWriter.cs
@@ -117,8 +117,10 @@ namespace Microsoft.PowerShell.PlatyPS.YamlWriter
         {
             if (help.Aliases?.Count > 0)
             {
-                string aliasString = string.Join(", ", help.Aliases);
-                sb.AppendLine($"{Constants.yamlAliasHeader} {aliasString}");
+                Hashtable aliasHash = new();
+                aliasHash.Add("aliases", help.Aliases);
+                string aliasString = YamlUtils.SerializeElement(aliasHash).Trim();
+                sb.AppendLine(aliasString);
             }
             else
             {

--- a/test/Pester/ExportYamlModuleFile.Tests.ps1
+++ b/test/Pester/ExportYamlModuleFile.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Describe "Export-YamlModuleFile tests" {
     BeforeAll {
         $moduleFileNames = "Microsoft.PowerShell.Archive.md", "Microsoft.PowerShell.Core.md",

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -13,10 +13,10 @@ Describe "Export-MarkdownModuleFile" {
 
     It "Should identify all the '<fileType>' assets" -TestCases @(
         @{ fileType = "unknown"; expectedCount = 2 }
-        @{ fileType = "CommandHelp"; expectedCount = 32 }
+        @{ fileType = "CommandHelp"; expectedCount = 33 }
         @{ fileType = "ModuleFile"; expectedCount = 14 }
         @{ fileType = "V1Schema"; expectedCount = 45 }
-        @{ fileType = "V2Schema"; expectedCount = 1 }
+        @{ fileType = "V2Schema"; expectedCount = 2 }
     ) {
         param ($fileType, $expectedCount)
         $idents.Where({($_.FileType -band $fileType) -eq $fileType}).Count | Should -Be $expectedCount

--- a/test/Pester/Miscellaneous.Tests.ps1
+++ b/test/Pester/Miscellaneous.Tests.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Miscellaneous tests" {
+    Context "Alias preservation" {
+        BeforeAll {
+            $cmdHelpPath = [io.path]::Combine($PSScriptRoot, "assets", "Get-ChildItem.V2.md")
+            $ch_md = Import-MarkdownCommandHelp $cmdHelpPath
+            $fPath = $ch_md | Export-YamlCommandHelp -output $TESTDRIVE -Force
+            $ch_yaml = Import-YamlCommandHelp $fPath
+        }
+
+        It "Should preserve the aliases" {
+            $ch_md.Aliases | Should -Not -BeNullOrEmpty
+            $ch_md.Aliases | Should -Be $ch_yaml.Aliases
+        }
+
+        It "Should have the correct diagnostic message from the markdown parse" {
+            $message = $ch_md.Diagnostics.Messages.Where({$_.source -eq "alias" -and $_.Identifier -match "length"})
+            $message | Should -Not -BeNullOrEmpty
+            $message.Identifier | Should -Match "118"
+        }
+
+    }
+}

--- a/test/Pester/assets/Get-ChildItem.V2.md
+++ b/test/Pester/assets/Get-ChildItem.V2.md
@@ -1,0 +1,1238 @@
+---
+document type: cmdlet
+external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
+HelpUri: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.4&WT.mc_id=ps-gethelp
+Locale: en-US
+Module Name: Microsoft.PowerShell.Management
+ms.date: 08/09/2024
+PlatyPS schema version: 2024-05-01
+title: Get-ChildItem
+alias: dir, ls, gci
+---
+
+# Get-ChildItem
+
+## SYNOPSIS
+
+Gets the items and child items in one or more specified locations.
+
+## SYNTAX
+
+### Items (Default)
+
+```
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-Depth <uint>] [-Force] [-Name] [<CommonParameters>]
+```
+
+### LiteralItems
+
+```
+Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name] [<CommonParameters>]
+```
+
+### Items (Default) - Certificate provider
+
+```
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-Depth <uint>] [-Force] [-Name] [-CodeSigningCert] [-DocumentEncryptionCert]
+ [-SSLServerAuthentication] [-DnsName <string>] [-Eku <string[]>] [-ExpiringInDays <int>]
+ [<CommonParameters>]
+```
+
+### LiteralItems - Certificate provider
+
+```
+Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name] [-CodeSigningCert]
+ [-DocumentEncryptionCert] [-SSLServerAuthentication] [-DnsName <string>] [-Eku <string[]>]
+ [-ExpiringInDays <int>] [<CommonParameters>]
+```
+
+### Items (Default) - Filesystem provider
+
+```
+Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>] [-Exclude <string[]>]
+ [-Recurse] [-Depth <uint>] [-Force] [-Name] [-Attributes <FlagsExpression[FileAttributes]>]
+ [-FollowSymlink] [-Directory] [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+```
+
+### LiteralItems - FileSystem provider
+
+```
+Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>]
+ [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name]
+ [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory] [-File] [-Hidden]
+ [-ReadOnly] [-System] [<CommonParameters>]
+```
+
+## ALIASES
+
+PowerShell includes the following aliases for `Get-ChildItem`:
+
+- All platforms:
+  - `dir`, `gci`
+- Windows:
+  - `ls`
+
+## DESCRIPTION
+
+The `Get-ChildItem` cmdlet gets the items in one or more specified locations. If the item is a
+container, it gets the items inside the container, known as child items. You can use the **Recurse**
+parameter to get items in all child containers and use the **Depth** parameter to limit the number
+of levels to recurse.
+
+`Get-ChildItem` doesn't display empty directories. When a `Get-ChildItem` command includes the
+**Depth** or **Recurse** parameters, empty directories aren't included in the output.
+
+Locations are exposed to `Get-ChildItem` by PowerShell providers. A location can be a file system
+directory, registry hive, or a certificate store. Some parameters are only available for a specific
+provider. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+
+## EXAMPLES
+
+### Example 1: Get child items from a file system directory
+
+This example gets the child items from a file system directory. The filenames and subdirectory
+names are displayed. For empty locations, the command doesn't return any output and returns to the
+PowerShell prompt.
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test`.
+`Get-ChildItem` displays the files and directories in the PowerShell console.
+
+```powershell
+Get-ChildItem -Path C:\Test
+```
+
+```Output
+   Directory: C:\Test
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/15/2019     08:29                Logs
+-a----        2/13/2019     08:55             26 anotherfile.txt
+-a----        2/12/2019     15:40         118014 Command.txt
+-a----         2/1/2019     08:43            183 CreateTestFile.ps1
+-ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+```
+
+By default `Get-ChildItem` lists the mode (**Attributes**), **LastWriteTime**, file size
+(**Length**), and the **Name** of the item. The letters in the **Mode** property can be interpreted
+as follows:
+
+- `l` (link)
+- `d` (directory)
+- `a` (archive)
+- `r` (read-only)
+- `h` (hidden)
+- `s` (system)
+
+For more information about the mode flags, see
+[about_Filesystem_Provider](../microsoft.powershell.core/about/about_filesystem_provider.md#attributes-flagsexpression).
+
+### Example 2: Get child item names in a directory
+
+This example lists only the names of items in a directory.
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test`. The
+**Name** parameter returns only the file or directory names from the specified path. The names
+returned are relative to the value of the **Path** parameter.
+
+```powershell
+Get-ChildItem -Path C:\Test -Name
+```
+
+```Output
+Logs
+anotherfile.txt
+Command.txt
+CreateTestFile.ps1
+ReadOnlyFile.txt
+```
+
+### Example 3: Get child items in the current directory and subdirectories
+
+This example displays `.txt` files that are located in the current directory and its
+subdirectories.
+
+```powershell
+Get-ChildItem -Path .\*.txt -Recurse -Force
+```
+
+```Output
+    Directory: C:\Test\Logs\Adirectory
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        2/12/2019     16:16             20 Afile4.txt
+-a-h--        2/12/2019     15:52             22 hiddenfile.txt
+-a----        2/13/2019     13:26             20 LogFile4.txt
+
+    Directory: C:\Test\Logs\Backup
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        2/12/2019     16:16             20 ATextFile.txt
+-a----        2/12/2019     15:50             20 LogFile3.txt
+
+    Directory: C:\Test\Logs
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        2/12/2019     16:16             20 Afile.txt
+-a-h--        2/12/2019     15:52             22 hiddenfile.txt
+-a----        2/13/2019     13:26             20 LogFile1.txt
+
+    Directory: C:\Test
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        2/13/2019     08:55             26 anotherfile.txt
+-a----        2/12/2019     15:40         118014 Command.txt
+-a-h--        2/12/2019     15:52             22 hiddenfile.txt
+-ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+```
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify `C:\Test\*.txt`. **Path** uses the
+asterisk (`*`) wildcard to specify all files with the filename extension `.txt`. The **Recurse**
+parameter searches the **Path** directory and its subdirectories, as shown in the **Directory:**
+headings. The **Force** parameter displays hidden files such as `hiddenfile.txt` that have a mode of
+**h**.
+
+### Example 4: Get child items using the Include parameter
+
+In this example `Get-ChildItem` uses the **Include** parameter to find specific items from the
+directory specified by the **Path** parameter.
+
+```powershell
+# When using the -Include parameter, if you don't include an asterisk in the path
+# the command returns no output.
+Get-ChildItem -Path C:\Test\ -Include *.txt
+```
+
+```Output
+
+```
+
+```powershell
+Get-ChildItem -Path C:\Test\* -Include *.txt
+```
+
+```Output
+    Directory: C:\Test
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----        2/13/2019     08:55             26 anotherfile.txt
+-a----        2/12/2019     15:40         118014 Command.txt
+-ar---        2/12/2019     14:31             27 ReadOnlyFile.txt
+```
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test`. The
+**Path** parameter includes a trailing asterisk (`*`) wildcard to specify the directory's contents.
+The **Include** parameter uses an asterisk (`*`) wildcard to specify all files with the file name
+extension `.txt`.
+
+When the **Include** parameter is used, the **Path** parameter needs a trailing asterisk (`*`)
+wildcard to specify the directory's contents. For example, `-Path C:\Test\*`.
+
+- If the **Recurse** parameter is added to the command, the trailing asterisk (`*`) in the **Path**
+  parameter is optional. The **Recurse** parameter gets items from the **Path** directory and its
+  subdirectories. For example, `-Path C:\Test\ -Recurse -Include *.txt`
+- If a trailing asterisk (`*`) isn't included in the **Path** parameter, the command doesn't return
+  any output and returns to the PowerShell prompt. For example, `-Path C:\Test\`.
+
+### Example 5: Get child items using the Exclude parameter
+
+The example's output shows the contents of the directory `C:\Test\Logs`. The output is a reference
+for the other commands that use the **Exclude** and **Recurse** parameters.
+
+```powershell
+Get-ChildItem -Path C:\Test\Logs
+```
+
+```Output
+    Directory: C:\Test\Logs
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/15/2019     13:21                Adirectory
+d-----        2/15/2019     08:28                AnEmptyDirectory
+d-----        2/15/2019     13:21                Backup
+-a----        2/12/2019     16:16             20 Afile.txt
+-a----        2/13/2019     13:26             20 LogFile1.txt
+-a----        2/12/2019     16:24             23 systemlog1.log
+```
+
+```powershell
+Get-ChildItem -Path C:\Test\Logs\* -Exclude A*
+```
+
+```Output
+    Directory: C:\Test\Logs
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/15/2019     13:21                Backup
+-a----        2/13/2019     13:26             20 LogFile1.txt
+-a----        2/12/2019     16:24             23 systemlog1.log
+```
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the directory `C:\Test\Logs`. The
+**Exclude** parameter uses the asterisk (`*`) wildcard to specify any files or directories that
+begin with `A` or `a` are excluded from the output.
+
+When the **Exclude** parameter is used, a trailing asterisk (`*`) in the **Path** parameter is
+optional. For example, `-Path C:\Test\Logs` or `-Path C:\Test\Logs\*`.
+
+- If a trailing asterisk (`*`) isn't included in the **Path** parameter, the contents of the
+  **Path** parameter are displayed. The exceptions are filenames or subdirectory names that match
+  the **Exclude** parameter's value.
+- If a trailing asterisk (`*`) is included in the **Path** parameter, the command recurses into the
+  **Path** parameter's subdirectories. The exceptions are filenames or subdirectory names that match
+  the **Exclude** parameter's value.
+- If the **Recurse** parameter is added to the command, the recursion output is the same whether or
+  not the **Path** parameter includes a trailing asterisk (`*`).
+
+### Example 6: Get the registry keys from a registry hive
+
+This example gets all the registry keys from `HKEY_LOCAL_MACHINE\HARDWARE`.
+
+`Get-ChildItem` uses the **Path** parameter to specify the registry key `HKLM:\HARDWARE`. The hive's
+path and top level of registry keys are displayed in the PowerShell console.
+
+For more information, see
+[about_Registry_Provider](../Microsoft.PowerShell.Core/About/about_Registry_Provider.md).
+
+```powershell
+Get-ChildItem -Path HKLM:\HARDWARE
+```
+
+```Output
+    Hive: HKEY_LOCAL_MACHINE\HARDWARE
+
+Name             Property
+----             --------
+ACPI
+DESCRIPTION
+DEVICEMAP
+RESOURCEMAP
+UEFI
+```
+
+```powershell
+Get-ChildItem -Path HKLM:\HARDWARE -Exclude D*
+```
+
+```Output
+   Hive: HKEY_LOCAL_MACHINE\HARDWARE
+
+Name                           Property
+----                           --------
+ACPI
+RESOURCEMAP
+```
+
+The first command shows the contents of the `HKLM:\HARDWARE` registry key. The **Exclude** parameter
+tells `Get-ChildItem` not to return any subkeys that start with `D*`. Currently, the **Exclude**
+parameter only works on subkeys, not item properties.
+
+### Example 7: Get all certificates with code-signing authority
+
+This example gets each certificate in the PowerShell `Cert:` drive that has code-signing authority.
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify the Certificate provider with the
+`Cert:` drive. The **Recurse** parameter searches the directory specified by **Path** and its
+subdirectories. The **CodeSigningCert** parameter gets only certificates that have code-signing
+authority.
+
+```powershell
+Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
+```
+
+For more information about the Certificate provider and the `Cert:` drive,
+see [about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md).
+
+### Example 8: Get items using the Depth parameter
+
+This example displays the items in a directory and its subdirectories. The **Depth** parameter
+determines the number of subdirectory levels to include in the recursion. Empty directories are
+excluded from the output.
+
+```powershell
+Get-ChildItem -Path C:\Parent -Depth 2
+```
+
+```Output
+    Directory: C:\Parent
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/14/2019     10:24                SubDir_Level1
+-a----        2/13/2019     08:55             26 file.txt
+
+    Directory: C:\Parent\SubDir_Level1
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/14/2019     10:24                SubDir_Level2
+-a----        2/13/2019     08:55             26 file.txt
+
+    Directory: C:\Parent\SubDir_Level1\SubDir_Level2
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+d-----        2/14/2019     10:22                SubDir_Level3
+-a----        2/13/2019     08:55             26 file.txt
+```
+
+The `Get-ChildItem` cmdlet uses the **Path** parameter to specify `C:\Parent`. The **Depth**
+parameter specifies two levels of recursion. `Get-ChildItem` displays the contents of the directory
+specified by the **Path** parameter and the two levels of subdirectories.
+
+### Example 9: Getting hard link information
+
+In PowerShell 6.2, an alternate view was added to get hard link information.
+
+```powershell
+Get-ChildItem -Path C:\PathContainingHardLink | Format-Table -View childrenWithHardLink
+```
+
+### Example 10: Output for Non-Windows Operating Systems
+
+In PowerShell 7.1 on Unix systems, the `Get-ChildItem` provides Unix-like output:
+
+```powershell
+PS> Get-ChildItem /etc/r*
+```
+
+```Output
+    Directory: /etc
+
+UnixMode   User Group    LastWriteTime Size Name
+--------   ---- -----    ------------- ---- ----
+drwxr-xr-x root wheel  9/30/2019 19:19  128 racoon
+-rw-r--r-- root wheel  9/26/2019 18:20 1560 rc.common
+-rw-r--r-- root wheel  7/31/2017 17:30 1560 rc.common~previous
+-rw-r--r-- root wheel  9/27/2019 20:34 5264 rc.netboot
+lrwxr-xr-x root wheel  11/8/2019 15:35   22 resolv.conf -> /private/var/run/resolv.conf
+-rw-r--r-- root wheel 10/23/2019 17:41    0 rmtab
+-rw-r--r-- root wheel 10/23/2019 17:41 1735 rpc
+-rw-r--r-- root wheel  7/25/2017 18:37 1735 rpc~previous
+-rw-r--r-- root wheel 10/23/2019 18:42  891 rtadvd.conf
+-rw-r--r-- root wheel  8/24/2017 21:54  891 rtadvd.conf~previous
+```
+
+The new properties that are now part of the output are:
+
+- **UnixMode** is the file permissions as represented on a Unix system
+- **User** is the file owner
+- **Group** is the group owner
+- **Size** is the size of the file or directory as represented on a Unix system
+
+> [!NOTE]
+> This feature was moved from experimental to mainstream in PowerShell 7.1.
+
+### Example 11: Get the link target for a junction point
+
+The `dir` command in the Windows Command Shell shows the target location of a filesystem junction
+point. In PowerShell, this information is available from the **LinkTarget** property of the
+filesystem object returned by `Get-ChildItem` and is displayed in the default output.
+
+```powershell
+PS D:\> New-Item -ItemType Junction -Name tmp -Target $env:TEMP
+PS D:\> Get-ChildItem | Select-Object name,LinkTarget
+
+Name     LinkTarget
+----     ----------
+tmp      C:\Users\user1\AppData\Local\Temp
+
+PS D:\> Get-ChildItem
+
+    Directory: D:\
+
+Mode          LastWriteTime    Length Name
+----          -------------    ------ ----
+l----   12/16/2021  9:29 AM           tmp -> C:\Users\user1\AppData\Local\Temp
+```
+
+### Example 12: Get the link target for an AppX reparse point
+
+This example attempts to get the target information for an AppX reparse point. Microsoft Store
+applications create AppX reparse points in the user's AppData directory.
+
+```powershell
+Get-ChildItem ~\AppData\Local\Microsoft\WindowsApps\MicrosoftEdge.exe |
+    Select-Object Mode, LinkTarget, LinkType, Name
+```
+
+```Output
+Mode  LinkTarget LinkType Name
+----  ---------- -------- ----
+la---                     MicrosoftEdge.exe
+```
+
+At this time, Windows doesn't provide a way to get the target information for an AppX reparse point.
+The **LinkTarget** and **LinkType** properties of the filesystem object are empty.
+
+## PARAMETERS
+
+### -Attributes
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+Gets files and folders with the specified attributes. This parameter supports all attributes and
+lets you specify complex combinations of attributes.
+
+For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
+`Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed`
+
+To find files and folders with commonly used attributes, use the **Attributes** parameter. Or, the
+parameters **Directory**, **File**, **Hidden**, **ReadOnly**, and **System**.
+
+The **Attributes** parameter supports the following properties:
+
+- **Archive**
+- **Compressed**
+- **Device**
+- **Directory**
+- **Encrypted**
+- **Hidden**
+- **IntegrityStream**
+- **Normal**
+- **NoScrubData**
+- **NotContentIndexed**
+- **Offline**
+- **ReadOnly**
+- **ReparsePoint**
+- **SparseFile**
+- **System**
+- **Temporary**
+
+For a description of these attributes, see the [FileAttributes Enumeration](/dotnet/api/system.io.fileattributes).
+
+To combine attributes, use the following operators:
+
+- `!` (NOT)
+- `+` (AND)
+- `,` (OR)
+
+Don't use spaces between an operator and its attribute. Spaces are accepted after commas.
+
+For common attributes, use the following abbreviations:
+
+- `D` (Directory)
+- `H` (Hidden)
+- `R` (Read-only)
+- `S` (System)
+
+```yaml
+Type: System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues:
+- Archive
+- Compressed
+- Device
+- Directory
+- Encrypted
+- Hidden
+- IntegrityStream
+- Normal
+- NoScrubData
+- NotContentIndexed
+- Offline
+- ReadOnly
+- ReparsePoint
+- SparseFile
+- System
+- Temporary
+HelpMessage: ''
+```
+
+### -CodeSigningCert
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Code Signing` in their **EnhancedKeyUsageList** property
+value, use the **CodeSigningCert** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Depth
+
+This parameter was added in PowerShell 5.0 and enables you to control the depth of recursion. By
+default, `Get-ChildItem` displays the contents of the parent directory. The **Depth** parameter
+determines the number of subdirectory levels that are included in the recursion and displays the
+contents.
+
+For example, `-Depth 2` includes the **Path** parameter's directory, first level of subdirectories,
+and second level of subdirectories. By default directory names and filenames are included in the
+output.
+
+> [!NOTE]
+> On a Windows computer from PowerShell or **cmd.exe**, you can display a graphical view of a
+> directory structure with the **tree.com** command.
+
+```yaml
+Type: System.UInt32
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Directory
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+To get a list of directories, use the **Directory** parameter or the **Attributes** parameter with
+the **Directory** property. You can use the **Recurse** parameter with **Directory**.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- ad
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DnsName
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies a domain name or name pattern to match with the **DNSNameList** property of certificates
+the cmdlet gets. The value of this parameter can either be `Unicode` or `ASCII`. Punycode values
+are converted to Unicode. Wildcard characters (`*`) are permitted.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: Microsoft.PowerShell.Commands.DnsNameRepresentation
+DefaultValue: None
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DocumentEncryptionCert
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Document Encryption` in their **EnhancedKeyUsageList**
+property value, use the **DocumentEncryptionCert** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Eku
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies text or a text pattern to match with the **EnhancedKeyUsageList** property of
+certificates the cmdlet gets. Wildcard characters (`*`) are permitted. The **EnhancedKeyUsageList**
+property contains the friendly name and the OID fields of the EKU.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: System.String
+DefaultValue: None
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Exclude
+
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is excluded from the output. Enter a path element or pattern, such as `*.txt` or `A*`.
+Wildcard characters are accepted.
+
+A trailing asterisk (`*`) in the **Path** parameter is optional. For example, `-Path C:\Test\Logs`
+or `-Path C:\Test\Logs\*`. If a trailing asterisk (`*`) is included, the command recurses into the
+**Path** parameter's subdirectories. Without the asterisk (`*`), the contents of the **Path**
+parameter are displayed. More details are included in Example 5 and the Notes section.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
+
+```yaml
+Type: System.String[]
+DefaultValue: None
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ExpiringInDays
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+Specifies that the cmdlet should only return certificates that are expiring in or before the
+specified number of days. A value of zero (`0`) gets certificates that have expired.
+
+This parameter was reintroduced in PowerShell 7.1
+
+```yaml
+Type: System.Int32
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -File
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+To get a list of files, use the **File** parameter. You can use the **Recurse** parameter with
+**File**.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- af
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Filter
+
+Specifies a filter to qualify the **Path** parameter. The
+[FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider is the only
+installed PowerShell provider that supports filters. Filters are more efficient than other
+parameters. The provider applies filter when the cmdlet gets the objects rather than having
+PowerShell filter the objects after they're retrieved. The filter string is passed to the .NET API
+to enumerate files. The API only supports `*` and `?` wildcards.
+
+```yaml
+Type: System.String
+DefaultValue: None
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 1
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -FollowSymlink
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+By default, the `Get-ChildItem` cmdlet displays symbolic links to directories found during
+recursion, but doesn't recurse into them. Use the **FollowSymlink** parameter to search the
+directories that target those symbolic links. The **FollowSymlink** is a dynamic parameter and is
+supported only in the **FileSystem** provider.
+
+This parameter was introduced in PowerShell 6.0.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Force
+
+Allows the cmdlet to get items that otherwise can't be accessed by the user, such as hidden or
+system files. The **Force** parameter doesn't override security restrictions. Implementation varies
+among providers. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Hidden
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+To get only hidden items, use the **Hidden** parameter or the **Attributes** parameter with the
+**Hidden** property. By default, `Get-ChildItem` doesn't display hidden items. Use the **Force**
+parameter to get hidden items.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- ah
+- h
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Include
+
+Specifies an array of one or more string patterns to be matched as the cmdlet gets child items. Any
+matching item is included in the output. Enter a path element or pattern, such as `"*.txt"`.
+Wildcard characters are permitted. The **Include** parameter is effective only when the command
+includes the contents of an item, such as `C:\Windows\*`, where the wildcard character specifies the
+contents of the `C:\Windows` directory.
+
+The **Include** and **Exclude** parameters can be used together. However, the exclusions are applied
+after the inclusions, which can affect the final output.
+
+```yaml
+Type: System.String[]
+DefaultValue: None
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -LiteralPath
+
+Specifies a path to one or more locations. The value of **LiteralPath** is used exactly as it's
+typed. No characters are interpreted as wildcards. If the path includes escape characters, enclose
+it in single quotation marks. Single quotation marks tell PowerShell to not interpret any characters
+as escape sequences.
+
+For more information, see [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md).
+
+```yaml
+Type: System.String[]
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- PSPath
+- LP
+ParameterSets:
+- Name: LiteralItems
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: true
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+Gets only the names of the items in the location. The output is a string object that can be sent
+down the pipeline to other commands. The names returned are relative to the value of the **Path**
+parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Path
+
+Specifies a path to one or more locations. Wildcards are accepted. The default location is the
+current directory (`.`).
+
+```yaml
+Type: System.String[]
+DefaultValue: Current directory
+SupportsWildcards: true
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: Items
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: true
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ReadOnly
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+To get only read-only items, use the **ReadOnly** parameter or the **Attributes** parameter
+**ReadOnly** property.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- ar
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Recurse
+
+Gets the items in the specified locations and in all child items of the locations.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- s
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SSLServerAuthentication
+
+> [!NOTE]
+> This parameter is only available in the
+> [Certificate](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md) provider.
+
+To get a list of certificates that have `Server Authentication` in their **EnhancedKeyUsageList**
+property value, use the **SSLServerAuthentication** parameter.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -System
+
+> [!NOTE]
+> This parameter is only available in the
+> [FileSystem](../Microsoft.PowerShell.Core/About/about_FileSystem_Provider.md) provider.
+
+Gets only system files and directories. To get only system files and folders, use the **System**
+parameter or **Attributes** parameter **System** property.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: None
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- as
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+You can pipe a string that contains a path to this cmdlet.
+
+## OUTPUTS
+
+### System.Management.Automation.AliasInfo
+
+The cmdlet outputs this type when accessing the `Alias:` drive.
+
+### Microsoft.PowerShell.Commands.X509StoreLocation
+
+### System.Security.Cryptography.X509Certificates.X509Store
+
+### System.Security.Cryptography.X509Certificates.X509Certificate2
+
+The cmdlet outputs these types when accessing the `Cert:` drive.
+
+### System.Collections.DictionaryEntry
+
+The cmdlet outputs this type when accessing the `Env:` drive.
+
+### System.IO.DirectoryInfo
+
+### System.IO.FileInfo
+
+The cmdlet outputs these types when accessing the Filesystem drives.
+
+### System.Management.Automation.FunctionInfo
+
+### System.Management.Automation.FilterInfo
+
+The cmdlet outputs these types when accessing the `Function:` drives.
+
+### Microsoft.Win32.RegistryKey
+
+The cmdlet outputs this type when accessing the Registry drives.
+
+### System.Management.Automation.PSVariable
+
+The cmdlet outputs this type when accessing the `Variable:` drives.
+
+### Microsoft.WSMan.Management.WSManConfigContainerElement
+
+### Microsoft.WSMan.Management.WSManConfigLeafElement
+
+The cmdlet outputs these types when accessing the `WSMan:` drives.
+
+### System.String
+
+When you use the **Name** parameter, this cmdlet returns the object names as strings.
+
+## NOTES
+
+`Get-ChildItem` doesn't get hidden items by default. To get hidden items, use the **Force**
+parameter.
+
+The `Get-ChildItem` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
+
+## RELATED LINKS
+
+- [about_Certificate_Provider](../Microsoft.PowerShell.Security/About/about_Certificate_Provider.md)
+- [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)
+- [about_Quoting_Rules](../Microsoft.Powershell.Core/About/about_Quoting_Rules.md)
+- [about_Registry_Provider](../Microsoft.PowerShell.Core/About/about_Registry_Provider.md)
+- [ForEach-Object](../Microsoft.PowerShell.Core/ForEach-Object.md)
+- [Get-Alias](../Microsoft.PowerShell.Utility/Get-Alias.md)
+- [Get-Item](Get-Item.md)
+- [Get-Location](Get-Location.md)
+- [Get-Process](Get-Process.md)
+- [Get-PSProvider](Get-PSProvider.md)
+- [Split-Path](Split-Path.md)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Fix issues scanning for aliases in markdown. 
  - Aliases are not a list, but unparsed markdown.
  - Add a new get-childitem v2 help file for testing aliases.
- Add some improved diagnostics for parsing yaml (more to do here)
- Improve diagnostics for alias scanning in markdown.
- Fix an issue in SyntaxItem parameter sorting to handle cases where a position may not be known
  - (such as command help as generated by MAML).
- Change yaml serialization for aliases to use yaml serializer.
- Add copyright to exportyamlmodulefile tests.


<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
