### PR TITLE
Confirm and WhatIf parameters should have constant descriptions

### DIFF
--- a/src/Common/MergeUtils.cs
+++ b/src/Common/MergeUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Microsoft.PowerShell.PlatyPS.Model;
 
@@ -238,7 +239,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     var dm = new DiagnosticMessage(DiagnosticMessageSource.Merge, $"updating {pName}.", DiagnosticSeverity.Information, "TryGetMergedParameters", -1);
                     diagnosticMessages.Add(dm);
 
-                    var checkTemplate = string.Format(Constants.FillInParameterDescriptionTemplate, helpParam.Name);
+                    var checkTemplate = TransformUtils.GetParameterTemplateString(helpParam.Name);
 
                     var description = helpParam.Description;
 

--- a/src/Model/Constants.cs
+++ b/src/Model/Constants.cs
@@ -85,8 +85,8 @@ namespace Microsoft.PowerShell.PlatyPS.Model
         internal const string FillInGuid = "XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
         internal const string LocaleEnUs = "en-US";
         internal const string skippingMessageFmt = "'{0}' exists, skipping. Use -Force to overwrite.";
-        internal const string ConfirmParameterDescription = "{{ Fill Confirm Description }}";
-        internal const string WhatIfParameterDescription = "{{ Fill WhatIf Description }}";
+        internal const string ConfirmParameterDescription = "Prompts you for confirmation before running the cmdlet.";
+        internal const string WhatIfParameterDescription = "Tells PowerShell to run the command in a mode that only reports what would happen, but not actually let the command run or make changes.";
 
         // TODO: ProgressAction is not a common parameter for all versions of PowerShell.
         //  This should not be added under all circumstances.

--- a/src/Model/Constants.cs
+++ b/src/Model/Constants.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.PowerShell.PlatyPS.Model
 {
@@ -84,6 +85,8 @@ namespace Microsoft.PowerShell.PlatyPS.Model
         internal const string FillInGuid = "XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
         internal const string LocaleEnUs = "en-US";
         internal const string skippingMessageFmt = "'{0}' exists, skipping. Use -Force to overwrite.";
+        internal const string ConfirmParameterDescription = "{{ Fill Confirm Description }}";
+        internal const string WhatIfParameterDescription = "{{ Fill WhatIf Description }}";
 
         // TODO: ProgressAction is not a common parameter for all versions of PowerShell.
         //  This should not be added under all circumstances.

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -236,7 +236,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
                 string descriptionFromHelp = GetParameterDescriptionFromHelp(helpItem, param.Name) ?? param.HelpMessage ?? string.Empty;
                 param.Description = string.IsNullOrEmpty(descriptionFromHelp) ?
-                    string.Format(Constants.FillInParameterDescriptionTemplate, param.Name) :
+                    TransformUtils.GetParameterTemplateString(param.Name) :
                     descriptionFromHelp.Trim();
 
                 parameters.Add(param);
@@ -517,7 +517,7 @@ namespace Microsoft.PowerShell.PlatyPS
             }
             else
             {
-                if (TranformUtils.TryGetTypeAbbreviation(type.FullName, out string abbreviation))
+                if (TransformUtils.TryGetTypeAbbreviation(type.FullName, out string abbreviation))
                 {
                     return abbreviation;
                 }
@@ -613,7 +613,7 @@ namespace Microsoft.PowerShell.PlatyPS
             string descriptionFromHelp = GetParameterDescriptionFromHelp(helpItem, param.Name) ?? paramAttribInfo.HelpMessage ?? string.Empty;
 
             param.Description = string.IsNullOrEmpty(descriptionFromHelp) ?
-                string.Format(Constants.FillInParameterDescriptionTemplate, param.Name) :
+                TransformUtils.GetParameterTemplateString(param.Name) :
                 descriptionFromHelp;
 
             param.Aliases = paramInfo.Aliases.ToList();

--- a/src/Transform/TransformUtils.cs
+++ b/src/Transform/TransformUtils.cs
@@ -15,7 +15,7 @@ using Microsoft.PowerShell.PlatyPS.Model;
 
 namespace Microsoft.PowerShell.PlatyPS
 {
-    public class TranformUtils
+    public class TransformUtils
     {
         private static Dictionary<string, string> TypeAbbreviations = new Dictionary<string, string> {
             { "System.Management.Automation.AliasAttribute" , "Alias" },
@@ -122,6 +122,27 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             return false;
+        }
+
+        public static string GetParameterTemplateString(string paramName)
+        {
+            if (string.IsNullOrEmpty(paramName))
+            {
+                throw new ArgumentException("Parameter name cannot be null or empty.", nameof(paramName));
+            }
+
+            if (string.Equals(paramName, "Confirm", StringComparison.OrdinalIgnoreCase))
+            {
+                return Constants.ConfirmParameterDescription;
+            }
+            else if (string.Equals(paramName, "WhatIf", StringComparison.OrdinalIgnoreCase))
+            {
+                return Constants.WhatIfParameterDescription;
+            }
+            else
+            {
+                return string.Format(Constants.FillInParameterDescriptionTemplate, paramName);
+            }
         }
     }
 }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -653,8 +653,8 @@ Write-Host 'Hello World!'
         }
 
         It 'should have a description for Confirm and WhatIf parameters' {
-            $file | Should -FileContentMatch '### -Confirm'
-            $file | Should -FileContentMatch '### -WhatIf'
+            $file | Should -FileContentMatch 'Prompts you for confirmation before running the cmdlet.'
+            $file | Should -FileContentMatch 'Tells PowerShell to run the command in a mode that only reports what would happen, but not actually let the command run or make changes.'
         }
     }
 }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -638,4 +638,23 @@ Write-Host 'Hello World!'
             $file | Should -FileContentMatch 'SupportsWildcards: true'
         }
     }
