### PR TITLE
Follow pascal casing on -AbbreviateParameterTypename parameter

### DIFF
--- a/src/Command/NewMarkdownHelpCommand.cs
+++ b/src/Command/NewMarkdownHelpCommand.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.PlatyPS
         public SwitchParameter WithModulePage { get; set; }
 
         [Parameter]
-        public SwitchParameter AbbreviateParameterTypename { get; set; }
+        public SwitchParameter AbbreviateParameterTypeName { get; set; }
 
         #endregion
 
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.PlatyPS
                         ModuleName = cmd.ModuleName is null ? string.Empty : cmd.ModuleName,
                         ModuleGuid = cmd.Module?.Guid is null ? Guid.Empty : cmd.Module.Guid,
                         OnlineVersionUrl = HelpUri,
-                        UseFullTypeName = ! AbbreviateParameterTypename
+                        UseFullTypeName = ! AbbreviateParameterTypeName
                     };
 
                     try

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -554,7 +554,7 @@ Write-Host 'Hello World!'
             $expectedParameterNames = "CCC","ddd","WhatIf"
             $expectedParameterTypes = "String","Nullable``1[System.Int32]","SwitchParameter"
             $expectedSyntax = 'Get-Alpha [[-CCC] <string>] [[-ddd] <int>] [-WhatIf] [<CommonParameters>]'
-            $file = New-MarkdownCommandHelp -Command (get-command Get-Alpha) -OutputFolder "$TestDrive/alpha" -Force -AbbreviateParameterTypename
+            $file = New-MarkdownCommandHelp -Command (get-command Get-Alpha) -OutputFolder "$TestDrive/alpha" -Force -AbbreviateParameterTypeName
             $ch = Import-MarkdownCommandHelp $file
             $ch.Parameters.Name | Should -Be $expectedParameterNames
             $ch.Parameters.Type | Should -Be $expectedParameterTypes

--- a/v2docs/Microsoft.PowerShell.PlatyPS/New-MarkdownCommandHelp.md
+++ b/v2docs/Microsoft.PowerShell.PlatyPS/New-MarkdownCommandHelp.md
@@ -24,7 +24,7 @@ Creates Markdown help files for PowerShell modules and commands.
 New-MarkdownCommandHelp -OutputFolder <string> [-CommandInfo <CommandInfo[]>] [-Encoding <Encoding>]
  [-Force] [-HelpUri <string>] [-HelpInfoUri <string>] [-HelpVersion <version>] [-Locale <string>]
  [-Metadata <hashtable>] [-ModuleInfo <psmoduleinfo[]>] [-WithModulePage]
- [-AbbreviateParameterTypename] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-AbbreviateParameterTypeName] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
@@ -61,7 +61,7 @@ New-MarkdownCommandHelp @newMarkdownCommandHelpSplat
 
 ## PARAMETERS
 
-### -AbbreviateParameterTypename
+### -AbbreviateParameterTypeName
 
 By default, this command uses full type names in the parameter metadata and for the input and output
 types. When you use this parameter, the cmdlet outputs short type names.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Nit: According to the [documentation](https://learn.microsoft.com/en-us/powershell/scripting/developer/format/typename-element-for-types-format?view=powershell-7.4), typename should be in pascal case.

## PR Context

Just in the small details.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
