### PR TITLE
Remove nullable

### DIFF
--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -100,7 +100,8 @@ namespace Microsoft.PowerShell.PlatyPS
         // We can also simplify the string if desired.
         private string GetAdjustedTypename(Type t, bool simplify = false)
         {
-            string tName = simplify ?  LanguagePrimitives.ConvertTo<string>(t) : t.FullName;
+            var t2 = Nullable.GetUnderlyingType(t) ?? t;
+            string tName = simplify ?  LanguagePrimitives.ConvertTo<string>(t2) : t2.FullName;
             return tName;
         }
 
@@ -847,7 +848,7 @@ namespace Microsoft.PowerShell.PlatyPS
         // We also will remove trailing [] because we should generally return singletons
         private string FixUpTypeName(string typename)
         {
-            string fixedString = typename.Trim();
+            string fixedString = typename.Replace("System.Nullable`1[[", string.Empty).Replace(",", string.Empty).Trim();
             if (fixedString.EndsWith("[]"))
             {
                 fixedString = fixedString.Remove(fixedString.Length - 2);

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -848,7 +848,14 @@ namespace Microsoft.PowerShell.PlatyPS
         // We also will remove trailing [] because we should generally return singletons
         private string FixUpTypeName(string typename)
         {
-            string fixedString = typename.Replace("System.Nullable`1[[", string.Empty).Replace(",", string.Empty).Trim();
+            // If the type is a generic type, we need to remove the backtick and the number.
+            string fixedString = typename.Replace("System.Nullable`1[[", string.Empty);
+            int commaIndex = fixedString.IndexOf(',');
+            if (commaIndex >= 0)
+            {
+                fixedString = fixedString.Substring(0, commaIndex).Trim();
+            }
+
             if (fixedString.EndsWith("[]"))
             {
                 fixedString = fixedString.Remove(fixedString.Length - 2);

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -141,6 +141,20 @@ Describe "New-CommandHelp tests" {
         BeforeAll {
             $cmd = Get-Command Get-Command
             $ch = $cmd | New-CommandHelp
+
+            function global:Test-InputOutputTypes
+            {
+                [CmdletBinding()]
+                [OutputType()]
+                param(
+                    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+                    [Nullable[int]]$InputString
+                )
+
+                Write-Output "Processed: $InputString"
+            }
+
+            $io = New-CommandHelp -Command (Get-Command Test-InputOutputTypes)
         }
 
         It "Should have the proper number of output types" {
@@ -182,6 +196,10 @@ Describe "New-CommandHelp tests" {
             param ($type)
             $ch.inputs.typename | Should -Contain $type
         }
-    }
 
+        It "Should not have Nullable in the input type" {
+            $io.inputs.typename | Should -Not -Contain "Nullable"
+            $io.inputs.typename | Should -Be "System.Int32"
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces enhancements to handle nullable types more effectively in type names and includes corresponding updates to tests. The key changes involve adjustments to type name processing logic and the addition of test cases to validate the new behavior.

### Improvements to nullable type handling:

* [`src/Transform/TransformBase.cs`](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L103-R104): Updated the `GetAdjustedTypename` method to unwrap nullable types using `Nullable.GetUnderlyingType`, ensuring that type names are simplified correctly.
* [`src/Transform/TransformBase.cs`](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L850-R858): Enhanced the `FixUpTypeName` method to handle generic nullable types by removing backticks and type arguments, further improving the readability of type names.

### Test updates for nullable type handling:

* [`test/Pester/ConvertToCommandHelp.Tests.ps1`](diffhunk://#diff-478faade5a2a1496acacb86a06dc8c54204a4d7928aab5995d58c21f56fa71ceR144-R157): Added a new helper function, `Test-InputOutputTypes`, to test input and output type handling for nullable types.
* [`test/Pester/ConvertToCommandHelp.Tests.ps1`](diffhunk://#diff-478faade5a2a1496acacb86a06dc8c54204a4d7928aab5995d58c21f56fa71ceL185-R204): Introduced a test case to verify that nullable types are correctly processed and do not include "Nullable" in the input type name.

## PR Context

Fixes #545 
