### PR TITLE
Ensure empty descriptions  notes, inputs, outputs and links create an accurate YAML

### DIFF
--- a/src/YamlWriter/CommandHelpYamlWriter.cs
+++ b/src/YamlWriter/CommandHelpYamlWriter.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.PlatyPS.YamlWriter
                 }
                 else
                 {
-                    sb.AppendLine("  description:");
+                    sb.AppendLine("  description: ''");
                 }
             }
         }
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.PlatyPS.YamlWriter
 
             if (string.IsNullOrEmpty(help.Notes.Trim()))
             {
-                sb.AppendLine(Constants.NotesYamlHeader);
+                sb.AppendLine(Constants.NotesYamlHeader + " ''");
                 return;
             }
 
@@ -239,14 +239,19 @@ namespace Microsoft.PowerShell.PlatyPS.YamlWriter
 
         internal override void WriteRelatedLinks(CommandHelp help)
         {
-            sb.AppendLine(Constants.RelatedLinksYamlHeader);
             if (help.RelatedLinks?.Count > 0)
             {
+                sb.AppendLine(Constants.RelatedLinksYamlHeader);
+
                 foreach (var link in help.RelatedLinks)
                 {
                     sb.AppendLine(string.Format("- text: '{0}'", link.LinkText));
                     sb.AppendLine(string.Format("  href: {0}", link.Uri));
                 }
+            }
+            else
+            {
+                sb.AppendLine(Constants.RelatedLinksYamlHeader + " []");
             }
         }
     }

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -13,10 +13,10 @@ Describe "Export-MarkdownModuleFile" {
 
     It "Should identify all the '<fileType>' assets" -TestCases @(
         @{ fileType = "unknown"; expectedCount = 2 }
-        @{ fileType = "CommandHelp"; expectedCount = 34 }
+        @{ fileType = "CommandHelp"; expectedCount = 35 }
         @{ fileType = "ModuleFile"; expectedCount = 14 }
         @{ fileType = "V1Schema"; expectedCount = 45 }
-        @{ fileType = "V2Schema"; expectedCount = 3 }
+        @{ fileType = "V2Schema"; expectedCount = 4 }
     ) {
         param ($fileType, $expectedCount)
         $idents.Where({($_.FileType -band $fileType) -eq $fileType}).Count | Should -Be $expectedCount

--- a/test/Pester/YamlFormatting.Tests.ps1
+++ b/test/Pester/YamlFormatting.Tests.ps1
@@ -6,8 +6,10 @@ Describe 'Yaml formatting tests' {
         Import-MarkdownCommandHelp -Path 'assets/New-EmptyCommand.md' | Export-YamlCommandHelp -OutputFolder $TestDrive
         $yaml = Get-Content "$TestDrive/New-EmptyCommand.yml" -Raw
 
-        $inputPattern = if ($IsWindows) { 'inputs:\r\n- name: System\.String\r\n  description: ''' } else { 'inputs:\n- name: System\.String\n  description: ''' }
-        $outputPattern = if ($IsWindows) { 'outputs:\r\n- name: System\.String\r\n  description: ''' } else { 'outputs:\n- name: System\.String\n  description: ''' }
+        $isWinPS = $PSVersionTable.PSVersion.Major -eq 5
+
+        $inputPattern = if ($IsWindows -or $IsWinPS) { 'inputs:\r\n- name: System\.String\r\n  description: ''' } else { 'inputs:\n- name: System\.String\n  description: ''' }
+        $outputPattern = if ($IsWindows -or $IsWinPS) { 'outputs:\r\n- name: System\.String\r\n  description: ''' } else { 'outputs:\n- name: System\.String\n  description: ''' }
         $notesPattern = "notes: ''"
         $linksPattern = "links: \[\]"
 

--- a/test/Pester/YamlFormatting.Tests.ps1
+++ b/test/Pester/YamlFormatting.Tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Yaml formatting tests' {
     It 'Inputs output and notes should have empty array when empty' {
-        Import-MarkdownCommandHelp -Path 'test/Pester/assets/New-EmptyCommand.md' | Export-YamlCommandHelp -OutputFolder $TestDrive
+        Import-MarkdownCommandHelp -Path 'assets/New-EmptyCommand.md' | Export-YamlCommandHelp -OutputFolder $TestDrive
         $yaml = Get-Content "$TestDrive/New-EmptyCommand.yml" -Raw
 
         $inputPattern = if ($IsWindows) { 'inputs:\r\n- name: System\.String\r\n  description: ''' } else { 'inputs:\n- name: System\.String\n  description: ''' }

--- a/test/Pester/YamlFormatting.Tests.ps1
+++ b/test/Pester/YamlFormatting.Tests.ps1
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Yaml formatting tests' {
+    It 'Inputs output and notes should have empty array when empty' {
+        Import-MarkdownCommandHelp -Path 'test/Pester/assets/New-EmptyCommand.md' | Export-YamlCommandHelp -OutputFolder $TestDrive
+        $yaml = Get-Content "$TestDrive/New-EmptyCommand.yml" -Raw
+
+        $inputPattern = if ($IsWindows) { 'inputs:\r\n- name: System\.String\r\n  description: ''' } else { 'inputs:\n- name: System\.String\n  description: ''' }
+        $outputPattern = if ($IsWindows) { 'outputs:\r\n- name: System\.String\r\n  description: ''' } else { 'outputs:\n- name: System\.String\n  description: ''' }
+        $notesPattern = "notes: ''"
+        $linksPattern = "links: \[\]"
+
+        $yaml | Should -Match $inputPattern
+        $yaml | Should -Match $outputPattern
+        $yaml | Should -Match $notesPattern
+        $yaml | Should -Match $linksPattern
+    }
+}

--- a/test/Pester/assets/New-EmptyCommand.md
+++ b/test/Pester/assets/New-EmptyCommand.md
@@ -1,0 +1,84 @@
+---
+document type: cmdlet
+external help file: New-EmptyCommand-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: ''
+ms.date: 03/04/2025
+PlatyPS schema version: 2024-05-01
+title: New-EmptyCommand
+---
+
+# New-EmptyCommand
+
+## SYNOPSIS
+
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-EmptyCommand [[-InputString] <string>] [<CommonParameters>]
+```
+
+## ALIASES
+
+This cmdlet has the following aliases,
+  {{Insert list of aliases}}
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -InputString
+
+{{ Fill InputString Description }}
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+ParameterValue: []
+Aliases:
+- InputObject
+- InputParameter
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: true
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes changes to improve the handling of empty values in YAML outputs and adds corresponding tests to ensure the correct formatting. The most important changes include updates to the `YamlWriter` methods and the addition of new test cases.

Improvements to YAML output handling:

* [`src/YamlWriter/CommandHelpYamlWriter.cs`](diffhunk://#diff-58320355751c3f2ed3f95bdaecf7ef5dad5d8826f5098b1f0ccf19ba6ab82366L214-R214): Modified the `WriteInputsOutputs` and `WriteNotes` methods to handle empty values by adding explicit empty strings or arrays in the YAML output. [[1]](diffhunk://#diff-58320355751c3f2ed3f95bdaecf7ef5dad5d8826f5098b1f0ccf19ba6ab82366L214-R214) [[2]](diffhunk://#diff-58320355751c3f2ed3f95bdaecf7ef5dad5d8826f5098b1f0ccf19ba6ab82366L229-R229) [[3]](diffhunk://#diff-58320355751c3f2ed3f95bdaecf7ef5dad5d8826f5098b1f0ccf19ba6ab82366L242-R255)

Addition of new test cases:

* [`test/Pester/YamlFormatting.Tests.ps1`](diffhunk://#diff-27e16f59b527fe767306369ba4981b91d2ef3e18074289e358a1274c05709514R1-R19): Added new test cases to verify that inputs, outputs, notes, and related links are correctly formatted as empty arrays or strings when they are empty.
* [`test/Pester/assets/New-EmptyCommand.md`](diffhunk://#diff-0f5c32512c5f2fe84bd5bcda1082b09912d16883971990818232fc1850e8c90fR1-R84): Added a new markdown file to serve as a test asset for the new YAML formatting tests.

## PR Context

Fixes #710
