### PR TITLE
Fix example parsing when there no parameters on the command

### DIFF
--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -1056,7 +1056,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
                 var exampleItemIndex = GetNextHeaderIndex(md, expectedHeaderLevel: 3, startIndex: currentIndex);
 
-                if (exampleItemIndex > endExampleIndex)
+                if (exampleItemIndex > endExampleIndex || exampleItemIndex == -1)
                 {
                     break;
                 }

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -201,6 +201,12 @@ Describe 'Import-MarkdownCommandHelp Tests' {
         It "Should preserve embedded emphasis in the example title" {
             $v2ch.Examples[0].Title | Should -Be "Example 1: Get child items from a **file** system directory"
         }
+
+        It 'Should work if only 1 example is present' {
+            $ch = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Get-MPIOSetting.md"
+            $ch.Examples.Count | Should -Be 1
+            $ch.Examples[0].Title | Should -Be "Example 1: Get MPIO settings"
+        }
     }
 
     Context 'Syntax' {

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -13,9 +13,9 @@ Describe "Export-MarkdownModuleFile" {
 
     It "Should identify all the '<fileType>' assets" -TestCases @(
         @{ fileType = "unknown"; expectedCount = 2 }
-        @{ fileType = "CommandHelp"; expectedCount = 37 }
+        @{ fileType = "CommandHelp"; expectedCount = 38 }
         @{ fileType = "ModuleFile"; expectedCount = 14 }
-        @{ fileType = "V1Schema"; expectedCount = 47 }
+        @{ fileType = "V1Schema"; expectedCount = 48 }
         @{ fileType = "V2Schema"; expectedCount = 4 }
     ) {
         param ($fileType, $expectedCount)

--- a/test/Pester/assets/Get-MPIOSetting.md
+++ b/test/Pester/assets/Get-MPIOSetting.md
@@ -1,0 +1,62 @@
+---
+external help file: MPIO_Cmdlets.xml
+Module Name: MPIO
+online version: https://learn.microsoft.com/powershell/module/mpio/get-mpiosetting?view=windowsserver2012-ps&wt.mc_id=ps-gethelp
+schema: 2.0.0
+title: Get-MPIOSetting
+---
+# Get-MPIOSetting
+
+## SYNOPSIS
+Gets MPIO settings.
+
+## SYNTAX
+
+```
+Get-MPIOSetting
+```
+
+## DESCRIPTION
+The **Get-MPIOSetting** cmdlet gets Microsoft Multipath I/O (MPIO) settings.
+The settings are as follows:
+
+- PathVerificationState
+- PathVerificationPeriod
+- PDORemovePeriod
+- RetryCount
+- RetryInterval
+- UseCustomPathRecoveryTime
+- CustomPathRecoveryTime
+- DiskTimeoutValue
+
+You can use the **Set-MPIOSetting** cmdlet to change these values.
+
+## EXAMPLES
+
+### Example 1: Get MPIO settings
+```
+PS C:\>Get-MPIOSetting
+
+PathVerificationState     : Disabled
+PathVerificationPeriod    : 30
+PDORemovePeriod           : 20
+RetryCount                : 3
+RetryInterval             : 1
+UseCustomPathRecoveryTime : Disabled
+CustomPathRecoveryTime    : 40
+DiskTimeoutValue          : 120
+```
+
+This command gets the MPIO settings.
+
+## PARAMETERS
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Set-MPIOSetting](./Set-MPIOSetting.md)


### PR DESCRIPTION
# PR Summary

Fix index out of bound error when there is only 1 example. Added tests for the same,

## PR Context

Fixes #734 
