### PR TITLE
Ensure all the metadata is added to CommandHelp

### DIFF
--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -190,6 +190,10 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 help.Metadata = GetMetadataFromDictionary(metadata);
                 help.Diagnostics.TryAddDiagnostic(DiagnosticMessageSource.General, "Found Metadata", DiagnosticSeverity.Information, "yaml metadata", -1);
+
+                help.ExternalHelpFile = metadata["external help file"] as string ?? string.Empty;
+                help.SchemaVersion = metadata["PlatyPS schema version"] as string ?? string.Empty;
+                help.OnlineVersionUrl = metadata["HelpUri"] as string ?? string.Empty;
             }
 
             if (dictionary["synopsis"] is string synopsis)

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -224,6 +224,13 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             commandHelp.Metadata = metadata;
+            commandHelp.ExternalHelpFile = metadata["external help file"] as string ?? string.Empty;
+            commandHelp.SchemaVersion = metadata["PlatyPS schema version"] as string ?? string.Empty;
+            commandHelp.OnlineVersionUrl = metadata["HelpUri"] as string ?? string.Empty;
+
+            string? moduleGuid = metadata["ModuleGuid"] as string;
+            commandHelp.ModuleGuid = moduleGuid is not null ? new Guid(moduleGuid) : null;
+
             commandHelp.HasCmdletBinding = GetCmdletBindingState(markdownContent, out var cmdletBindingDiagnostics);
             if (cmdletBindingDiagnostics is not null)
             {

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -54,11 +54,11 @@ namespace Microsoft.PowerShell.PlatyPS
                 addDefaultStrings = true;
             }
 
-
             CommandHelp cmdHelp = new(commandInfo.Name, commandInfo.ModuleName, Settings.Locale);
             cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo);
             cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"].ToString() ?? string.Empty;
-            cmdHelp.OnlineVersionUrl = Settings.OnlineVersionUrl;
+            cmdHelp.OnlineVersionUrl = Settings.OnlineVersionUrl ?? cmdHelp.Metadata["HelpUri"] as string;
+            cmdHelp.SchemaVersion = cmdHelp.Metadata["PlatyPS schema version"] as string ?? string.Empty;
             cmdHelp.Synopsis = GetSynopsis(helpItem, addDefaultStrings);
             cmdHelp.AddSyntaxItemRange(GetSyntaxItem(commandInfo, helpItem));
             cmdHelp.Description = GetDescription(helpItem, addDefaultStrings).Trim();

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -7,8 +7,8 @@ Describe "Export-MamlCommandHelp tests" {
         $markdownFiles = 'get-date.md', 'Import-Module.md', 'Invoke-Command.md', 'Out-Null.md'
         $chObjects = $markdownFiles | Foreach-Object { Import-MarkdownCommandHelp  (Join-Path $assetDir $_) }
         $outputDirectory = Join-Path $TESTDRIVE MamlBase
-        $f1 = "$outputDirectory/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core-Help.xml"
-        $f2 = "$outputDirectory/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility-Help.xml"
+        $f1 = "$outputDirectory/Microsoft.PowerShell.Core/System.Management.Automation.dll-Help.xml"
+        $f2 = "$outputDirectory/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Commands.Utility.dll-Help.xml"
     }
 
     Context "Basic Operations" {

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -65,6 +65,18 @@ Describe 'Import-MarkdownCommandHelp Tests' {
         It 'Should be able to read multiline metadata' {
             $md.Metadata['foo'] | Should -Be "bar"
         }
+
+        It 'Should be able to set all metadata properties' {
+            $m = Import-MarkdownCommandHelp -Path "$assetdir/get-date.md"
+            $m.ExternalHelpFile | Should -Be "Microsoft.PowerShell.Commands.Utility.dll-Help.xml"
+            $m.Locale | Should -Be "en-US"
+            $m.SchemaVersion | Should -Be "2024-05-01"
+            $m.OnlineVersionUrl | Should -Be "https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&WT.mc_id=ps-gethelp"
+            $m.ModuleGuid | Should -BeNullOrEmpty
+
+            $maml = $m | Export-MamlCommandHelp -OutputFolder $TestDrive -Force -Verbose
+            $maml.Name | Should -Be 'Microsoft.PowerShell.Commands.Utility.dll-Help.xml'
+        }
     }
 
     Context "Validate Aliases" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces enhancements to how metadata is extracted and processed for `CommandHelp` objects in the `MarkdownReader` and `Transform` modules. These changes improve the handling of optional metadata fields and ensure better compatibility with external help files and schema versions.

### Enhancements to metadata handling:

* **`src/MarkdownReader/CommandHelpMarkdownReader.cs`:** Added support for extracting additional metadata fields (`ExternalHelpFile`, `SchemaVersion`, `OnlineVersionUrl`, and `ModuleGuid`) from the parsed markdown content. These fields are now assigned to the `CommandHelp` object, with appropriate default values for missing entries. (`[src/MarkdownReader/CommandHelpMarkdownReader.csR227-R233](diffhunk://#diff-2b2e6a603c33dbdccc6d0bb591d4d3dd530c741130ac94757d7b754744853476R227-R233)`)

* **`src/Transform/TransformBase.cs`:** Enhanced the `ConvertCmdletInfo` method to include `SchemaVersion` and improve the logic for assigning `OnlineVersionUrl`. The method now prioritizes the `HelpUri` metadata field when the `Settings.OnlineVersionUrl` is not provided. (`[src/Transform/TransformBase.csL57-R61](diffhunk://#diff-0dbc578bebc8903843082ecba5daf89936c0af78f376c14f7e2b068ae11996f0L57-R61)`)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
