### PR TITLE
Ignore parameterValue from Yaml serialization

### DIFF
--- a/src/Model/Parameter.cs
+++ b/src/Model/Parameter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public string Description { get; set;}
 
+        [YamlIgnore]
         public List<string> ParameterValue { get; set;}
 
         public string DefaultValue { get; set;}

--- a/test/Pester/assets/get-date.yml
+++ b/test/Pester/assets/get-date.yml
@@ -1,10 +1,10 @@
 metadata:
   document type: cmdlet
   external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-  HelpUri: https://go.microsoft.com/fwlink/?LinkID=2096615
+  HelpUri: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&WT.mc_id=ps-gethelp
   Locale: en-US
   Module Name: Microsoft.PowerShell.Utility
-  ms.date: 03/05/2025
+  ms.date: 12/12/2022
   PlatyPS schema version: 2024-05-01
   title: Get-Date
 title: Get-Date
@@ -14,183 +14,310 @@ syntaxes:
   parameterSetName: DateAndFormat
   isDefault: true
   parameters:
-  - '[[-Date] <datetime>]'
-  - '[-Year <int>]'
-  - '[-Month <int>]'
-  - '[-Day <int>]'
-  - '[-Hour <int>]'
-  - '[-Minute <int>]'
-  - '[-Second <int>]'
-  - '[-Millisecond <int>]'
+  - '[[-Date] <DateTime>]'
+  - '[-Year <Int32>]'
+  - '[-Month <Int32>]'
+  - '[-Day <Int32>]'
+  - '[-Hour <Int32>]'
+  - '[-Minute <Int32>]'
+  - '[-Second <Int32>]'
+  - '[-Millisecond <Int32>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - '[-Format <string>]'
+  - '[-Format <String>]'
   - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: DateAndUFormat
   isDefault: false
   parameters:
-  - '[[-Date] <datetime>]'
-  - '[-Year <int>]'
-  - '[-Month <int>]'
-  - '[-Day <int>]'
-  - '[-Hour <int>]'
-  - '[-Minute <int>]'
-  - '[-Second <int>]'
-  - '[-Millisecond <int>]'
+  - '[[-Date] <DateTime>]'
+  - -UFormat <String>
+  - '[-Year <Int32>]'
+  - '[-Month <Int32>]'
+  - '[-Day <Int32>]'
+  - '[-Hour <Int32>]'
+  - '[-Minute <Int32>]'
+  - '[-Second <Int32>]'
+  - '[-Millisecond <Int32>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - -UFormat <string>
-  - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: UnixTimeSecondsAndFormat
   isDefault: false
   parameters:
-  - -UnixTimeSeconds <long>
-  - '[-Year <int>]'
-  - '[-Month <int>]'
-  - '[-Day <int>]'
-  - '[-Hour <int>]'
-  - '[-Minute <int>]'
-  - '[-Second <int>]'
-  - '[-Millisecond <int>]'
+  - -UnixTimeSeconds <Int64>
+  - '[-Year <Int32>]'
+  - '[-Month <Int32>]'
+  - '[-Day <Int32>]'
+  - '[-Hour <Int32>]'
+  - '[-Minute <Int32>]'
+  - '[-Second <Int32>]'
+  - '[-Millisecond <Int32>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - '[-Format <string>]'
+  - '[-Format <String>]'
   - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: UnixTimeSecondsAndUFormat
   isDefault: false
   parameters:
-  - -UnixTimeSeconds <long>
-  - '[-Year <int>]'
-  - '[-Month <int>]'
-  - '[-Day <int>]'
-  - '[-Hour <int>]'
-  - '[-Minute <int>]'
-  - '[-Second <int>]'
-  - '[-Millisecond <int>]'
+  - -UnixTimeSeconds <Int64>
+  - -UFormat <String>
+  - '[-Year <Int32>]'
+  - '[-Month <Int32>]'
+  - '[-Day <Int32>]'
+  - '[-Hour <Int32>]'
+  - '[-Minute <Int32>]'
+  - '[-Second <Int32>]'
+  - '[-Millisecond <Int32>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - -UFormat <string>
-  - '[-AsUTC]'
 aliases: ''
 description: |-
-  The `Get-Date` cmdlet gets a DateTime object that represents the current date or a date that you specify.
+  The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
+  specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
+  `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
+  programs.
   
-  `Get-Date` can format the date and time in several .NET and UNIX formats.
-  
-  You can use `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or programs.
-  
-  
-  
-  `Get-Date` uses the computer's culture settings to determine how the output is formatted.
-  
-  To view your computer's settings, use `(Get-Culture).DateTimeFormat`.
+  `Get-Date` uses the computer's culture settings to determine how the output is formatted. To view
+  your computer's settings, use `(Get-Culture).DateTimeFormat`.
 examples:
-- title: Get the current date and time
+- title: 'Example 1: Get the current date and time'
   description: >-
+    In this example, `Get-Date` displays the current system date and time. The output is in the
+
+    long-date and long-time formats.
+
+
+    ```powershell
+
     Get-Date
 
+    ```
+
+
+    ```Output
 
     Tuesday, June 25, 2019 14:53:32
-- title: Get elements of the current date and time
+
+    ```
+- title: 'Example 2: Get elements of the current date and time'
   description: >-
+    This example shows how to use `Get-Date` to get either the date or time element. The parameter uses
+
+    the arguments **Date**, **Time**, or **DateTime**.
+
+
+    ```powershell
+
     Get-Date -DisplayHint Date
 
+    ```
+
+
+    ```Output
 
     Tuesday, June 25, 2019
 
+    ```
 
-    `Get-Date` uses the DisplayHint parameter with the Date argument to get only the date.
-- title: Get the date and time with a .NET format specifier
+
+    `Get-Date` uses the **DisplayHint** parameter with the **Date** argument to get only the date.
+- title: 'Example 3: Get the date and time with a .NET format specifier'
   description: >-
+    In this example, a .NET format specifier is used to customize the output's format. The output is a
+
+    **String** object.
+
+
+    ```powershell
+
     Get-Date -Format "dddd MM/dd/yyyy HH:mm K"
 
+    ```
+
+
+    ```Output
 
     Tuesday 06/25/2019 16:17 -07:00
 
+    ```
 
-    `Get-Date` uses the Format parameter to specify several format specifiers.
+
+    `Get-Date` uses the **Format** parameter to specify several format specifiers.
 
 
     The .NET format specifiers used in this example are defined as follows:
 
 
