### PR TITLE
Fix export when the file does not exist already

### DIFF
--- a/src/Microsoft.PowerShell.PlatyPS.psm1
+++ b/src/Microsoft.PowerShell.PlatyPS.psm1
@@ -248,8 +248,9 @@ function MakeHelpInfoXml {
         [xml] $HelpInfoContent = $xml
     }
 
-    $outputItem = Get-Item $outputFullPath
-    $null = $HelpInfoContent.Save($outputItem.FullName)
+    $null = $HelpInfoContent.Save($OutputFullPath)
+    $outputItem = Get-Item $OutputFullPath
+
     # return this to the caller
     $outputItem
 }
@@ -393,7 +394,7 @@ function New-HelpCabinetFile {
                 }
             }
         }
-        
+
         $outputFiles
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes a small change to the `MakeHelpInfoXml` function in the `src/Microsoft.PowerShell.PlatyPS.psm1` file. The change reorders the lines where `$HelpInfoContent.Save` and `Get-Item` are called to ensure that the file is saved before it is retrieved.

* [`src/Microsoft.PowerShell.PlatyPS.psm1`](diffhunk://#diff-92baab2079c807df40454768f886051f5135b2002687c759b18abac547a8e9c9L251-R253): Reordered the lines to save `$HelpInfoContent` before retrieving the item with `Get-Item`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
