### PR TITLE
Ensure external help file from metadata is used for generating the MAML file name

### DIFF
--- a/src/Command/ExportMamlCommandHelp.cs
+++ b/src/Command/ExportMamlCommandHelp.cs
@@ -70,11 +70,12 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             // emit a MAML file for each group of CommandHelp objects
-            var helpGroup = _commandHelps.GroupBy(c => c.ModuleName);
+            var helpGroup = _commandHelps.GroupBy(c => c?.ExternalHelpFile ?? c?.ModuleName)
+                                         .OrderBy(g => g.Key);
             foreach(var group in helpGroup)
             {
                 string moduleName = group.First().ModuleName;
-                string helpFileName = $"{moduleName}-Help.xml";
+                string helpFileName = group.First().ExternalHelpFile ?? $"{moduleName}-Help.xml";
 
                 if (!ShouldProcess(helpFileName))
                 {

--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -60,6 +60,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
         private static string GetHelpFileFromCommandInfo(CommandInfo commandInfo)
         {
+            // We are chosing upper case for the "Help.xml" file name to avoid issues with non-Windows platforms.
             string helpFileName;
             if (commandInfo is CmdletInfo cmdlet && ! string.IsNullOrEmpty(cmdlet.HelpFile))
             {

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
             CommandHelp cmdHelp = new(commandInfo.Name, commandInfo.ModuleName, Settings.Locale);
             cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo);
+            cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"].ToString() ?? string.Empty;
             cmdHelp.OnlineVersionUrl = Settings.OnlineVersionUrl;
             cmdHelp.Synopsis = GetSynopsis(helpItem, addDefaultStrings);
             cmdHelp.AddSyntaxItemRange(GetSyntaxItem(commandInfo, helpItem));


### PR DESCRIPTION
# PR Summary

This pull request introduces changes to improve the handling of external help files in the help generation system. The updates ensure better organization and compatibility across platforms, as well as enhance metadata handling for command help objects.

### Improvements to help file grouping and naming:

* [`src/Command/ExportMamlCommandHelp.cs`](diffhunk://#diff-b1d3384072174af5eb09d69b31aa6e837520d9e09a44844c0536de9e308788ecL73-R78): Updated the grouping logic in `EndProcessing()` to prioritize `ExternalHelpFile` over `ModuleName` and added ordering by group key. Modified the help file name generation to use `ExternalHelpFile` if available.

### Platform compatibility:

* [`src/Common/MetadataUtils.cs`](diffhunk://#diff-9052f8749bcca5a2d66859dcba26b2abbc83c7c4adfeb0dcec7e70cbd8743e71R63): Added a comment explaining the use of upper case for "Help.xml" file names to avoid issues on non-Windows platforms.

### Enhanced metadata handling:

* [`src/Transform/TransformBase.cs`](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0R60): Updated `ConvertCmdletInfo()` to set the `ExternalHelpFile` property based on metadata, ensuring it defaults to an empty string if no value is provided.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
