### PR TITLE
Update CI and release pipeline for branch name changes

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -4,15 +4,15 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
     - release/*
-    - v2
+    - v1
 pr:
   branches:
     include:
-    - master
+    - main
     - release/*
-    - v2
+    - v1
 
 resources:
   repositories:

--- a/.pipelines/PlatyPS-Official.yml
+++ b/.pipelines/PlatyPS-Official.yml
@@ -7,7 +7,8 @@ schedules:
   displayName: Weekly Build
   branches:
     include:
-    - v2
+    - release/*
+    - main
   always: true
 
 parameters:

--- a/tools/releaseBuild/release.yml
+++ b/tools/releaseBuild/release.yml
@@ -4,8 +4,8 @@ trigger: none
 pr:
   branches:
     include:
-    - v2
-    - release/v2/*
+    - main
+    - release/*
 
 variables:
   - group: ESRP
@@ -38,7 +38,6 @@ stages:
         $versionString = if ($env:RELEASE_VERSION -eq 'fromBranch') {
           $branch = $env:BUILD_SOURCEBRANCH
           $branchOnly = $branch -replace '^refs/heads/'
-          $branchOnly -replace '^.*(release/v2[-/])'
         }
         else {
             $env:RELEASE_VERSION

--- a/tools/releaseBuild/template/publish.yml
+++ b/tools/releaseBuild/template/publish.yml
@@ -6,7 +6,7 @@ parameters:
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: Release Microsoft.PowerShell.PlatyPS to '${{ parameters.stageName }}'
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/v2'))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))
 
   jobs:
   - deployment: Publish_${{ parameters.stageName }}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates CI/CD pipeline configurations to align with branch naming conventions and simplify conditions. The changes primarily replace references to `master` and `v2` branches with `main` and `release/*`, ensuring consistency across pipeline files.

### Updates to branch naming conventions:

* [`.ci/ci.yml`](diffhunk://#diff-3ef4eed28777167cb9eb6ea4ae3c26a39ca299a2a125fcb3a913b5dce6c60d76L7-R15): Updated `trigger:` and `pr:` sections to replace `master` with `main` and `v2` with `v1` for branch inclusions.
* [`.pipelines/PlatyPS-Official.yml`](diffhunk://#diff-53ad3f8187d3ce8b93168b15ccd4ab23cbb40df6e38d4b1e8a1e682c816afd98L10-R11): Modified `schedules:` section to include `main` and `release/*` branches instead of `v2`.
* [`tools/releaseBuild/release.yml`](diffhunk://#diff-d0fba49a7da3d39cfda9458b28a812ec75eaac97f7ec1c9390a980b1c59f22edL7-R8): Updated `trigger:` section to replace `v2` and `release/v2/*` with `main` and `release/*`.

### Simplification of branch-related conditions:

* [`tools/releaseBuild/release.yml`](diffhunk://#diff-d0fba49a7da3d39cfda9458b28a812ec75eaac97f7ec1c9390a980b1c59f22edL41): Removed regex logic for branch name transformation in `stages:` section, simplifying branch handling.
* [`tools/releaseBuild/template/publish.yml`](diffhunk://#diff-1d976651b9aa86fbab83244134ccf645118f916fe0a5ba8d5b1289c2b96a6893L9-R9): Adjusted `parameters:` section to simplify the condition for manual builds, replacing `release/v2` with `release`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
