### PR TITLE
Update the parameter description in markdown when comment based help …

### DIFF
--- a/src/Common/MergeUtils.cs
+++ b/src/Common/MergeUtils.cs
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 var cmdParam = matchingCommandParameter.Count() > 0 ? matchingCommandParameter.First() : null;
                 var foundParams = fromHelp.Where(x => string.Compare(x.Name, pName) == 0);
                 var helpParam = foundParams.Count() > 0 ? foundParams.First() : null;
-                
+
                 // This should never happen, but if it does, we'll log it.
                 if (helpParam is null && cmdParam is null)
                 {
@@ -237,9 +237,25 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     var dm = new DiagnosticMessage(DiagnosticMessageSource.Merge, $"updating {pName}.", DiagnosticSeverity.Information, "TryGetMergedParameters", -1);
                     diagnosticMessages.Add(dm);
+
+                    var checkTemplate = string.Format(Constants.FillInParameterDescriptionTemplate, helpParam.Name);
+
+                    var description = helpParam.Description;
+
+                    if (string.Equals(helpParam.Description, checkTemplate, StringComparison.OrdinalIgnoreCase))
+                    {
+                        diagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Merge, $"Parameter {pName} has no description in the help.", DiagnosticSeverity.Warning, "TryGetMergedParameters", -1));
+                        description = cmdParam.Description;
+                    }
+                    else if (!string.Equals(helpParam.Description, cmdParam.Description, StringComparison.OrdinalIgnoreCase))
+                    {
+                        diagnosticMessages.Add(new DiagnosticMessage(DiagnosticMessageSource.Merge, $"Parameter {pName} has the different description in the help and the command. Concatinating.", DiagnosticSeverity.Information, "TryGetMergedParameters", -1));
+                        description = string.Join(Environment.NewLine, helpParam.Description, cmdParam.Description);
+                    }
+
                     var newParameter = new Parameter(cmdParam)
                     {
-                        Description = helpParam.Description,
+                        Description = description,
                         DontShow = helpParam.DontShow,
                         DefaultValue = helpParam.DefaultValue
                     };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces an enhancement to the `TryGetMergedParameters` method in `src/Common/MergeUtils.cs` to improve how parameter descriptions are handled during the merge process. The changes ensure better diagnostics and more accurate merging of parameter descriptions.

Enhancements to parameter merging:

* Added logic to check if a parameter's description in the help matches a predefined template (`FillInParameterDescriptionTemplate`). If it does, a warning diagnostic is logged, and the description falls back to the command's description.
* Introduced a conditional check to identify and handle cases where the help description differs from the command description. In such cases, the descriptions are concatenated, and an informational diagnostic is logged.
* Updated the `newParameter` object to use the resolved `description` variable instead of directly using the help description, ensuring the merged description reflects the new logic.

## PR Context

Fixes #751 
