### PR TITLE
Ensure the next header after description is examples while parsing MD

### DIFF
--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -561,7 +561,7 @@ namespace Microsoft.PowerShell.PlatyPS
             diagnostics.Add(new DiagnosticMessage( DiagnosticMessageSource.Description, "DESCRIPTION header found", DiagnosticSeverity.Information, "DESCRIPTION", markdownContent.GetTextLine(start)));
             markdownContent.Seek(start);
             markdownContent.Take();
-            var end = markdownContent.FindHeader(2, string.Empty);
+            var end = markdownContent.FindHeader(2, "EXAMPLES");
             return markdownContent.GetStringFromAst(end).Trim();
         }
 

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -254,7 +254,7 @@ Describe 'Import-MarkdownCommandHelp Tests' {
 
     Context 'Validate Description' {
         BeforeAll {
-            $ch = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Compare-CommandHelp.md"
+            $ch = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Compare-CommandHelp2.md"
         }
 
         It "Should handle empty description" {

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -251,4 +251,14 @@ Describe 'Import-MarkdownCommandHelp Tests' {
             $ch.Syntax[$offset].ToString() | Should -Be $string
         }
     }
+
+    Context 'Validate Description' {
+        BeforeAll {
+            $ch = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Compare-CommandHelp.md"
+        }
+
+        It "Should handle empty description" {
+            $ch.Description | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -13,10 +13,10 @@ Describe "Export-MarkdownModuleFile" {
 
     It "Should identify all the '<fileType>' assets" -TestCases @(
         @{ fileType = "unknown"; expectedCount = 2 }
-        @{ fileType = "CommandHelp"; expectedCount = 39 }
+        @{ fileType = "CommandHelp"; expectedCount = 40 }
         @{ fileType = "ModuleFile"; expectedCount = 14 }
         @{ fileType = "V1Schema"; expectedCount = 49 }
-        @{ fileType = "V2Schema"; expectedCount = 4 }
+        @{ fileType = "V2Schema"; expectedCount = 5 }
     ) {
         param ($fileType, $expectedCount)
         $idents.Where({($_.FileType -band $fileType) -eq $fileType}).Count | Should -Be $expectedCount

--- a/test/Pester/assets/Compare-CommandHelp.md
+++ b/test/Pester/assets/Compare-CommandHelp.md
@@ -1,66 +1,45 @@
 ---
 document type: cmdlet
-title: Compare-CommandHelp
-Module Name: Microsoft.PowerShell.PlatyPS
-Locale: "en-US"
-PlatyPS schema version: 2024-05-01
-HelpUri: 
-ms.date: 05/20/2024
 external help file: Microsoft.PowerShell.PlatyPS.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Microsoft.PowerShell.PlatyPS
+ms.date: 03/07/2025
+PlatyPS schema version: 2024-05-01
+title: Compare-CommandHelp
 ---
 
 # Compare-CommandHelp
 
 ## SYNOPSIS
 
-{{ Fill in the Synopsis }}
-
 ## SYNTAX
 
 ### __AllParameterSets
 
 ```
-Compare-CommandHelp [-Reference] <CommandHelp> [-Difference] <CommandHelp>
- [-PropertyNamesToExclude <String[]>] [<CommonParameters>]
+Compare-CommandHelp [-ReferenceCommandHelp] <CommandHelp> [-DifferenceCommandHelp] <CommandHelp>
+ [-PropertyNamesToExclude <string[]>] [<CommonParameters>]
 ```
 
 ## ALIASES
 
 This cmdlet has the following aliases,
-  {{Insert list of aliases}}
 
 ## DESCRIPTION
 
-{{ Fill in the Description }}
-
 ## EXAMPLES
 
-### My Example
-
-description
-
-```powershell
-PS> write-output hi
-hi
-```
-
-description 2
-
-```powershell
-PS> echo bye
-bye
-```
-
-description 3
+### Example 1
 
 ## PARAMETERS
 
-### -Difference
+### -DifferenceCommandHelp
 
 ```yaml
-Type: CommandHelp
+Type: Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -77,12 +56,10 @@ HelpMessage: ''
 
 ### -PropertyNamesToExclude
 
-{{ Fill PropertyNamesToExclude Description }}
-
 ```yaml
-Type: String[]
+Type: System.String[]
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -97,14 +74,12 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
-### -Reference
-
-{{ Fill Reference Description }}
+### -ReferenceCommandHelp
 
 ```yaml
-Type: CommandHelp
+Type: Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -123,23 +98,17 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, -WarningVariable.
-For more information, see
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.Management.Automation.HiThere
+### Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 
 ## OUTPUTS
 
-### System.Object
+### System.String
 
 ## NOTES
 
-Just a note
-
 ## RELATED LINKS
-
-
-

--- a/test/Pester/assets/Compare-CommandHelp2.md
+++ b/test/Pester/assets/Compare-CommandHelp2.md
@@ -1,66 +1,45 @@
 ---
 document type: cmdlet
-title: Compare-CommandHelp
-Module Name: Microsoft.PowerShell.PlatyPS
-Locale: "en-US"
-PlatyPS schema version: 2024-05-01
-HelpUri: 
-ms.date: 05/20/2024
 external help file: Microsoft.PowerShell.PlatyPS.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Microsoft.PowerShell.PlatyPS
+ms.date: 03/07/2025
+PlatyPS schema version: 2024-05-01
+title: Compare-CommandHelp
 ---
 
 # Compare-CommandHelp
 
 ## SYNOPSIS
 
-{{ Fill in the Synopsis }}
-
 ## SYNTAX
 
 ### __AllParameterSets
 
 ```
-Compare-CommandHelp [-Reference] <CommandHelp> [-Difference] <CommandHelp>
- [-PropertyNamesToExclude <String[]>] [<CommonParameters>]
+Compare-CommandHelp [-ReferenceCommandHelp] <CommandHelp> [-DifferenceCommandHelp] <CommandHelp>
+ [-PropertyNamesToExclude <string[]>] [<CommonParameters>]
 ```
 
 ## ALIASES
 
 This cmdlet has the following aliases,
-  {{Insert list of aliases}}
 
 ## DESCRIPTION
 
-{{ Fill in the Description }}
-
 ## EXAMPLES
 
-### My Example
-
-description
-
-```powershell
-PS> write-output hi
-hi
-```
-
-description 2
-
-```powershell
-PS> echo bye
-bye
-```
-
-description 3
+### Example 1
 
 ## PARAMETERS
 
-### -Difference
+### -DifferenceCommandHelp
 
 ```yaml
-Type: CommandHelp
+Type: Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -77,12 +56,10 @@ HelpMessage: ''
 
 ### -PropertyNamesToExclude
 
-{{ Fill PropertyNamesToExclude Description }}
-
 ```yaml
-Type: String[]
+Type: System.String[]
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -97,14 +74,12 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
-### -Reference
-
-{{ Fill Reference Description }}
+### -ReferenceCommandHelp
 
 ```yaml
-Type: CommandHelp
+Type: Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 DefaultValue: ''
-Globbing: false
+SupportsWildcards: false
 ParameterValue: []
 Aliases: []
 ParameterSets:
@@ -123,23 +98,17 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, -WarningVariable.
-For more information, see
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### System.Management.Automation.HiThere
+### Microsoft.PowerShell.PlatyPS.Model.CommandHelp
 
 ## OUTPUTS
 
-### System.Object
+### System.String
 
 ## NOTES
 
-Just a note
-
 ## RELATED LINKS
-
-
-


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes a single change to the `GetDescriptionFromMarkdown` method in `CommandHelpMarkdownReader.cs`. The change modifies the logic for determining the end of the "DESCRIPTION" section by specifying the "EXAMPLES" header as the stopping point instead of using an empty string to find the next header.

## PR Context

Fixes #723 