### PR TITLE
Get the description from comment-based help for input and output

### DIFF
--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -802,7 +802,6 @@ namespace Microsoft.PowerShell.PlatyPS
                     string typeName = FixUpTypeName(ioType.type.name?.Split()?[0] ?? string.Empty);
                     if (! string.IsNullOrEmpty(typeName) && string.Compare(typeName, "None", true) != 0)
                     {
-                        //string description = GetStringFromDescriptionArray(ioType.description).Trim();
                         string description = ioType.type.name.Replace(typeName, string.Empty).Trim();
                         itemList.Add(new InputOutput(typeName, string.IsNullOrEmpty(description) ? Constants.FillInDescription : description));
                     }

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -802,7 +802,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     string typeName = FixUpTypeName(ioType.type.name?.Split()?[0] ?? string.Empty);
                     if (! string.IsNullOrEmpty(typeName) && string.Compare(typeName, "None", true) != 0)
                     {
-                        string description = ioType.type.name.Replace(typeName, string.Empty).Trim();
+                        string description = GetStringFromDescriptionArray(ioType.description)?.Trim() ?? string.Empty;
                         itemList.Add(new InputOutput(typeName, string.IsNullOrEmpty(description) ? Constants.FillInDescription : description));
                     }
                 }

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -799,10 +799,11 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 foreach (dynamic ioType in typesInfo)
                 {
-                    string typeName = FixUpTypeName(ioType.type.ToString());
+                    string typeName = FixUpTypeName(ioType.type.name?.Split()?[0] ?? string.Empty);
                     if (! string.IsNullOrEmpty(typeName) && string.Compare(typeName, "None", true) != 0)
                     {
-                        string description = GetStringFromDescriptionArray(ioType.description).Trim();
+                        //string description = GetStringFromDescriptionArray(ioType.description).Trim();
+                        string description = ioType.type.name.Replace(typeName, string.Empty).Trim();
                         itemList.Add(new InputOutput(typeName, string.IsNullOrEmpty(description) ? Constants.FillInDescription : description));
                     }
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Ensure that we can get the typename and description from the INPUT and OUTPUT blocks from comment based help.

## PR Context

Fixes #745 
