### PR TITLE
Multiline yaml

### DIFF
--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -364,7 +364,7 @@ namespace Microsoft.PowerShell.PlatyPS
                         {
                             sb = Constants.StringBuilderPool.Get();
                             int startIndex = ast[2].Line - 1; // -1 because we are 0 based
-                            int endIndex = ast[3].Line - 1; // -1 because we are 0 based
+                            int endIndex = ast[3].Line;
                             for (int i = startIndex; i < endIndex; i++)
                             {
                                 sb.AppendLine(md.MarkdownLines[i].TrimEnd());

--- a/src/MarkdownReader/MarkdownProbeInfo.cs
+++ b/src/MarkdownReader/MarkdownProbeInfo.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.PlatyPS
             FilePath = filePath;
             DiagnosticMessages = new();
             MarkdownContent = ParsedMarkdownContent.ParseFile(filePath);
-            MetaData = MarkdownConverter.GetMetadata(MarkdownContent.Ast);
+            MetaData = MarkdownConverter.GetMetadata(MarkdownContent);
             DetermineContentType();
         }
 

--- a/src/MarkdownReader/ModuleFileMarkdownReader.cs
+++ b/src/MarkdownReader/ModuleFileMarkdownReader.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.PlatyPS
             */
 
             ModuleFileInfo moduleFileInfo = new();
-            OrderedDictionary? metadata = GetMetadata(markdownContent.Ast);
+            OrderedDictionary? metadata = GetMetadata(markdownContent);
             if (metadata is null)
             {
                 throw new InvalidDataException("null metadata");
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 return string.Empty;
             }
 
-            var titleString = titleBlock.Inline?.FirstChild?.ToString().Trim(); 
+            var titleString = titleBlock.Inline?.FirstChild?.ToString().Trim();
             if (titleString is null)
             {
                 diagnostics.Add(new DiagnosticMessage(DiagnosticMessageSource.ModuleFileTitle, "Null title", DiagnosticSeverity.Error, "GetModuleFileTitle", -1));
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell.PlatyPS
         }
 
         /// <summary>
-        /// Read the module file looking for 
+        /// Read the module file looking for
         /// "### [name](markdownfile.md)
         /// Description
         /// </summary>

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -24,6 +24,8 @@ Describe 'Import-MarkdownCommandHelp Tests' {
         BeforeAll {
             $result = Import-MarkdownCommandHelp -Path $goodMarkdownPath
             $metadata = $result.GetType().GetProperty('Metadata', [System.Reflection.BindingFlags]'Public,NonPublic,Instance').GetValue($result, $null)
+
+            $md = Import-MarkdownModuleFile -Path "$assetdir/CimCmdlets2.md"
         }
 
         It 'Should be a valid CommandHelp object' {
@@ -58,6 +60,10 @@ Describe 'Import-MarkdownCommandHelp Tests' {
             $result.Metadata.aliases[0] | Should -Be "dir"
             $result.Metadata.aliases[1] | Should -Be "ls"
             $result.Metadata.aliases[2] | Should -Be "gci"
+        }
+
+        It 'Should be able to read multiline metadata' {
+            $md.Metadata['foo'] | Should -Be "bar"
         }
     }
 

--- a/test/Pester/ImportMarkdownModuleFile.Tests.ps1
+++ b/test/Pester/ImportMarkdownModuleFile.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Import-ModuleFile tests" {
     Context "File creation" {
         It "Should be able to read module files" {
             $results = $modFiles.FullName | Import-MarkdownModuleFile
-            $results.Count | Should -Be 13
+            $results.Count | Should -Be 14
         }
 
         It "Should produce the correct type of object" {

--- a/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
+++ b/test/Pester/MeasurePlatyPSMarkdown.Tests.ps1
@@ -14,8 +14,8 @@ Describe "Export-MarkdownModuleFile" {
     It "Should identify all the '<fileType>' assets" -TestCases @(
         @{ fileType = "unknown"; expectedCount = 2 }
         @{ fileType = "CommandHelp"; expectedCount = 40 }
-        @{ fileType = "ModuleFile"; expectedCount = 14 }
-        @{ fileType = "V1Schema"; expectedCount = 49 }
+        @{ fileType = "ModuleFile"; expectedCount = 15 }
+        @{ fileType = "V1Schema"; expectedCount = 50 }
         @{ fileType = "V2Schema"; expectedCount = 5 }
     ) {
         param ($fileType, $expectedCount)

--- a/test/Pester/assets/CimCmdlets2.md
+++ b/test/Pester/assets/CimCmdlets2.md
@@ -3,7 +3,7 @@ Download Help Link: https://aka.ms/powershell74-help
 Help Version: 7.4.0.0
 Locale: en-US
 Module Guid: fb6cc51d-c096-4b38-b78d-0fed6277096a
-Module Name: CimCmdlets
+Module Name: CimCmdlets2
 ms.date: 02/20/2019
 schema: 2.0.0
 title: CimCmdlets Module
@@ -12,7 +12,7 @@ foo:
   - bar
 test: true
 ---
-# CimCmdlets Module
+# CimCmdlets2 Module
 
 ## Description
 

--- a/test/Pester/assets/CimCmdlets2.md
+++ b/test/Pester/assets/CimCmdlets2.md
@@ -1,0 +1,80 @@
+---
+Download Help Link: https://aka.ms/powershell74-help
+Help Version: 7.4.0.0
+Locale: en-US
+Module Guid: fb6cc51d-c096-4b38-b78d-0fed6277096a
+Module Name: CimCmdlets
+ms.date: 02/20/2019
+schema: 2.0.0
+title: CimCmdlets Module
+isPreview: true
+foo:
+  - bar
+test: true
+---
+# CimCmdlets Module
+
+## Description
+
+Contains cmdlets that interact with Common Information Model (CIM) Servers like the Windows
+Management Instrumentation (WMI) service.
+
+This module is only available on the Windows platform.
+
+## CimCmdlets Cmdlets
+
+### [Export-BinaryMiLog](Export-BinaryMiLog.md)
+
+Creates a binary encoded representation of an object or objects and stores it in a file.
+
+### [Get-CimAssociatedInstance](Get-CimAssociatedInstance.md)
+
+Retrieves the CIM instances that are connected to a specific CIM instance by an association.
+
+### [Get-CimClass](Get-CimClass.md)
+
+Gets a list of CIM classes in a specific namespace.
+
+### [Get-CimInstance](Get-CimInstance.md)
+
+Gets the CIM instances of a class from a CIM server.
+
+### [Get-CimSession](Get-CimSession.md)
+
+Gets the CIM session objects from the current session.
+
+### [Import-BinaryMiLog](Import-BinaryMiLog.md)
+
+Used to re-create the saved objects based on the contents of an export file.
+
+### [Invoke-CimMethod](Invoke-CimMethod.md)
+
+Invokes a method of a CIM class.
+
+### [New-CimInstance](New-CimInstance.md)
+
+Creates a CIM instance.
+
+### [New-CimSession](New-CimSession.md)
+
+Creates a CIM session.
+
+### [New-CimSessionOption](New-CimSessionOption.md)
+
+Specifies advanced options for the `New-CimSession` cmdlet.
+
+### [Register-CimIndicationEvent](Register-CimIndicationEvent.md)
+
+Subscribes to indications using a filter expression or a query expression.
+
+### [Remove-CimInstance](Remove-CimInstance.md)
+
+Removes a CIM instance from a computer.
+
+### [Remove-CimSession](Remove-CimSession.md)
+
+Removes one or more CIM sessions.
+
+### [Set-CimInstance](Set-CimInstance.md)
+
+Modifies a CIM instance on a CIM server by calling the **ModifyInstance** method of the CIM class.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes updates to improve metadata handling in markdown processing and enhance test coverage. The changes primarily focus on modifying how metadata is extracted and processed, adding support for multiline metadata, and updating test assets and cases accordingly.

### Metadata Handling Improvements:
* Updated `GetMetadata` method in `src/MarkdownReader/CommandHelpMarkdownReader.cs` to accept `ParsedMarkdownContent` instead of `MarkdownDocument`, allowing access to the full markdown content for metadata extraction. [[1]](diffhunk://#diff-2b2e6a603c33dbdccc6d0bb591d4d3dd530c741130ac94757d7b754744853476L201-R201) [[2]](diffhunk://#diff-2b2e6a603c33dbdccc6d0bb591d4d3dd530c741130ac94757d7b754744853476L330-R332)
* Enhanced metadata parsing to handle multiline metadata blocks by iterating through markdown lines and converting them into an `OrderedDictionary`. This change ensures better support for complex metadata structures.

### Test Enhancements:
* Added a new test case to verify that multiline metadata can be correctly parsed and accessed.
* Updated the test asset `CimCmdlets2.md` to include multiline metadata for testing purposes.
* Adjusted metadata-related test counts to reflect the addition of new test cases and assets.

### Codebase Adjustments:
* Replaced `MarkdownDocument.Ast` references with `ParsedMarkdownContent` in other files (`MarkdownProbeInfo.cs`, `ModuleFileMarkdownReader.cs`) to maintain consistency with the updated metadata handling approach. [[1]](diffhunk://#diff-801bb87d9bb2634372fee77b082257451c1079325e883f7e8c7b4a02b5f0df28L71-R71) [[2]](diffhunk://#diff-692c38b0d7ede71ac3457a68e76c2bec7495d62d2304fb0f498c863326b34f71L36-R36)

## PR Context

Fixes #731 
