### PR TITLE
MAML conversion uses the function name as Verb and empty string as noun

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -216,8 +216,18 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             var details = new CommandDetails();
             details.Name = commandHelp.Title;
             string[] verbNoun = commandHelp.Title.Split('-');
-            details.Verb = verbNoun[0];
-            details.Noun = verbNoun[1];
+
+            if (verbNoun.Length == 2)
+            {
+                details.Verb = verbNoun[0];
+                details.Noun = verbNoun[1];
+            }
+            else
+            {
+                details.Verb = commandHelp.Title;
+                details.Noun = string.Empty;
+            }
+
             details.Synopsis.Add(commandHelp.Synopsis);
             return details;
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Functions dont follow the Verb-Noun pattern, so we use the function name as the Verb and an empty string as the Noun.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
