### PR TITLE
Fix online help

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -40,7 +40,19 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             var helpItems = new HelpItems();
             foreach(var command in commandHelp)
             {
-                helpItems.Commands.Add(ConvertCommandHelpToMamlCommand(command));
+                if (command is not null)
+                {
+                    var onlineHelpUri = command.Metadata?["HelpUri"]?.ToString();
+
+                    var mamlCommand = ConvertCommandHelpToMamlCommand(command);
+
+                    if (onlineHelpUri is not null)
+                    {
+                        mamlCommand.RelatedLinks.Insert(0, new NavigationLink { LinkText = "Online Version", Uri = onlineHelpUri });
+                    }
+
+                    helpItems.Commands.Add(mamlCommand);
+                }
             }
             return helpItems;
         }

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -112,7 +112,7 @@ Describe "Export-MamlCommandHelp tests" {
         }
 
         It "Should have the proper number of relatedLinks" {
-            $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).relatedLinks.navigationLink.Count | Should -Be 6
+            $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).relatedLinks.navigationLink.Count | Should -Be 7
         }
 
         It "Should have the same content for the description" {
@@ -134,6 +134,14 @@ Describe "Export-MamlCommandHelp tests" {
             $m = Import-MarkdownCommandHelp -Path (Join-Path $assetDir 'get-date.md')
             $mamlFie = $m | Export-MamlCommandHelp -OutputFolder $outputDirectory -Force
             $mamlFie | Should -FileContentMatch '<maml:para>&#x80;</maml:para>'
+        }
+
+        It "Should have online help uri" {
+            $m = Import-MarkdownCommandHelp -Path (Join-Path $assetDir 'Get-Date.V2.md')
+            $mamlFile = $m | Export-MamlCommandHelp -OutputFolder "$outputDirectory/helpuri" -Force
+            $mamlFile | Should -Exist
+            $maml = Get-Content -Path $mamlFile -Raw
+            $maml | Should -BeLike '*<command:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>*'
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request enhances the handling of online help URIs in the MAML (Microsoft Assistance Markup Language) export process and updates the corresponding tests. The most significant changes include adding support for online help URIs in the MAML output and introducing new test cases to validate this functionality.

### Enhancements to MAML export functionality:

* [`src/MamlWriter/MamlHelpers.cs`](diffhunk://#diff-9879b0e3889e8fadbc300aa1ac6552f025791a6f552aed2e54b413e3a04e0cf9L43-R55): Updated the `ConvertCommandHelpToMamlHelpItems` method to include an online help URI as a `NavigationLink` for commands, if available in the metadata. This ensures that the MAML output includes a link to the online version of the command's help documentation.

### Updates to test cases:

* [`test/Pester/ExportMamlCommandHelp.Tests.ps1`](diffhunk://#diff-69f1da727477caecd047b8f9e061ffc9652f242977ff977f3c1f65b32ffd48d3L115-R115): Modified the test validating the number of `relatedLinks` for the `Get-Date` command to account for the addition of the online help URI, increasing the expected count from 6 to 7.
* [`test/Pester/ExportMamlCommandHelp.Tests.ps1`](diffhunk://#diff-69f1da727477caecd047b8f9e061ffc9652f242977ff977f3c1f65b32ffd48d3R138-R145): Added a new test case to verify that the exported MAML file contains the correct online help URI for the `Get-Date` command, ensuring the new functionality works as intended.

## PR Context

Fix #788 
