### PR TITLE
Fix MAML Namespaces for rendering (v2)

### DIFF
--- a/src/MamlWriter/DataType.cs
+++ b/src/MamlWriter/DataType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         /// <summary>
         ///     The data-type name.
         /// </summary>
-        [XmlElement("name", Namespace = Constants.XmlNamespace.Dev, Order = 0)]
+        [XmlElement("name", Namespace = Constants.XmlNamespace.MAML, Order = 0)]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>

--- a/src/MamlWriter/RelatedLink.cs
+++ b/src/MamlWriter/RelatedLink.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         /// <summary>
         ///     The command parameters associated with this syntax.
         /// </summary>
-        [XmlElement("uri", Namespace = Constants.XmlNamespace.Command, Order = 1)]
+        [XmlElement("uri", Namespace = Constants.XmlNamespace.MAML, Order = 1)]
         public string Uri { get; set; } = string.Empty;
 
         public bool Equals(NavigationLink other)


### PR DESCRIPTION
# PR Summary

This PR is fix the wrong XML namespaces generated by `Export-MamlCommandHelp`.

- fix XML namespace of `name` element in `<command:inputType><dev:type>` and `<command:returnValue><dev:type>` to `MAML` instead of `Dev`
- fix XML namespace of `uri` element in `<maml:navigationLink>`  to `MAML` instead of `Command`

## PR Context

I noticed the error when comparing the original XML with the generated XML.