-    | Specifier |                      Definition                       | | --------- | ----------------------------------------------------- | | `dddd`    | Day of the week - full name                           | | `MM`      | Month number                                          | | `dd`      | Day of the month - 2 digits                           | | `yyyy`    | Year in 4-digit format                                | | `HH:mm`   | Time in 24-hour format - no seconds                   | | `K`       | Time zone offset from Universal Time Coordinate (UTC) |
+    | Specifier |                      Definition                       |
+
+    | --------- | ----------------------------------------------------- |
+
+    | `dddd`    | Day of the week - full name                           |
+
+    | `MM`      | Month number                                          |
+
+    | `dd`      | Day of the month - 2 digits                           |
+
+    | `yyyy`    | Year in 4-digit format                                |
+
+    | `HH:mm`   | Time in 24-hour format - no seconds                   |
+
+    | `K`       | Time zone offset from Universal Time Coordinate (UTC) |
 
 
-    For more information about .NET format specifiers, see Custom date and time format strings (/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
-- title: Get the date and time with a UFormat specifier
+    For more information about .NET format specifiers, see
+
+    [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
+- title: 'Example 4: Get the date and time with a UFormat specifier'
   description: >-
+    In this example, several **UFormat** format specifiers are used to customize the output's format.
+
+    The output is a **String** object.
+
+
+    ```powershell
+
     Get-Date -UFormat "%A %m/%d/%Y %R %Z"
 
+    ```
+
+
+    ```Output
 
     Tuesday 06/25/2019 16:19 -07
 
-
-    `Get-Date` uses the UFormat parameter to specify several format specifiers.
-
-
-    The UFormat format specifiers used in this example are defined as follows:
+    ```
 
 
-    | Specifier |                      Definition                       | | --------- | ----------------------------------------------------- | | `%A`      | Day of the week - full name                           | | `%m`      | Month number                                          | | `%d`      | Day of the month - 2 digits                           | | `%Y`      | Year in 4-digit format                                | | `%R`      | Time in 24-hour format - no seconds                   | | `%Z`      | Time zone offset from Universal Time Coordinate (UTC) |
+    `Get-Date` uses the **UFormat** parameter to specify several format specifiers.
 
 
-    For a list of valid UFormat format specifiers, see the Notes (#notes)section.
-- title: Get a date's day of the year
+    The **UFormat** format specifiers used in this example are defined as follows:
+
+
+    | Specifier |                      Definition                       |
+
+    | --------- | ----------------------------------------------------- |
+
+    | `%A`      | Day of the week - full name                           |
+
+    | `%m`      | Month number                                          |
+
+    | `%d`      | Day of the month - 2 digits                           |
+
+    | `%Y`      | Year in 4-digit format                                |
+
+    | `%R`      | Time in 24-hour format - no seconds                   |
+
+    | `%Z`      | Time zone offset from Universal Time Coordinate (UTC) |
+
+
+    For a list of valid **UFormat** format specifiers, see the [Notes](#notes) section.
+- title: "Example 5: Get a date's day of the year"
   description: >-
+    In this example, a property is used to get the numeric day of the year.
+
+
+    The Gregorian calendar has 365 days, except for leap years that have 366 days. For example, December
+
+    31, 2020 is day 366.
+
+
+    ```powershell
+
     (Get-Date -Year 2020 -Month 12 -Day 31).DayOfYear
 
+    ```
+
+
+    ```Output
 
     366
 
+    ```
 
-    `Get-Date` uses three parameters to specify the date: Year , Month , and Day .
 
-    The command is wrapped with parentheses so that the result is evaluated by the DayofYear property.
-- title: Check if a date is adjusted for daylight savings time
+    `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
+
+    is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
+- title: 'Example 6: Check if a date is adjusted for daylight saving time'
   description: >-
+    This example uses a boolean method to verify if a date is adjusted by daylight saving time.
+
+
+    ```powershell
+
     $DST = Get-Date
 
     $DST.IsDaylightSavingTime()
 
+    ```
+
+
+    ```Output
 
     True
 
+    ```
 
-    A variable, `$DST` stores the result of `Get-Date`.
 
-    `$DST` uses the IsDaylightSavingTime method to test if the date is adjusted for daylight savings time.
-- title: Convert the current time to UTC time
+    A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
+
+    to test if the date is adjusted for daylight saving time.
+- title: 'Example 7: Convert the current time to UTC time'
   description: >-
+    In this example, the current time is converted to UTC time. The UTC offset for the system's locale
+
+    is used to convert the time. A table in the [Notes](#notes) section lists the valid **UFormat**
+
+    format specifiers.
+
+
+    ```powershell
+
     Get-Date -UFormat "%A %B/%d/%Y %T %Z"
 
     $Time = Get-Date
 
     $Time.ToUniversalTime()
 
+    ```
+
+
+    ```Output
 
     Wednesday June/26/2019 10:45:26 -07
 
 
     Wednesday, June 26, 2019 17:45:26
 
-
-    `Get-Date` uses the UFormat parameter with format specifiers to display the current system date and time.
-
-    The format specifier %Z represents the UTC offset of -07 .
+    ```
 
 
-    The `$Time` variable stores the current system date and time.
+    `Get-Date` uses the **UFormat** parameter with format specifiers to display the current system date
 
-    `$Time` uses the ToUniversalTime() method to convert the time based on the computer's UTC offset.
-- title: Create a timestamp
+    and time. The format specifier **%Z** represents the UTC offset of **-07**.
+
+
+    The `$Time` variable stores the current system date and time. `$Time` uses the **ToUniversalTime()**
+
+    method to convert the time based on the computer's UTC offset.
+- title: 'Example 8: Create a timestamp'
   description: >-
+    In this example, a format specifier creates a timestamp **String** object for a directory name. The
+
+    timestamp includes the date, time, and UTC offset.
+
+
+    ```powershell
+
     $timestamp = Get-Date -Format o | ForEach-Object { $_ -replace ":", "." }
 
     New-Item -Path C:\Test\$timestamp -Type Directory
 
+    ```
 
-    Directory: C:\Test
 
+    ```Output
+        Directory: C:\Test
 
     Mode                LastWriteTime         Length Name
 
@@ -198,31 +325,53 @@ examples:
 
     d-----         6/27/2019    07:59                2019-06-27T07.59.24.4603750-07.00
 
-
-    The `$timestamp` variable stores the results of a `Get-Date` command.
-
-    `Get-Date` uses the Format parameter with the format specifier of lowercase `o` to create a timestamp String object.
-
-    The object is sent down the pipeline to `ForEach-Object`.
-
-    A ScriptBlock contains the `$_` variable that represents the current pipeline object.
-
-    The timestamp string is delimited by colons that are replaced by periods.
+    ```
 
 
-    `New-Item` uses the Path parameter to specify the location for a new directory.
+    The `$timestamp` variable stores the results of a `Get-Date` command. `Get-Date` uses the **Format**
 
-    The path includes the `$timestamp` variable as the directory name.
+    parameter with the format specifier of lowercase `o` to create a timestamp **String** object. The
 
-    The Type parameter specifies that a directory is created.
-- title: Convert a Unix timestamp
+    object is sent down the pipeline to `ForEach-Object`. A **ScriptBlock** contains the `$_` variable
+
+    that represents the current pipeline object. The timestamp string is delimited by colons that are
+
+    replaced by periods.
+
+
+    `New-Item` uses the **Path** parameter to specify the location for a new directory. The path
+
+    includes the `$timestamp` variable as the directory name. The **Type** parameter specifies that a
+
+    directory is created.
+- title: 'Example 9: Convert a Unix timestamp'
   description: >-
+    This example converts a Unix time (represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
+
+
+    ```powershell
+
     Get-Date -UnixTimeSeconds 1577836800
 
+    ```
+
+
+    ```Output
 
     Wednesday, January 01, 2020 12:00:00 AM
-- title: Return a date value interpreted as UTC
+
+    ```
+- title: 'Example 10: Return a date value interpreted as UTC'
   description: >-
+    This example shows how to interpret a date value as its UTC equivalent. For the example, this
+
+    machine is set to **Pacific Standard Time**. By default, `Get-Date` returns values for that
+
+    timezone. Use the **AsUTC** parameter to convert the value to the UTC equivalent time.
+
+
+    ```powershell
+
     PS> Get-TimeZone
 
 
@@ -259,6 +408,8 @@ examples:
 
 
     Wednesday, January 1, 2020 8:00:00 AM
+
+    ```
 parameters:
 - name: AsUTC
   type: System.Management.Automation.SwitchParameter
@@ -267,7 +418,8 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  defaultValue: False
+  parameterValue: []
+  defaultValue: None
   supportsWildcards: false
   isDynamic: false
   aliases: ''
@@ -285,9 +437,7 @@ parameters:
 - name: Date
   type: System.DateTime
   description: >-
-    Specifies a date and time.
-
-    Time is optional and if not specified, returns 00:00:00.
+    Specifies a date and time. Time is optional and if not specified, returns 00:00:00.
 
 
     Enter the date and time in a format that is standard for the system locale.
@@ -297,6 +447,7 @@ parameters:
 
 
     `Get-Date -Date "6/25/2019 12:30:22"` returns Tuesday, June 25, 2019 12:30:22
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -320,14 +471,13 @@ parameters:
 - name: Day
   type: System.Int32
   description: >-
-    Specifies the day of the month that is displayed.
-
-    Enter a value from 1 to 31.
+    Specifies the day of the month that is displayed. Enter a value from 1 to 31.
 
 
-    If the specified value is greater than the number of days in a month, PowerShell adds the number of days to the month.
+    If the specified value is greater than the number of days in a month, PowerShell adds the number of
 
-    For example, `Get-Date -Month 2 -Day 31` displays March 3 , not February 31 .
+    days to the month. For example, `Get-Date -Month 2 -Day 31` displays **March 3**, not **February 31**.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -346,13 +496,21 @@ parameters:
     The accepted values are as follows:
 
 
-    - Date : displays only the date - Time : displays only the time - DateTime : displays the date and time
+    - **Date**: displays only the date
+
+    - **Time**: displays only the time
+
+    - **DateTime**: displays the date and time
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
   aliases: ''
   dontShow: false
-  acceptedValues: []
+  acceptedValues:
+  - Date
+  - Time
+  - DateTime
   parameterSets:
   - *o0
   helpMessage: ''
@@ -361,54 +519,45 @@ parameters:
   description: >-
     Displays the date and time in the Microsoft .NET Framework format indicated by the format specifier.
 
-    The Format parameter outputs a String object.
+    The **Format** parameter outputs a **String** object.
 
 
-    For a list of available .NET format specifiers, see Custom date and time format strings (/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
+    For a list of available .NET format specifiers, see
+
+    [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
 
 
-    When the Format parameter is used, `Get-Date` only gets the DateTime object's properties necessary to display the date.
+    When the **Format** parameter is used, `Get-Date` only gets the **DateTime** object's properties
 
-    As a result, some of the properties and methods of DateTime objects might not be available.
+    necessary to display the date. As a result, some of the properties and methods of **DateTime**
 
-
-    Starting in PowerShell 5.0, you can use the following additional formats as values for the Format parameter.
-
-
-    - FileDate .
-
-    A file or path-friendly representation of the current date in local time.
-
-    The format   is `yyyyMMdd` (case-sensitive, using a 4-digit year, 2-digit month, and 2-digit day).
-
-    For example:   20190627.
+    objects might not be available.
 
 
-    - FileDateUniversal .
+    Starting in PowerShell 5.0, you can use the following additional formats as values for the
 
-    A file or path-friendly representation of the current date in universal   time (UTC).
-
-    The format is `yyyyMMddZ` (case-sensitive, using a 4-digit year, 2-digit month,   2-digit day, and the letter `Z` as the UTC indicator).
-
-    For example: 20190627Z.
+    **Format** parameter.
 
 
-    - FileDateTime .
+    - **FileDate**. A file or path-friendly representation of the current date in local time. The format
+      is `yyyyMMdd` (case-sensitive, using a 4-digit year, 2-digit month, and 2-digit day). For example:
+      20190627.
 
-    A file or path-friendly representation of the current date and time in local   time, in 24-hour format.
+    - **FileDateUniversal**. A file or path-friendly representation of the current date in universal
+      time (UTC). The format is `yyyyMMddZ` (case-sensitive, using a 4-digit year, 2-digit month,
+      2-digit day, and the letter `Z` as the UTC indicator). For example: 20190627Z.
 
-    The format is `yyyyMMddTHHmmssffff` (case-sensitive, using a 4-digit   year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit hour, 2-digit   minute, 2-digit second, and 4-digit millisecond).
+    - **FileDateTime**. A file or path-friendly representation of the current date and time in local
+      time, in 24-hour format. The format is `yyyyMMddTHHmmssffff` (case-sensitive, using a 4-digit
+      year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit hour, 2-digit
+      minute, 2-digit second, and 4-digit millisecond). For example: 20190627T0840107271.
 
-    For example: 20190627T0840107271.
-
-
-    - FileDateTimeUniversal .
-
-    A file or path-friendly representation of the current date and time in   universal time (UTC), in 24-hour format.
-
-    The format is `yyyyMMddTHHmmssffffZ` (case-sensitive,   using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit   hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC   indicator).
-
-    For example: 20190627T1540500718Z.
+    - **FileDateTimeUniversal**. A file or path-friendly representation of the current date and time in
+      universal time (UTC), in 24-hour format. The format is `yyyyMMddTHHmmssffffZ` (case-sensitive,
+      using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit
+      hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC
+      indicator). For example: 20190627T1540500718Z.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -431,10 +580,8 @@ parameters:
   helpMessage: ''
 - name: Hour
   type: System.Int32
-  description: >-
-    Specifies the hour that is displayed.
-
-    Enter a value from 0 to 23.
+  description: Specifies the hour that is displayed. Enter a value from 0 to 23.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -447,12 +594,11 @@ parameters:
 - name: Millisecond
   type: System.Int32
   description: >-
-    Specifies the milliseconds in the date.
-
-    Enter a value from 0 to 999.
+    Specifies the milliseconds in the date. Enter a value from 0 to 999.
 
 
     This parameter was introduced in PowerShell 3.0.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -464,10 +610,8 @@ parameters:
   helpMessage: ''
 - name: Minute
   type: System.Int32
-  description: >-
-    Specifies the minute that is displayed.
-
-    Enter a value from 0 to 59.
+  description: Specifies the minute that is displayed. Enter a value from 0 to 59.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -479,10 +623,8 @@ parameters:
   helpMessage: ''
 - name: Month
   type: System.Int32
-  description: >-
-    Specifies the month that is displayed.
-
-    Enter a value from 1 to 12.
+  description: Specifies the month that is displayed. Enter a value from 1 to 12.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -494,10 +636,8 @@ parameters:
   helpMessage: ''
 - name: Second
   type: System.Int32
-  description: >-
-    Specifies the second that is displayed.
-
-    Enter a value from 0 to 59.
+  description: Specifies the second that is displayed. Enter a value from 0 to 59.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -510,18 +650,20 @@ parameters:
 - name: UFormat
   type: System.String
   description: >-
-    Displays the date and time in UNIX format.
-
-    The UFormat parameter outputs a string object.
-
-    UFormat specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`.
-
-    The Notes (#notes)section contains a table of valid UFormat specifiers .
+    Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
 
 
-    When the UFormat parameter is used, `Get-Date` only gets the DateTime object's properties necessary to display the date.
+    **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The [Notes](#notes)
 
-    As a result, some of the properties and methods of DateTime objects might not be available.
+    section contains a table of valid **UFormat specifiers**.
+
+
+    When the **UFormat** parameter is used, `Get-Date` only gets the **DateTime** object's properties
+
+    necessary to display the date. As a result, some of the properties and methods of **DateTime**
+
+    objects might not be available.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -531,14 +673,13 @@ parameters:
   parameterSets:
   - name: DateAndUFormat
     position: Named
-    isRequired: true
+    isRequired: false
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
-  - &o1
-    name: UnixTimeSecondsAndUFormat
+  - name: UnixTimeSecondsAndUFormat
     position: Named
-    isRequired: true
+    isRequired: false
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
@@ -550,6 +691,7 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -563,14 +705,17 @@ parameters:
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
-  - *o1
+  - name: UnixTimeSecondsAndUFormat
+    position: Named
+    isRequired: true
+    valueFromPipeline: false
+    valueFromPipelineByPropertyName: false
+    valueFromRemainingArguments: false
   helpMessage: ''
 - name: Year
   type: System.Int32
-  description: >-
-    Specifies the year that is displayed.
-
-    Enter a value from 1 to 9999.
+  description: Specifies the year that is displayed. Enter a value from 1 to 9999.
+  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -590,54 +735,89 @@ parameters:
 inputs:
 - name: System.DateTime
   description: |-
-    You can pipe a DateTime object to this cmdlet.
+    You can pipe a **DateTime** object to this cmdlet.
 outputs:
-- name: System.String
-  description: |-
-    {{ Fill in the Description }}
 - name: System.DateTime
   description: |-
-    {{ Fill in the Description }}
+    By default, this cmdlet returns a **DateTime** object.
+    
+    When a **DateTime** object is sent down the pipeline to a cmdlet such as `Add-Content` that expects
+    string input, PowerShell converts the object to a **String** object.
+    
+    The method `(Get-Date).ToString()` converts a **DateTime** object a **String** object.
+    
+    To display an object's properties and methods, send the object down the pipeline to `Get-Member`.
+    For example, `Get-Date | Get-Member`.
+- name: System.String
+  description: |-
+    When you use the **Format** or **UFormat** parameters, this cmdlet returns **String** objects.
 notes: |-
-  DateTime objects are in long-date and long-time formats for the system locale.
+  **DateTime** objects are in long-date and long-time formats for the system locale.
   
+  The valid **UFormat specifiers** are displayed in the following table:
   
+  > [!IMPORTANT]
+  > **UFormat** specifiers are changed or added in newer versions of PowerShell. For example, `%F` was
+  > added in PowerShell 6.2, so it isn't available in Windows PowerShell 5.1 or older. Keep this in
+  > mind when using **UFormat** specifiers in scripts designed to be run on multiple versions of
+  > PowerShell.
   
-  The valid UFormat specifiers are displayed in the following table:
+  | Format specifier |                                 Meaning                     |         Example          |
+  | ---- | ----------------------------------------------------------------------- | ------------------------ |
+  | `%A` | Day of the week - full name                                             | Monday                   |
+  | `%a` | Day of the week - abbreviated name                                      | Mon                      |
+  | `%B` | Month name - full                                                       | January                  |
+  | `%b` | Month name - abbreviated                                                | Jan                      |
+  | `%C` | Century                                                                 | 20 for 2019              |
+  | `%c` | Date and time - abbreviated                                             | Thu Jun 27 08:44:18 2019 |
+  | `%D` | Date in mm/dd/yy format                                                 | 06/27/19                 |
+  | `%d` | Day of the month - 2 digits                                             | 05                       |
+  | `%e` | Day of the month - preceded by a space if only a single digit           | \<space\>5               |
+  | `%F` | Date in YYYY-mm-dd format, equal to %Y-%m-%d (the ISO 8601 date format) | 2019-06-27               |
+  | `%G` | ISO week date year (year containing Thursday of the week)               |                          |
+  | `%g` | Same as 'G' - 2 digits                                                  |                          |
+  | `%H` | Hour in 24-hour format                                                  | 17                       |
+  | `%h` | Same as 'b'                                                             |                          |
+  | `%I` | Hour in 12-hour format                                                  | 05                       |
+  | `%j` | Day of the year                                                         | 1-366                    |
+  | `%k` | Same as 'H'                                                             |                          |
+  | `%l` | Same as 'I' (Upper-case I)                                              | 05                       |
+  | `%M` | Minutes                                                                 | 35                       |
+  | `%m` | Month number                                                            | 06                       |
+  | `%n` | newline character                                                       |                          |
+  | `%p` | AM or PM                                                                |                          |
+  | `%R` | Time in 24-hour format -no seconds                                      | 17:45                    |
+  | `%r` | Time in 12-hour format                                                  | 09:15:36 AM              |
+  | `%S` | Seconds                                                                 | 05                       |
+  | `%s` | Seconds elapsed since January 1, 1970 00:00:00 (UTC)                    | 1150451174               |
+  | `%t` | Horizontal tab character                                                |                          |
+  | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
+  | `%U` | Same as 'W'                                                             |                          |
+  | `%u` | Numeric day of the week (1-7) (Changed in PowerShell 7.2)               | Monday = 1, Sunday = 7   |
+  | `%V` | Week of the year                                                        | 01-53                    |
+  | `%w` | Numeric day of the week (0-6)                                           | Sunday = 0, Saturday = 6 |
+  | `%W` | Week of the year                                                        | 00-52                    |
+  | `%X` | Same as 'T'                                                             |                          |
+  | `%x` | Date in standard format for locale                                      | 06/27/19 for English-US  |
+  | `%Y` | Year in 4-digit format                                                  | 2019                     |
+  | `%y` | Year in 2-digit format                                                  | 19                       |
+  | `%Z` | Time zone offset from Universal Time Coordinate (UTC)                   | -07                      |
   
-  
-  
-  > [!IMPORTANT] > UFormat specifiers are changed or added in newer versions of PowerShell.
-  
-  For example, `%F` was > added in PowerShell 6.2, so it isn't available in Windows PowerShell 5.1 or older.
-  
-  Keep this in > mind when using UFormat specifiers in scripts designed to be run on multiple versions of > PowerShell.
-  
-  
-  
-  | Format specifier |                                 Meaning                     |         Example          | | ---- | ----------------------------------------------------------------------- | ------------------------ | | `%A` | Day of the week - full name                                             | Monday                   | | `%a` | Day of the week - abbreviated name                                      | Mon                      | | `%B` | Month name - full                                                       | January                  | | `%b` | Month name - abbreviated                                                | Jan                      | | `%C` | Century                                                                 | 20 for 2019              | | `%c` | Date and time - abbreviated                                             | Thu Jun 27 08:44:18 2019 | | `%D` | Date in mm/dd/yy format                                                 | 06/27/19                 | | `%d` | Day of the month - 2 digits                                             | 05                       | | `%e` | Day of the month - preceded by a space if only a single digit           | <space>5               | | `%F` | Date in YYYY-mm-dd format, equal to %Y-%m-%d (the ISO 8601 date format) | 2019-06-27               | | `%G` | ISO week date year (year containing Thursday of the week)               |                          | | `%g` | Same as 'G' - 2 digits                                                  |                          | | `%H` | Hour in 24-hour format                                                  | 17                       | | `%h` | Same as 'b'                                                             |                          | | `%I` | Hour in 12-hour format                                                  | 05                       | | `%j` | Day of the year                                                         | 1-366                    | | `%k` | Same as 'H'                                                             |                          | | `%l` | Same as 'I' (Upper-case I)                                              | 05                       | | `%M` | Minutes                                                                 | 35                       | | `%m` | Month number                                                            | 06                       | | `%n` | newline character                                                       |                          | | `%p` | AM or PM                                                                |                          | | `%R` | Time in 24-hour format -no seconds                                      | 17:45                    | | `%r` | Time in 12-hour format                                                  | 09:15:36 AM              | | `%S` | Seconds                                                                 | 05                       | | `%s` | Seconds elapsed since January 1, 1970 00:00:00 (UTC)                    | 1150451174               | | `%t` | Horizontal tab character                                                |                          | | `%T` | Time in 24-hour format                                                  | 17:45:52                 | | `%U` | Same as 'W'                                                             |                          | | `%u` | Numeric day of the week (1-7) (Changed in PowerShell 7.2)               | Monday = 1, Sunday = 7   | | `%V` | Week of the year                                                        | 01-53                    | | `%w` | Numeric day of the week (0-6)                                           | Sunday = 0, Saturday = 6 | | `%W` | Week of the year                                                        | 00-52                    | | `%X` | Same as 'T'                                                             |                          | | `%x` | Date in standard format for locale                                      | 06/27/19 for English-US  | | `%Y` | Year in 4-digit format                                                  | 2019                     | | `%y` | Year in 2-digit format                                                  | 19                       | | `%Z` | Time zone offset from Universal Time Coordinate (UTC)                   | -07                      |
-  
-  
-  
-  > [!NOTE] > The behavior of `-UFormat %s` was changed to fix problems with the behavior in Windows PowerShell.
-  
-  > > - The return value is based on UTC time.
-  
+  > [!NOTE]
+  > The behavior of `-UFormat %s` was changed to fix problems with the behavior in Windows PowerShell.
+  >
+  > - The return value is based on UTC time.
   > - The value is a whole number of seconds value (no fractional part).
-  
-  
 links:
-- text: 'Online Version:'
-  href: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.3&WT.mc_id=ps-gethelp
 - text: 'ForEach-Object'
-  href: 
+  href: ../Microsoft.PowerShell.Core/ForEach-Object.md
 - text: 'Get-Culture'
-  href: 
+  href: Get-Culture.md
 - text: 'Get-Member'
-  href: 
+  href: Get-Member.md
 - text: 'New-Item'
-  href: 
+  href: ../Microsoft.PowerShell.Management/New-Item.md
 - text: 'New-TimeSpan'
-  href: 
+  href: New-TimeSpan.md
 - text: 'Set-Date'
-  href: 
+  href: Set-Date.md

--- a/test/Pester/assets/get-date.yml
+++ b/test/Pester/assets/get-date.yml
@@ -74,7 +74,7 @@ description: |-
   specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
   `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
   programs.
-  
+
   `Get-Date` uses the computer's culture settings to determine how the output is formatted. To view
   your computer's settings, use `(Get-Culture).DateTimeFormat`.
 examples:
@@ -418,7 +418,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -447,7 +446,6 @@ parameters:
 
 
     `Get-Date -Date "6/25/2019 12:30:22"` returns Tuesday, June 25, 2019 12:30:22
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -477,7 +475,6 @@ parameters:
     If the specified value is greater than the number of days in a month, PowerShell adds the number of
 
     days to the month. For example, `Get-Date -Month 2 -Day 31` displays **March 3**, not **February 31**.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -501,7 +498,6 @@ parameters:
     - **Time**: displays only the time
 
     - **DateTime**: displays the date and time
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -557,7 +553,6 @@ parameters:
       using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit
       hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC
       indicator). For example: 20190627T1540500718Z.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -581,7 +576,6 @@ parameters:
 - name: Hour
   type: System.Int32
   description: Specifies the hour that is displayed. Enter a value from 0 to 23.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -598,7 +592,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 3.0.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -611,7 +604,6 @@ parameters:
 - name: Minute
   type: System.Int32
   description: Specifies the minute that is displayed. Enter a value from 0 to 59.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -624,7 +616,6 @@ parameters:
 - name: Month
   type: System.Int32
   description: Specifies the month that is displayed. Enter a value from 1 to 12.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -637,7 +628,6 @@ parameters:
 - name: Second
   type: System.Int32
   description: Specifies the second that is displayed. Enter a value from 0 to 59.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -663,7 +653,6 @@ parameters:
     necessary to display the date. As a result, some of the properties and methods of **DateTime**
 
     objects might not be available.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -691,7 +680,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -715,7 +703,6 @@ parameters:
 - name: Year
   type: System.Int32
   description: Specifies the year that is displayed. Enter a value from 1 to 9999.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -740,12 +727,12 @@ outputs:
 - name: System.DateTime
   description: |-
     By default, this cmdlet returns a **DateTime** object.
-    
+
     When a **DateTime** object is sent down the pipeline to a cmdlet such as `Add-Content` that expects
     string input, PowerShell converts the object to a **String** object.
-    
+
     The method `(Get-Date).ToString()` converts a **DateTime** object a **String** object.
-    
+
     To display an object's properties and methods, send the object down the pipeline to `Get-Member`.
     For example, `Get-Date | Get-Member`.
 - name: System.String
@@ -753,15 +740,15 @@ outputs:
     When you use the **Format** or **UFormat** parameters, this cmdlet returns **String** objects.
 notes: |-
   **DateTime** objects are in long-date and long-time formats for the system locale.
-  
+
   The valid **UFormat specifiers** are displayed in the following table:
-  
+
   > [!IMPORTANT]
   > **UFormat** specifiers are changed or added in newer versions of PowerShell. For example, `%F` was
   > added in PowerShell 6.2, so it isn't available in Windows PowerShell 5.1 or older. Keep this in
   > mind when using **UFormat** specifiers in scripts designed to be run on multiple versions of
   > PowerShell.
-  
+
   | Format specifier |                                 Meaning                     |         Example          |
   | ---- | ----------------------------------------------------------------------- | ------------------------ |
   | `%A` | Day of the week - full name                                             | Monday                   |
@@ -802,7 +789,7 @@ notes: |-
   | `%Y` | Year in 4-digit format                                                  | 2019                     |
   | `%y` | Year in 2-digit format                                                  | 19                       |
   | `%Z` | Time zone offset from Universal Time Coordinate (UTC)                   | -07                      |
-  
+
   > [!NOTE]
   > The behavior of `-UFormat %s` was changed to fix problems with the behavior in Windows PowerShell.
   >

--- a/test/Pester/assets/get-date.yml
+++ b/test/Pester/assets/get-date.yml
@@ -418,7 +418,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -447,7 +446,6 @@ parameters:
 
 
     `Get-Date -Date "6/25/2019 12:30:22"` returns Tuesday, June 25, 2019 12:30:22
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -477,7 +475,6 @@ parameters:
     If the specified value is greater than the number of days in a month, PowerShell adds the number of
 
     days to the month. For example, `Get-Date -Month 2 -Day 31` displays **March 3**, not **February 31**.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -501,7 +498,6 @@ parameters:
     - **Time**: displays only the time
 
     - **DateTime**: displays the date and time
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -557,7 +553,6 @@ parameters:
       using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit
       hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC
       indicator). For example: 20190627T1540500718Z.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -581,7 +576,6 @@ parameters:
 - name: Hour
   type: System.Int32
   description: Specifies the hour that is displayed. Enter a value from 0 to 23.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -598,7 +592,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 3.0.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -611,7 +604,6 @@ parameters:
 - name: Minute
   type: System.Int32
   description: Specifies the minute that is displayed. Enter a value from 0 to 59.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -624,7 +616,6 @@ parameters:
 - name: Month
   type: System.Int32
   description: Specifies the month that is displayed. Enter a value from 1 to 12.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -637,7 +628,6 @@ parameters:
 - name: Second
   type: System.Int32
   description: Specifies the second that is displayed. Enter a value from 0 to 59.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -663,7 +653,6 @@ parameters:
     necessary to display the date. As a result, some of the properties and methods of **DateTime**
 
     objects might not be available.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -691,7 +680,6 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -715,7 +703,6 @@ parameters:
 - name: Year
   type: System.Int32
   description: Specifies the year that is displayed. Enter a value from 1 to 9999.
-  parameterValue: []
   defaultValue: None
   supportsWildcards: false
   isDynamic: false

--- a/test/Pester/assets/get-date.yml
+++ b/test/Pester/assets/get-date.yml
@@ -1,10 +1,10 @@
 metadata:
   document type: cmdlet
   external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
-  HelpUri: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&WT.mc_id=ps-gethelp
+  HelpUri: https://go.microsoft.com/fwlink/?LinkID=2096615
   Locale: en-US
   Module Name: Microsoft.PowerShell.Utility
-  ms.date: 12/12/2022
+  ms.date: 03/05/2025
   PlatyPS schema version: 2024-05-01
   title: Get-Date
 title: Get-Date
@@ -14,310 +14,183 @@ syntaxes:
   parameterSetName: DateAndFormat
   isDefault: true
   parameters:
-  - '[[-Date] <DateTime>]'
-  - '[-Year <Int32>]'
-  - '[-Month <Int32>]'
-  - '[-Day <Int32>]'
-  - '[-Hour <Int32>]'
-  - '[-Minute <Int32>]'
-  - '[-Second <Int32>]'
-  - '[-Millisecond <Int32>]'
+  - '[[-Date] <datetime>]'
+  - '[-Year <int>]'
+  - '[-Month <int>]'
+  - '[-Day <int>]'
+  - '[-Hour <int>]'
+  - '[-Minute <int>]'
+  - '[-Second <int>]'
+  - '[-Millisecond <int>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - '[-Format <String>]'
+  - '[-Format <string>]'
   - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: DateAndUFormat
   isDefault: false
   parameters:
-  - '[[-Date] <DateTime>]'
-  - -UFormat <String>
-  - '[-Year <Int32>]'
-  - '[-Month <Int32>]'
-  - '[-Day <Int32>]'
-  - '[-Hour <Int32>]'
-  - '[-Minute <Int32>]'
-  - '[-Second <Int32>]'
-  - '[-Millisecond <Int32>]'
+  - '[[-Date] <datetime>]'
+  - '[-Year <int>]'
+  - '[-Month <int>]'
+  - '[-Day <int>]'
+  - '[-Hour <int>]'
+  - '[-Minute <int>]'
+  - '[-Second <int>]'
+  - '[-Millisecond <int>]'
   - '[-DisplayHint <DisplayHintType>]'
+  - -UFormat <string>
+  - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: UnixTimeSecondsAndFormat
   isDefault: false
   parameters:
-  - -UnixTimeSeconds <Int64>
-  - '[-Year <Int32>]'
-  - '[-Month <Int32>]'
-  - '[-Day <Int32>]'
-  - '[-Hour <Int32>]'
-  - '[-Minute <Int32>]'
-  - '[-Second <Int32>]'
-  - '[-Millisecond <Int32>]'
+  - -UnixTimeSeconds <long>
+  - '[-Year <int>]'
+  - '[-Month <int>]'
+  - '[-Day <int>]'
+  - '[-Hour <int>]'
+  - '[-Minute <int>]'
+  - '[-Second <int>]'
+  - '[-Millisecond <int>]'
   - '[-DisplayHint <DisplayHintType>]'
-  - '[-Format <String>]'
+  - '[-Format <string>]'
   - '[-AsUTC]'
 - commandName: Get-Date
   parameterSetName: UnixTimeSecondsAndUFormat
   isDefault: false
   parameters:
-  - -UnixTimeSeconds <Int64>
-  - -UFormat <String>
-  - '[-Year <Int32>]'
-  - '[-Month <Int32>]'
-  - '[-Day <Int32>]'
-  - '[-Hour <Int32>]'
-  - '[-Minute <Int32>]'
-  - '[-Second <Int32>]'
-  - '[-Millisecond <Int32>]'
+  - -UnixTimeSeconds <long>
+  - '[-Year <int>]'
+  - '[-Month <int>]'
+  - '[-Day <int>]'
+  - '[-Hour <int>]'
+  - '[-Minute <int>]'
+  - '[-Second <int>]'
+  - '[-Millisecond <int>]'
   - '[-DisplayHint <DisplayHintType>]'
+  - -UFormat <string>
+  - '[-AsUTC]'
 aliases: ''
 description: |-
-  The `Get-Date` cmdlet gets a **DateTime** object that represents the current date or a date that you
-  specify. `Get-Date` can format the date and time in several .NET and UNIX formats. You can use
-  `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or
-  programs.
-
-  `Get-Date` uses the computer's culture settings to determine how the output is formatted. To view
-  your computer's settings, use `(Get-Culture).DateTimeFormat`.
+  The `Get-Date` cmdlet gets a DateTime object that represents the current date or a date that you specify.
+  
+  `Get-Date` can format the date and time in several .NET and UNIX formats.
+  
+  You can use `Get-Date` to generate a date or time character string, and then send the string to other cmdlets or programs.
+  
+  
+  
+  `Get-Date` uses the computer's culture settings to determine how the output is formatted.
+  
+  To view your computer's settings, use `(Get-Culture).DateTimeFormat`.
 examples:
-- title: 'Example 1: Get the current date and time'
+- title: Get the current date and time
   description: >-
-    In this example, `Get-Date` displays the current system date and time. The output is in the
-
-    long-date and long-time formats.
-
-
-    ```powershell
-
     Get-Date
 
-    ```
-
-
-    ```Output
 
     Tuesday, June 25, 2019 14:53:32
-
-    ```
-- title: 'Example 2: Get elements of the current date and time'
+- title: Get elements of the current date and time
   description: >-
-    This example shows how to use `Get-Date` to get either the date or time element. The parameter uses
-
-    the arguments **Date**, **Time**, or **DateTime**.
-
-
-    ```powershell
-
     Get-Date -DisplayHint Date
 
-    ```
-
-
-    ```Output
 
     Tuesday, June 25, 2019
 
-    ```
 
-
-    `Get-Date` uses the **DisplayHint** parameter with the **Date** argument to get only the date.
-- title: 'Example 3: Get the date and time with a .NET format specifier'
+    `Get-Date` uses the DisplayHint parameter with the Date argument to get only the date.
+- title: Get the date and time with a .NET format specifier
   description: >-
-    In this example, a .NET format specifier is used to customize the output's format. The output is a
-
-    **String** object.
-
-
-    ```powershell
-
     Get-Date -Format "dddd MM/dd/yyyy HH:mm K"
 
-    ```
-
-
-    ```Output
 
     Tuesday 06/25/2019 16:17 -07:00
 
-    ```
 
-
-    `Get-Date` uses the **Format** parameter to specify several format specifiers.
+    `Get-Date` uses the Format parameter to specify several format specifiers.
 
 
     The .NET format specifiers used in this example are defined as follows:
 
 
-    | Specifier |                      Definition                       |
-
-    | --------- | ----------------------------------------------------- |
-
-    | `dddd`    | Day of the week - full name                           |
-
-    | `MM`      | Month number                                          |
-
-    | `dd`      | Day of the month - 2 digits                           |
-
-    | `yyyy`    | Year in 4-digit format                                |
-
-    | `HH:mm`   | Time in 24-hour format - no seconds                   |
-
-    | `K`       | Time zone offset from Universal Time Coordinate (UTC) |
+    | Specifier |                      Definition                       | | --------- | ----------------------------------------------------- | | `dddd`    | Day of the week - full name                           | | `MM`      | Month number                                          | | `dd`      | Day of the month - 2 digits                           | | `yyyy`    | Year in 4-digit format                                | | `HH:mm`   | Time in 24-hour format - no seconds                   | | `K`       | Time zone offset from Universal Time Coordinate (UTC) |
 
 
-    For more information about .NET format specifiers, see
-
-    [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
-- title: 'Example 4: Get the date and time with a UFormat specifier'
+    For more information about .NET format specifiers, see Custom date and time format strings (/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
+- title: Get the date and time with a UFormat specifier
   description: >-
-    In this example, several **UFormat** format specifiers are used to customize the output's format.
-
-    The output is a **String** object.
-
-
-    ```powershell
-
     Get-Date -UFormat "%A %m/%d/%Y %R %Z"
 
-    ```
-
-
-    ```Output
 
     Tuesday 06/25/2019 16:19 -07
 
-    ```
+
+    `Get-Date` uses the UFormat parameter to specify several format specifiers.
 
 
-    `Get-Date` uses the **UFormat** parameter to specify several format specifiers.
+    The UFormat format specifiers used in this example are defined as follows:
 
 
-    The **UFormat** format specifiers used in this example are defined as follows:
+    | Specifier |                      Definition                       | | --------- | ----------------------------------------------------- | | `%A`      | Day of the week - full name                           | | `%m`      | Month number                                          | | `%d`      | Day of the month - 2 digits                           | | `%Y`      | Year in 4-digit format                                | | `%R`      | Time in 24-hour format - no seconds                   | | `%Z`      | Time zone offset from Universal Time Coordinate (UTC) |
 
 
-    | Specifier |                      Definition                       |
-
-    | --------- | ----------------------------------------------------- |
-
-    | `%A`      | Day of the week - full name                           |
-
-    | `%m`      | Month number                                          |
-
-    | `%d`      | Day of the month - 2 digits                           |
-
-    | `%Y`      | Year in 4-digit format                                |
-
-    | `%R`      | Time in 24-hour format - no seconds                   |
-
-    | `%Z`      | Time zone offset from Universal Time Coordinate (UTC) |
-
-
-    For a list of valid **UFormat** format specifiers, see the [Notes](#notes) section.
-- title: "Example 5: Get a date's day of the year"
+    For a list of valid UFormat format specifiers, see the Notes (#notes)section.
+- title: Get a date's day of the year
   description: >-
-    In this example, a property is used to get the numeric day of the year.
-
-
-    The Gregorian calendar has 365 days, except for leap years that have 366 days. For example, December
-
-    31, 2020 is day 366.
-
-
-    ```powershell
-
     (Get-Date -Year 2020 -Month 12 -Day 31).DayOfYear
 
-    ```
-
-
-    ```Output
 
     366
 
-    ```
 
+    `Get-Date` uses three parameters to specify the date: Year , Month , and Day .
 
-    `Get-Date` uses three parameters to specify the date: **Year**, **Month**, and **Day**. The command
-
-    is wrapped with parentheses so that the result is evaluated by the **DayofYear** property.
-- title: 'Example 6: Check if a date is adjusted for daylight saving time'
+    The command is wrapped with parentheses so that the result is evaluated by the DayofYear property.
+- title: Check if a date is adjusted for daylight savings time
   description: >-
-    This example uses a boolean method to verify if a date is adjusted by daylight saving time.
-
-
-    ```powershell
-
     $DST = Get-Date
 
     $DST.IsDaylightSavingTime()
 
-    ```
-
-
-    ```Output
 
     True
 
-    ```
 
+    A variable, `$DST` stores the result of `Get-Date`.
 
-    A variable, `$DST` stores the result of `Get-Date`. `$DST` uses the **IsDaylightSavingTime** method
-
-    to test if the date is adjusted for daylight saving time.
-- title: 'Example 7: Convert the current time to UTC time'
+    `$DST` uses the IsDaylightSavingTime method to test if the date is adjusted for daylight savings time.
+- title: Convert the current time to UTC time
   description: >-
-    In this example, the current time is converted to UTC time. The UTC offset for the system's locale
-
-    is used to convert the time. A table in the [Notes](#notes) section lists the valid **UFormat**
-
-    format specifiers.
-
-
-    ```powershell
-
     Get-Date -UFormat "%A %B/%d/%Y %T %Z"
 
     $Time = Get-Date
 
     $Time.ToUniversalTime()
 
-    ```
-
-
-    ```Output
 
     Wednesday June/26/2019 10:45:26 -07
 
 
     Wednesday, June 26, 2019 17:45:26
 
-    ```
+
+    `Get-Date` uses the UFormat parameter with format specifiers to display the current system date and time.
+
+    The format specifier %Z represents the UTC offset of -07 .
 
 
-    `Get-Date` uses the **UFormat** parameter with format specifiers to display the current system date
+    The `$Time` variable stores the current system date and time.
 
-    and time. The format specifier **%Z** represents the UTC offset of **-07**.
-
-
-    The `$Time` variable stores the current system date and time. `$Time` uses the **ToUniversalTime()**
-
-    method to convert the time based on the computer's UTC offset.
-- title: 'Example 8: Create a timestamp'
+    `$Time` uses the ToUniversalTime() method to convert the time based on the computer's UTC offset.
+- title: Create a timestamp
   description: >-
-    In this example, a format specifier creates a timestamp **String** object for a directory name. The
-
-    timestamp includes the date, time, and UTC offset.
-
-
-    ```powershell
-
     $timestamp = Get-Date -Format o | ForEach-Object { $_ -replace ":", "." }
 
     New-Item -Path C:\Test\$timestamp -Type Directory
 
-    ```
 
+    Directory: C:\Test
 
-    ```Output
-        Directory: C:\Test
 
     Mode                LastWriteTime         Length Name
 
@@ -325,53 +198,31 @@ examples:
 
     d-----         6/27/2019    07:59                2019-06-27T07.59.24.4603750-07.00
 
-    ```
+
+    The `$timestamp` variable stores the results of a `Get-Date` command.
+
+    `Get-Date` uses the Format parameter with the format specifier of lowercase `o` to create a timestamp String object.
+
+    The object is sent down the pipeline to `ForEach-Object`.
+
+    A ScriptBlock contains the `$_` variable that represents the current pipeline object.
+
+    The timestamp string is delimited by colons that are replaced by periods.
 
 
-    The `$timestamp` variable stores the results of a `Get-Date` command. `Get-Date` uses the **Format**
+    `New-Item` uses the Path parameter to specify the location for a new directory.
 
-    parameter with the format specifier of lowercase `o` to create a timestamp **String** object. The
+    The path includes the `$timestamp` variable as the directory name.
 
-    object is sent down the pipeline to `ForEach-Object`. A **ScriptBlock** contains the `$_` variable
-
-    that represents the current pipeline object. The timestamp string is delimited by colons that are
-
-    replaced by periods.
-
-
-    `New-Item` uses the **Path** parameter to specify the location for a new directory. The path
-
-    includes the `$timestamp` variable as the directory name. The **Type** parameter specifies that a
-
-    directory is created.
-- title: 'Example 9: Convert a Unix timestamp'
+    The Type parameter specifies that a directory is created.
+- title: Convert a Unix timestamp
   description: >-
-    This example converts a Unix time (represented by the number of seconds since 1970-01-01 0:00:00) to DateTime.
-
-
-    ```powershell
-
     Get-Date -UnixTimeSeconds 1577836800
 
-    ```
-
-
-    ```Output
 
     Wednesday, January 01, 2020 12:00:00 AM
-
-    ```
-- title: 'Example 10: Return a date value interpreted as UTC'
+- title: Return a date value interpreted as UTC
   description: >-
-    This example shows how to interpret a date value as its UTC equivalent. For the example, this
-
-    machine is set to **Pacific Standard Time**. By default, `Get-Date` returns values for that
-
-    timezone. Use the **AsUTC** parameter to convert the value to the UTC equivalent time.
-
-
-    ```powershell
-
     PS> Get-TimeZone
 
 
@@ -408,8 +259,6 @@ examples:
 
 
     Wednesday, January 1, 2020 8:00:00 AM
-
-    ```
 parameters:
 - name: AsUTC
   type: System.Management.Automation.SwitchParameter
@@ -418,7 +267,7 @@ parameters:
 
 
     This parameter was introduced in PowerShell 7.1.
-  defaultValue: None
+  defaultValue: False
   supportsWildcards: false
   isDynamic: false
   aliases: ''
@@ -436,7 +285,9 @@ parameters:
 - name: Date
   type: System.DateTime
   description: >-
-    Specifies a date and time. Time is optional and if not specified, returns 00:00:00.
+    Specifies a date and time.
+
+    Time is optional and if not specified, returns 00:00:00.
 
 
     Enter the date and time in a format that is standard for the system locale.
@@ -469,12 +320,14 @@ parameters:
 - name: Day
   type: System.Int32
   description: >-
-    Specifies the day of the month that is displayed. Enter a value from 1 to 31.
+    Specifies the day of the month that is displayed.
+
+    Enter a value from 1 to 31.
 
 
-    If the specified value is greater than the number of days in a month, PowerShell adds the number of
+    If the specified value is greater than the number of days in a month, PowerShell adds the number of days to the month.
 
-    days to the month. For example, `Get-Date -Month 2 -Day 31` displays **March 3**, not **February 31**.
+    For example, `Get-Date -Month 2 -Day 31` displays March 3 , not February 31 .
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -493,20 +346,13 @@ parameters:
     The accepted values are as follows:
 
 
-    - **Date**: displays only the date
-
-    - **Time**: displays only the time
-
-    - **DateTime**: displays the date and time
+    - Date : displays only the date - Time : displays only the time - DateTime : displays the date and time
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
   aliases: ''
   dontShow: false
-  acceptedValues:
-  - Date
-  - Time
-  - DateTime
+  acceptedValues: []
   parameterSets:
   - *o0
   helpMessage: ''
@@ -515,44 +361,54 @@ parameters:
   description: >-
     Displays the date and time in the Microsoft .NET Framework format indicated by the format specifier.
 
-    The **Format** parameter outputs a **String** object.
+    The Format parameter outputs a String object.
 
 
-    For a list of available .NET format specifiers, see
-
-    [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
+    For a list of available .NET format specifiers, see Custom date and time format strings (/dotnet/standard/base-types/custom-date-and-time-format-strings?view=netframework-4.8).
 
 
-    When the **Format** parameter is used, `Get-Date` only gets the **DateTime** object's properties
+    When the Format parameter is used, `Get-Date` only gets the DateTime object's properties necessary to display the date.
 
-    necessary to display the date. As a result, some of the properties and methods of **DateTime**
-
-    objects might not be available.
+    As a result, some of the properties and methods of DateTime objects might not be available.
 
 
-    Starting in PowerShell 5.0, you can use the following additional formats as values for the
-
-    **Format** parameter.
+    Starting in PowerShell 5.0, you can use the following additional formats as values for the Format parameter.
 
 
-    - **FileDate**. A file or path-friendly representation of the current date in local time. The format
-      is `yyyyMMdd` (case-sensitive, using a 4-digit year, 2-digit month, and 2-digit day). For example:
-      20190627.
+    - FileDate .
 
-    - **FileDateUniversal**. A file or path-friendly representation of the current date in universal
-      time (UTC). The format is `yyyyMMddZ` (case-sensitive, using a 4-digit year, 2-digit month,
-      2-digit day, and the letter `Z` as the UTC indicator). For example: 20190627Z.
+    A file or path-friendly representation of the current date in local time.
 
-    - **FileDateTime**. A file or path-friendly representation of the current date and time in local
-      time, in 24-hour format. The format is `yyyyMMddTHHmmssffff` (case-sensitive, using a 4-digit
-      year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit hour, 2-digit
-      minute, 2-digit second, and 4-digit millisecond). For example: 20190627T0840107271.
+    The format   is `yyyyMMdd` (case-sensitive, using a 4-digit year, 2-digit month, and 2-digit day).
 
-    - **FileDateTimeUniversal**. A file or path-friendly representation of the current date and time in
-      universal time (UTC), in 24-hour format. The format is `yyyyMMddTHHmmssffffZ` (case-sensitive,
-      using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit
-      hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC
-      indicator). For example: 20190627T1540500718Z.
+    For example:   20190627.
+
+
+    - FileDateUniversal .
+
+    A file or path-friendly representation of the current date in universal   time (UTC).
+
+    The format is `yyyyMMddZ` (case-sensitive, using a 4-digit year, 2-digit month,   2-digit day, and the letter `Z` as the UTC indicator).
+
+    For example: 20190627Z.
+
+
+    - FileDateTime .
+
+    A file or path-friendly representation of the current date and time in local   time, in 24-hour format.
+
+    The format is `yyyyMMddTHHmmssffff` (case-sensitive, using a 4-digit   year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit hour, 2-digit   minute, 2-digit second, and 4-digit millisecond).
+
+    For example: 20190627T0840107271.
+
+
+    - FileDateTimeUniversal .
+
+    A file or path-friendly representation of the current date and time in   universal time (UTC), in 24-hour format.
+
+    The format is `yyyyMMddTHHmmssffffZ` (case-sensitive,   using a 4-digit year, 2-digit month, 2-digit day, the letter `T` as a time separator, 2-digit   hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter `Z` as the UTC   indicator).
+
+    For example: 20190627T1540500718Z.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -575,7 +431,10 @@ parameters:
   helpMessage: ''
 - name: Hour
   type: System.Int32
-  description: Specifies the hour that is displayed. Enter a value from 0 to 23.
+  description: >-
+    Specifies the hour that is displayed.
+
+    Enter a value from 0 to 23.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -588,7 +447,9 @@ parameters:
 - name: Millisecond
   type: System.Int32
   description: >-
-    Specifies the milliseconds in the date. Enter a value from 0 to 999.
+    Specifies the milliseconds in the date.
+
+    Enter a value from 0 to 999.
 
 
     This parameter was introduced in PowerShell 3.0.
@@ -603,7 +464,10 @@ parameters:
   helpMessage: ''
 - name: Minute
   type: System.Int32
-  description: Specifies the minute that is displayed. Enter a value from 0 to 59.
+  description: >-
+    Specifies the minute that is displayed.
+
+    Enter a value from 0 to 59.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -615,7 +479,10 @@ parameters:
   helpMessage: ''
 - name: Month
   type: System.Int32
-  description: Specifies the month that is displayed. Enter a value from 1 to 12.
+  description: >-
+    Specifies the month that is displayed.
+
+    Enter a value from 1 to 12.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -627,7 +494,10 @@ parameters:
   helpMessage: ''
 - name: Second
   type: System.Int32
-  description: Specifies the second that is displayed. Enter a value from 0 to 59.
+  description: >-
+    Specifies the second that is displayed.
+
+    Enter a value from 0 to 59.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -640,19 +510,18 @@ parameters:
 - name: UFormat
   type: System.String
   description: >-
-    Displays the date and time in UNIX format. The **UFormat** parameter outputs a string object.
+    Displays the date and time in UNIX format.
+
+    The UFormat parameter outputs a string object.
+
+    UFormat specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`.
+
+    The Notes (#notes)section contains a table of valid UFormat specifiers .
 
 
-    **UFormat** specifiers are preceded by a percent sign (`%`), for example, `%m`, `%d`, and `%Y`. The [Notes](#notes)
+    When the UFormat parameter is used, `Get-Date` only gets the DateTime object's properties necessary to display the date.
 
-    section contains a table of valid **UFormat specifiers**.
-
-
-    When the **UFormat** parameter is used, `Get-Date` only gets the **DateTime** object's properties
-
-    necessary to display the date. As a result, some of the properties and methods of **DateTime**
-
-    objects might not be available.
+    As a result, some of the properties and methods of DateTime objects might not be available.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -662,13 +531,14 @@ parameters:
   parameterSets:
   - name: DateAndUFormat
     position: Named
-    isRequired: false
+    isRequired: true
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
-  - name: UnixTimeSecondsAndUFormat
+  - &o1
+    name: UnixTimeSecondsAndUFormat
     position: Named
-    isRequired: false
+    isRequired: true
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
@@ -693,16 +563,14 @@ parameters:
     valueFromPipeline: false
     valueFromPipelineByPropertyName: false
     valueFromRemainingArguments: false
-  - name: UnixTimeSecondsAndUFormat
-    position: Named
-    isRequired: true
-    valueFromPipeline: false
-    valueFromPipelineByPropertyName: false
-    valueFromRemainingArguments: false
+  - *o1
   helpMessage: ''
 - name: Year
   type: System.Int32
-  description: Specifies the year that is displayed. Enter a value from 1 to 9999.
+  description: >-
+    Specifies the year that is displayed.
+
+    Enter a value from 1 to 9999.
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
@@ -722,89 +590,54 @@ parameters:
 inputs:
 - name: System.DateTime
   description: |-
-    You can pipe a **DateTime** object to this cmdlet.
+    You can pipe a DateTime object to this cmdlet.
 outputs:
-- name: System.DateTime
-  description: |-
-    By default, this cmdlet returns a **DateTime** object.
-
-    When a **DateTime** object is sent down the pipeline to a cmdlet such as `Add-Content` that expects
-    string input, PowerShell converts the object to a **String** object.
-
-    The method `(Get-Date).ToString()` converts a **DateTime** object a **String** object.
-
-    To display an object's properties and methods, send the object down the pipeline to `Get-Member`.
-    For example, `Get-Date | Get-Member`.
 - name: System.String
   description: |-
-    When you use the **Format** or **UFormat** parameters, this cmdlet returns **String** objects.
+    {{ Fill in the Description }}
+- name: System.DateTime
+  description: |-
+    {{ Fill in the Description }}
 notes: |-
-  **DateTime** objects are in long-date and long-time formats for the system locale.
-
-  The valid **UFormat specifiers** are displayed in the following table:
-
-  > [!IMPORTANT]
-  > **UFormat** specifiers are changed or added in newer versions of PowerShell. For example, `%F` was
-  > added in PowerShell 6.2, so it isn't available in Windows PowerShell 5.1 or older. Keep this in
-  > mind when using **UFormat** specifiers in scripts designed to be run on multiple versions of
-  > PowerShell.
-
-  | Format specifier |                                 Meaning                     |         Example          |
-  | ---- | ----------------------------------------------------------------------- | ------------------------ |
-  | `%A` | Day of the week - full name                                             | Monday                   |
-  | `%a` | Day of the week - abbreviated name                                      | Mon                      |
-  | `%B` | Month name - full                                                       | January                  |
-  | `%b` | Month name - abbreviated                                                | Jan                      |
-  | `%C` | Century                                                                 | 20 for 2019              |
-  | `%c` | Date and time - abbreviated                                             | Thu Jun 27 08:44:18 2019 |
-  | `%D` | Date in mm/dd/yy format                                                 | 06/27/19                 |
-  | `%d` | Day of the month - 2 digits                                             | 05                       |
-  | `%e` | Day of the month - preceded by a space if only a single digit           | \<space\>5               |
-  | `%F` | Date in YYYY-mm-dd format, equal to %Y-%m-%d (the ISO 8601 date format) | 2019-06-27               |
-  | `%G` | ISO week date year (year containing Thursday of the week)               |                          |
-  | `%g` | Same as 'G' - 2 digits                                                  |                          |
-  | `%H` | Hour in 24-hour format                                                  | 17                       |
-  | `%h` | Same as 'b'                                                             |                          |
-  | `%I` | Hour in 12-hour format                                                  | 05                       |
-  | `%j` | Day of the year                                                         | 1-366                    |
-  | `%k` | Same as 'H'                                                             |                          |
-  | `%l` | Same as 'I' (Upper-case I)                                              | 05                       |
-  | `%M` | Minutes                                                                 | 35                       |
-  | `%m` | Month number                                                            | 06                       |
-  | `%n` | newline character                                                       |                          |
-  | `%p` | AM or PM                                                                |                          |
-  | `%R` | Time in 24-hour format -no seconds                                      | 17:45                    |
-  | `%r` | Time in 12-hour format                                                  | 09:15:36 AM              |
-  | `%S` | Seconds                                                                 | 05                       |
-  | `%s` | Seconds elapsed since January 1, 1970 00:00:00 (UTC)                    | 1150451174               |
-  | `%t` | Horizontal tab character                                                |                          |
-  | `%T` | Time in 24-hour format                                                  | 17:45:52                 |
-  | `%U` | Same as 'W'                                                             |                          |
-  | `%u` | Numeric day of the week (1-7) (Changed in PowerShell 7.2)               | Monday = 1, Sunday = 7   |
-  | `%V` | Week of the year                                                        | 01-53                    |
-  | `%w` | Numeric day of the week (0-6)                                           | Sunday = 0, Saturday = 6 |
-  | `%W` | Week of the year                                                        | 00-52                    |
-  | `%X` | Same as 'T'                                                             |                          |
-  | `%x` | Date in standard format for locale                                      | 06/27/19 for English-US  |
-  | `%Y` | Year in 4-digit format                                                  | 2019                     |
-  | `%y` | Year in 2-digit format                                                  | 19                       |
-  | `%Z` | Time zone offset from Universal Time Coordinate (UTC)                   | -07                      |
-
-  > [!NOTE]
-  > The behavior of `-UFormat %s` was changed to fix problems with the behavior in Windows PowerShell.
-  >
-  > - The return value is based on UTC time.
+  DateTime objects are in long-date and long-time formats for the system locale.
+  
+  
+  
+  The valid UFormat specifiers are displayed in the following table:
+  
+  
+  
+  > [!IMPORTANT] > UFormat specifiers are changed or added in newer versions of PowerShell.
+  
+  For example, `%F` was > added in PowerShell 6.2, so it isn't available in Windows PowerShell 5.1 or older.
+  
+  Keep this in > mind when using UFormat specifiers in scripts designed to be run on multiple versions of > PowerShell.
+  
+  
+  
+  | Format specifier |                                 Meaning                     |         Example          | | ---- | ----------------------------------------------------------------------- | ------------------------ | | `%A` | Day of the week - full name                                             | Monday                   | | `%a` | Day of the week - abbreviated name                                      | Mon                      | | `%B` | Month name - full                                                       | January                  | | `%b` | Month name - abbreviated                                                | Jan                      | | `%C` | Century                                                                 | 20 for 2019              | | `%c` | Date and time - abbreviated                                             | Thu Jun 27 08:44:18 2019 | | `%D` | Date in mm/dd/yy format                                                 | 06/27/19                 | | `%d` | Day of the month - 2 digits                                             | 05                       | | `%e` | Day of the month - preceded by a space if only a single digit           | <space>5               | | `%F` | Date in YYYY-mm-dd format, equal to %Y-%m-%d (the ISO 8601 date format) | 2019-06-27               | | `%G` | ISO week date year (year containing Thursday of the week)               |                          | | `%g` | Same as 'G' - 2 digits                                                  |                          | | `%H` | Hour in 24-hour format                                                  | 17                       | | `%h` | Same as 'b'                                                             |                          | | `%I` | Hour in 12-hour format                                                  | 05                       | | `%j` | Day of the year                                                         | 1-366                    | | `%k` | Same as 'H'                                                             |                          | | `%l` | Same as 'I' (Upper-case I)                                              | 05                       | | `%M` | Minutes                                                                 | 35                       | | `%m` | Month number                                                            | 06                       | | `%n` | newline character                                                       |                          | | `%p` | AM or PM                                                                |                          | | `%R` | Time in 24-hour format -no seconds                                      | 17:45                    | | `%r` | Time in 12-hour format                                                  | 09:15:36 AM              | | `%S` | Seconds                                                                 | 05                       | | `%s` | Seconds elapsed since January 1, 1970 00:00:00 (UTC)                    | 1150451174               | | `%t` | Horizontal tab character                                                |                          | | `%T` | Time in 24-hour format                                                  | 17:45:52                 | | `%U` | Same as 'W'                                                             |                          | | `%u` | Numeric day of the week (1-7) (Changed in PowerShell 7.2)               | Monday = 1, Sunday = 7   | | `%V` | Week of the year                                                        | 01-53                    | | `%w` | Numeric day of the week (0-6)                                           | Sunday = 0, Saturday = 6 | | `%W` | Week of the year                                                        | 00-52                    | | `%X` | Same as 'T'                                                             |                          | | `%x` | Date in standard format for locale                                      | 06/27/19 for English-US  | | `%Y` | Year in 4-digit format                                                  | 2019                     | | `%y` | Year in 2-digit format                                                  | 19                       | | `%Z` | Time zone offset from Universal Time Coordinate (UTC)                   | -07                      |
+  
+  
+  
+  > [!NOTE] > The behavior of `-UFormat %s` was changed to fix problems with the behavior in Windows PowerShell.
+  
+  > > - The return value is based on UTC time.
+  
   > - The value is a whole number of seconds value (no fractional part).
+  
+  
 links:
+- text: 'Online Version:'
+  href: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.3&WT.mc_id=ps-gethelp
 - text: 'ForEach-Object'
-  href: ../Microsoft.PowerShell.Core/ForEach-Object.md
+  href: 
 - text: 'Get-Culture'
-  href: Get-Culture.md
+  href: 
 - text: 'Get-Member'
-  href: Get-Member.md
+  href: 
 - text: 'New-Item'
-  href: ../Microsoft.PowerShell.Management/New-Item.md
+  href: 
 - text: 'New-TimeSpan'
-  href: New-TimeSpan.md
+  href: 
 - text: 'Set-Date'
-  href: Set-Date.md
+  href: 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes a small change to the `Parameter` class in the `src/Model/Parameter.cs` file. The change involves adding a `[YamlIgnore]` attribute to the `ParameterValue` property to exclude it from YAML serialization.

## PR Context

Fixes https://github.com/PowerShell/platyPS/issues/711
