### PR TITLE
Add line breaks in MAML for examples content

### DIFF
--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -96,7 +96,15 @@ namespace Microsoft.PowerShell.PlatyPS
                 }
                 else
                 {
-                    WriteObject(this.InvokeProvider.Item.Get(MamlConversionHelper.WriteToFile(helpInfos, moduleMamlPath, Encoding).FullName));
+                    var mamlFile = MamlConversionHelper.WriteToFile(helpInfos, moduleMamlPath, Encoding);
+
+                    // Read the MAML file and replace the specific line
+                    string mamlContent = File.ReadAllText(mamlFile.FullName, Encoding);
+                    // Replace the line break placeholder with a proper line break
+                    // This is a workaround for the issue where line breaks are not preserved in MAML files
+                    string updatedContent = mamlContent.Replace("<maml:para>__REMOVE_ME_LINE_BREAK__</maml:para>", "<maml:para>&#x20;&#x08;</maml:para>");
+                    File.WriteAllText(mamlFile.FullName, updatedContent, Encoding);
+                    WriteObject(this.InvokeProvider.Item.Get(mamlFile.FullName));
                 }
             }
         }

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -209,7 +209,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 // Add an empty line after each item except the last
                 if (i < tempDescription.Count - 1)
                 {
-                    newExample.Description.Add("__REMOVE__ME__LINE__BREAK"); // Non-breaking space for empty line
+                    newExample.Description.Add("__REMOVE_ME_LINE_BREAK__"); // Non-breaking space for empty line
                 }
             }
 

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -194,12 +194,25 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
 
         private static CommandExample ConvertExample(Example example, int exampleNumber)
         {
+            var tempDescription = new List<string>();
             var newExample = new CommandExample();
             newExample.Title = string.Format($"--------- {example.Title} ---------");
             foreach(string s in example.Remarks.Split(new string[] { "\n\n" }, StringSplitOptions.None))
             {
-                newExample.Description.Add(s.Trim());
+                tempDescription.Add(s.Trim());
             }
+
+            for (int i = 0; i < tempDescription.Count; i++)
+            {
+                newExample.Description.Add(tempDescription[i]);
+
+                // Add an empty line after each item except the last
+                if (i < tempDescription.Count - 1)
+                {
+                    newExample.Description.Add("__REMOVE__ME__LINE__BREAK"); // Non-breaking space for empty line
+                }
+            }
+
             return newExample;
         }
 

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -129,5 +129,11 @@ Describe "Export-MamlCommandHelp tests" {
             $observed = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).examples.example.title
             $observed | Should -Be $expected
         }
+
+        It "Should have the line break workaround in the example code" {
+            $m = Import-MarkdownCommandHelp -Path (Join-Path $assetDir 'get-date.md')
+            $mamlFie = $m | Export-MamlCommandHelp -OutputFolder $outputDirectory -Force
+            $mamlFie | Should -FileContentMatch '<maml:para>&#x20;&#x08;</maml:para>'
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces a workaround to address an issue with line breaks not being preserved in MAML files during export. The changes include modifying the MAML file processing logic, adjusting how example descriptions are handled, and adding a test case to verify the workaround.

### Changes to MAML file processing:

* In `src/Command/ExportMamlCommandHelp.cs`, updated the `EndProcessing` method to read the generated MAML file, replace a placeholder (`<maml:para>__REMOVE_ME_LINE_BREAK__</maml:para>`) with a proper line break representation (`<maml:para>&#x20;&#x08;</maml:para>`), and write the updated content back to the file.

### Changes to example description handling:

* In `src/MamlWriter/MamlHelpers.cs`, updated the `ConvertExample` method to add a placeholder (`__REMOVE_ME_LINE_BREAK__`) for line breaks between example description items, ensuring proper formatting in the MAML output.

### Test case addition:

* In `test/Pester/ExportMamlCommandHelp.Tests.ps1`, added a test to verify that the exported MAML file contains the correct line break workaround (`<maml:para>&#x20;&#x08;</maml:para>`).

## PR Context

Fixes #754 