+
+    Context 'Confirm Whatif description' {
+        BeforeAll {
+            function global:Test-ConfirmWhatIfDescription {
+                [CmdletBinding(SupportsShouldProcess = $true)]
+                param (
+                    [Parameter()]
+                    [string] $Name
+                )
+            }
+
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-ConfirmWhatIfDescription') -OutputFolder "$TestDrive/NewMarkDownHelp"
+        }
+
+        It 'should have a description for Confirm and WhatIf parameters' {
+            $file | Should -FileContentMatch '### -Confirm'
+            $file | Should -FileContentMatch '### -WhatIf'
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces changes to improve parameter description handling and corrects a typo in the `TransformUtils` class name. It also adds unit tests to ensure proper descriptions for `Confirm` and `WhatIf` parameters. Below are the most important changes grouped by theme:

### Parameter Description Handling Enhancements:
* [`src/Transform/TransformUtils.cs`](diffhunk://#diff-81f59268cac945002e13b262a66991450d7d2db8434a9af191205c83a5746eccR126-R146): Added a new method `GetParameterTemplateString` to dynamically generate parameter descriptions, including specific descriptions for `Confirm` and `WhatIf` parameters.
* [`src/Model/Constants.cs`](diffhunk://#diff-e1a788ae17f42a265a5b460087a354b0b4d9f71b110d2aff80ae28920c67c9d5R88-R89): Added constants `ConfirmParameterDescription` and `WhatIfParameterDescription` for predefined parameter descriptions.
* [`src/Transform/TransformBase.cs`](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L239-R239): Replaced occurrences of `string.Format(Constants.FillInParameterDescriptionTemplate, param.Name)` with `TransformUtils.GetParameterTemplateString(param.Name)` to utilize the new method. [[1]](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L239-R239) [[2]](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L616-R616)

### Typo Fix:
* [`src/Transform/TransformUtils.cs`](diffhunk://#diff-81f59268cac945002e13b262a66991450d7d2db8434a9af191205c83a5746eccL18-R18): Corrected the class name from `TranformUtils` to `TransformUtils` and updated references accordingly. [[1]](diffhunk://#diff-81f59268cac945002e13b262a66991450d7d2db8434a9af191205c83a5746eccL18-R18) [[2]](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L520-R520)

### Unit Testing:
* [`test/Pester/NewMarkdownHelp.Tests.ps1`](diffhunk://#diff-6e1c8197d192837019b896fe941ff0f68995cc3a80e82a6b725d59bbdd7314c5R641-R659): Added a new test context to verify that descriptions for `Confirm` and `WhatIf` parameters are correctly generated and included in the output.

## PR Context

Fixes #735
