### PR TITLE
Make parameters alias to be lists instead of strings

### DIFF
--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using Microsoft.PowerShell.PlatyPS.Model;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -360,7 +361,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     p.VariableLength = result;
                 }
-            } 
+            }
 
             if (pDictionary.TryGetValue("helpMessage", out object helpMsg))
             {
@@ -387,7 +388,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 if (aliases is string aliasStr)
                 {
-                    p.Aliases = aliasStr;
+                    p.Aliases = new List<string> { aliasStr };
                 }
                 else if (aliases is List<object> aliasList)
                 {
@@ -396,7 +397,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     {
                         aList.Add(alias.ToString());
                     }
-                    p.Aliases = string.Join(", ", aList);
+                    p.Aliases = aList;
                 }
             }
 
@@ -526,7 +527,7 @@ namespace Microsoft.PowerShell.PlatyPS
                             {
                                 inputs.Add(new InputOutput(name.ToString(), string.Empty));
                             }
-                        } 
+                        }
                     }
                 }
             }

--- a/src/Model/Parameter.cs
+++ b/src/Model/Parameter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public bool IsDynamic { get; set ; }
 
-        public string Aliases { get; set;}
+        public List<string> Aliases { get; set;}
 
         public bool DontShow { get; set;}
 
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             Description = string.Empty;
             ParameterSets = new();
             ParameterValue = new();
-            Aliases = string.Empty;
+            Aliases = new();
             AcceptedValues = new();
             DefaultValue = string.Empty;
             HelpMessage = string.Empty;
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             Type = type;
             ParameterSets = new();
             ParameterValue = new();
-            Aliases = string.Empty;
+            Aliases = new();
             AcceptedValues = new();
             DefaultValue = string.Empty;
             Description = string.Empty;
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             VariableLength = metadata.VariableLength;
             DefaultValue = metadata.DefaultValue;
             SupportsWildcards = metadata.SupportsWildcards;
-            Aliases = string.Join(",", metadata.Aliases);
+            Aliases = metadata.Aliases;
             DontShow = metadata.DontShow;
             AcceptedValues = metadata.AcceptedValues;
             HelpMessage = metadata.HelpMessage;
@@ -200,16 +200,9 @@ namespace Microsoft.PowerShell.PlatyPS.Model
                 metadata.DefaultValue = DefaultValue;
             }
 
-            if (! string.IsNullOrEmpty(Aliases))
+            if (Aliases is not null)
             {
-                var aliases = Aliases?.Split(Constants.Comma, StringSplitOptions.RemoveEmptyEntries);
-                if (aliases is not null)
-                    {
-                    foreach(var alias in aliases)
-                    {
-                        metadata.Aliases.Add(alias.Trim());
-                    }
-                }
+                metadata.Aliases = Aliases;
             }
 
             if (ParameterValue is not null && ParameterValue.Count > 0)
@@ -247,7 +240,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             return (
                 string.Compare(Name, other.Name, StringComparison.CurrentCulture) == 0 &&
                 string.Compare(Type, other.Type, StringComparison.CurrentCulture) == 0 &&
-                string.Compare(Aliases, other.Aliases, StringComparison.CurrentCulture) == 0 &&
+                Aliases.SequenceEqual(other.Aliases, StringComparer.CurrentCulture) &&
                 string.Compare(DefaultValue, other.DefaultValue, StringComparison.CurrentCulture) == 0 &&
                 string.Compare(HelpMessage, other.HelpMessage, StringComparison.CurrentCulture) == 0 &&
                 SupportsWildcards == other.SupportsWildcards &&
@@ -269,7 +262,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
                 string.Compare(Name, other.Name, StringComparison.CurrentCulture) == 0 &&
                 string.Compare(Type, other.Type, StringComparison.CurrentCulture) == 0 &&
                 string.Compare(Description, other.Description, StringComparison.CurrentCulture) == 0 &&
-                string.Compare(Aliases, other.Aliases, StringComparison.CurrentCulture) == 0 &&
+                Aliases.SequenceEqual(other.Aliases, StringComparer.CurrentCulture) &&
                 string.Compare(DefaultValue, other.DefaultValue, StringComparison.CurrentCulture) == 0 &&
                 string.Compare(HelpMessage, other.HelpMessage, StringComparison.CurrentCulture) == 0 &&
                 SupportsWildcards == other.SupportsWildcards &&

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 var paramAttribInfo = GetParameterAtributeInfo(parameterMetadata.Value.Attributes);
                 string typeName = GetParameterTypeName(parameterMetadata.Value.ParameterType);
 
-                Parameter param = new(parameterMetadata.Value.Name, typeName); 
+                Parameter param = new(parameterMetadata.Value.Name, typeName);
                 param.DontShow = paramAttribInfo.DontShow;
                 param.SupportsWildcards = paramAttribInfo.Globbing;
                 param.HelpMessage = paramAttribInfo.HelpMessage ?? string.Empty;
@@ -236,7 +236,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 }
 
                 param.DefaultValue = GetParameterDefaultValueFromHelp(helpItem, param.Name);
