### PR TITLE
Remove param value from md

### DIFF
--- a/src/MarkdownReader/V2ParameterMetadata.cs
+++ b/src/MarkdownReader/V2ParameterMetadata.cs
@@ -46,6 +46,8 @@ namespace Microsoft.PowerShell.PlatyPS
         [YamlIgnore]
         public bool VariableLength { get; set;}
         public bool SupportsWildcards { get; set;}
+
+        [YamlIgnore]
         public List<string> ParameterValue { get; set;}
         public List<string> Aliases { get; set;}
         public List<ParameterSetV2> ParameterSets { get; set; }

--- a/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMarkdownCommandHelp.Tests.ps1
@@ -202,6 +202,10 @@ Describe "Export-MarkdownCommandHelp" {
             param ($number)
             $ch.Parameters[$number] -eq $ch2.Parameters[$number] | Should -Be $true
         }
+
+        It "Parameter yaml block should not have parameterValue" {
+            Get-Content "${outputFolder}/Get-Date.md" | Should -Not -Match "parameterValue"
+        }
     }
 
     Context "File Content - Input/Output" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces changes to the `ParameterMetadataV2` class and its corresponding tests to ensure that the `ParameterValue` property is excluded from YAML serialization. The most important changes include marking the `ParameterValue` property with the `[YamlIgnore]` attribute and adding a test to verify that the `parameterValue` field does not appear in the generated YAML output.

### Updates to `ParameterMetadataV2`:

* [`src/MarkdownReader/V2ParameterMetadata.cs`](diffhunk://#diff-ffe3c399f0ed130b90a8bb3929e4b4dce001f997da79fa2d47d77b625d6184ffR49-R50): Added the `[YamlIgnore]` attribute to the `ParameterValue` property to ensure it is excluded from YAML serialization.

### Test additions:

* [`test/Pester/ExportMarkdownCommandHelp.Tests.ps1`](diffhunk://#diff-af8a101341173764ad226e718726f0c640e8f5f5acc9968b7f692c8f5727d503R205-R208): Added a new test to verify that the `parameterValue` field is not present in the YAML block of the generated markdown file.

## PR Context

Fixes https://github.com/PowerShell/platyPS/issues/724