-                param.Aliases = string.Join(",", parameterMetadata.Value.Aliases);
+                param.Aliases = parameterMetadata.Value.Aliases.ToList();
 
                 string descriptionFromHelp = GetParameterDescriptionFromHelp(helpItem, param.Name) ?? param.HelpMessage ?? string.Empty;
                 param.Description = string.IsNullOrEmpty(descriptionFromHelp) ?
@@ -620,7 +620,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 string.Format(Constants.FillInParameterDescriptionTemplate, param.Name) :
                 descriptionFromHelp;
 
-            param.Aliases = string.Join("-", paramInfo.Aliases);
+            param.Aliases = paramInfo.Aliases.ToList();
             param.ParameterSets.ForEach(x => x.IsRequired = paramInfo.IsMandatory);
 
             string defaultValueFromHelp = GetParameterDefaultValueFromHelp(helpItem, param.Name);

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using System.Text;
 using System.Xml;
 
@@ -574,7 +575,7 @@ namespace Microsoft.PowerShell.PlatyPS
             parameter.ParameterSets.ForEach(x => x.IsRequired = required);
             parameter.VariableLength = variableLength;
             parameter.SupportsWildcards = globbing;
-            parameter.Aliases = aliases ?? string.Empty;
+            parameter.Aliases = aliases is not null ? new List<string> { aliases } : new List<string>();
 
             // need to go the end of command:parameter
             if (reader.ReadState != ReadState.EndOfFile)

--- a/test/Pester/assets/get-date.yml
+++ b/test/Pester/assets/get-date.yml
@@ -422,7 +422,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -451,7 +451,8 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: LastWriteTime
+  aliases:
+  - LastWriteTime
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -481,7 +482,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -505,7 +506,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues:
   - Date
@@ -561,7 +562,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -585,7 +586,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -602,7 +603,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -615,7 +616,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -628,7 +629,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -641,7 +642,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -667,7 +668,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -695,7 +696,8 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: UnixTime
+  aliases:
+  - UnixTime
   dontShow: false
   acceptedValues: []
   parameterSets:
@@ -719,7 +721,7 @@ parameters:
   defaultValue: None
   supportsWildcards: false
   isDynamic: false
-  aliases: ''
+  aliases: []
   dontShow: false
   acceptedValues: []
   parameterSets:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes multiple changes to improve the handling of parameter aliases in the codebase. The most important changes involve modifying the `Parameter` class and related methods to use a list of strings for aliases instead of a single string.

Changes to `Parameter` class:

* [`src/Model/Parameter.cs`](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L37-R37): Changed the `Aliases` property from a string to a `List<string>` and updated constructors and methods accordingly. [[1]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L37-R37) [[2]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L54-R54) [[3]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L66-R66) [[4]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L149-R149) [[5]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L203-R205) [[6]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L250-R243) [[7]](diffhunk://#diff-58c25feecfec1587caa20f68fcbf235dcc0d2e8abac9f73b5e61bc82e011b2b9L272-R265)

Updates to alias handling in methods:

* [`src/Common/YamlUtils.cs`](diffhunk://#diff-242a6359fe59a046e498f12a2be1ef4c47778e025794ee52ba0828d272a1bcbbL390-R391): Updated the `GetParametersFromDictionary` method to handle `Aliases` as a list of strings. [[1]](diffhunk://#diff-242a6359fe59a046e498f12a2be1ef4c47778e025794ee52ba0828d272a1bcbbL390-R391) [[2]](diffhunk://#diff-242a6359fe59a046e498f12a2be1ef4c47778e025794ee52ba0828d272a1bcbbL399-R400)
* [`src/Transform/TransformBase.cs`](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L239-R239): Modified methods to convert aliases to a list of strings. [[1]](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L239-R239) [[2]](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L623-R623)
* [`src/Transform/TransformMaml.cs`](diffhunk://#diff-762b9c896c58182d87b826881b0bc299fa2a91482de043e4410650dbe8f86d5eL577-R578): Adjusted the `ReadParameter` method to set aliases as a list of strings.

Test data updates:

* [`test/Pester/assets/get-date.yml`](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L425-R425): Updated test data to reflect the change in alias handling, representing aliases as lists instead of strings. [[1]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L425-R425) [[2]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L454-R455) [[3]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L484-R485) [[4]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L508-R509) [[5]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L564-R565) [[6]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L588-R589) [[7]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L605-R606) [[8]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L618-R619) [[9]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L631-R632) [[10]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L644-R645) [[11]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L670-R671) [[12]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L698-R700) [[13]](diffhunk://#diff-88cbf174a377bf7eb74eee12976d80670d6caab4d9bcf1a5c4881a08b27514b7L722-R724)

These changes ensure that the handling of parameter aliases is consistent and robust throughout the codebase.

## PR Context

Fixes #712 
