### PR TITLE
Fix MAML help generation for SwitchParameter parameter

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -144,7 +144,8 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             }
             foreach(var parameter in syntax.GetParametersInOrder())
             {
-                newSyntax.Parameters.Add(ConvertParameter(parameter));
+                SyntaxParameter? syntaxParam = syntax.SyntaxParameters.FirstOrDefault(x => x.ParameterName == parameter.Name);
+                newSyntax.Parameters.Add(ConvertParameter(parameter, syntaxParam));
             }
 
             return newSyntax;
@@ -157,12 +158,28 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             return pipelineInput;
         }
 
-        private static ParameterValue GetParameterValue(Model.Parameter parameter)
+        private static ParameterValue? GetParameterValue(Model.Parameter parameter, Model.SyntaxParameter? syntaxParameter = null)
         {
+            // dont render <command:parameterValue> element when the parameter type is SwichParameter
+            if (parameter.Type is "SwitchParameter" or "System.Management.Automation.SwitchParameter")
+            {
+                return null;
+            }
             var parameterValue = new ParameterValue();
             if (parameter is not null)
             {
-                parameterValue.DataType = parameter.Type;
+                // Set SyntaxParameter's parameter type name for <command:syntaxItem>
+                if (syntaxParameter is null)
+                {
+                    var t = parameter.Type;
+                    parameterValue.DataType = (t.StartsWith("System.Nullable`1[", StringComparison.OrdinalIgnoreCase)
+                                               && t.EndsWith("]", StringComparison.OrdinalIgnoreCase))
+                                              ? t.Substring(18, t.Length - 18 - 1) : t;
+                }
+                else
+                {
+                    parameterValue.DataType = syntaxParameter.ParameterType;
+                }
                 parameterValue.IsVariableLength = parameter.VariableLength;
                 // We just mark mandatory if one of the parameter sets is mandatory since MAML doesn't
                 // have a way to disambiguate these.
@@ -171,7 +188,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             return parameterValue;
         }
 
-        private static Parameter ConvertParameter(Model.Parameter parameter)
+        private static Parameter ConvertParameter(Model.Parameter parameter, Model.SyntaxParameter? syntaxParameter = null)
         {
             var newParameter = new MAML.Parameter();
             newParameter.Name = parameter.Name;
@@ -179,7 +196,8 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             newParameter.SupportsGlobbing = parameter.SupportsWildcards;
             var pSet = parameter.ParameterSets.FirstOrDefault();
             newParameter.Position = pSet is null ? Model.Constants.NamedString : pSet.Position;
-            newParameter.Value = GetParameterValue(parameter);
+            newParameter.Value = GetParameterValue(parameter, syntaxParameter);
+            newParameter.Type.Name = parameter.Type;
 
             if (parameter.Description is not null)
             {

--- a/src/MamlWriter/Parameter.cs
+++ b/src/MamlWriter/Parameter.cs
@@ -29,7 +29,13 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         ///     The parameter value information ("command:parameterValue").
         /// </summary>
         [XmlElement("parameterValue", Namespace = Constants.XmlNamespace.Command, Order = 2)]
-        public ParameterValue Value { get; set; } = new ParameterValue();
+        public ParameterValue? Value { get; set; }
+
+        /// <summary>
+        ///     The parameter value type information ("dev:type").
+        /// </summary>
+        [XmlElement("type", Namespace = Constants.XmlNamespace.Dev, Order = 3)]
+        public DataType Type { get; set; } = new DataType();
 
         /// <summary>
         ///     Is the parameter mandatory?

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -129,5 +129,18 @@ Describe "Export-MamlCommandHelp tests" {
             $observed = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).examples.example.title
             $observed | Should -Be $expected
         }
+
+        It "Should have proper type and not have 'parameterValue' for 'Force' SwitchParameter" {
+            $switchParameter = $xml.SelectNodes('//command:command', $ns).Where({$_.details.name -eq "Import-Module"}).Parameters.parameter.Where({$_.Name -eq "Force"})
+            $switchParameter.parameterValue | Should -Be $null
+            $switchParameter.type.name | Should -Be "System.Management.Automation.SwitchParameter"
+        }
+
+        It "Should have proper type and propertyValue for all parameters without SwitchParameter" {
+            $params = $xml.SelectNodes('//command:command', $ns).Parameters.parameter.Where({$_.type.name -ne "System.Management.Automation.SwitchParameter"})
+            $expectedCount = $params.Count
+            $params.parameterValue.Where({$null -ne $_}).Count | Should -Be $expectedCount
+            $params.type.name.Where({$null -ne $_}).Count | Should -Be $expectedCount
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

If the parameter is a SwitchParameter, skip rendering the `<command:parameterValue>` element.
Instead, use the `<dev:type>` element to represent the formal parameter type.

This change will result in the following changes in the help display

```
SYNTAX:
    CommandName [-ParameterName]

...

PARAMETERS
    -ParameterName
        {{ Fill ParameterName Description }}

```

```xml
<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="Named" aliases="none">
  <maml:name>ParameterName</maml:name>
  <maml:description>
    <maml:para>{{ Fill ParameterName Description }}</maml:para>
  </maml:description>
  <!-- Don't render when parameter is SwitchParameter.
  <command:parameterValue required="false" variableLength="true">System.Management.Automation.SwitchParameter</command:parameterValue>
  -->
  <dev:type><!-- Instead, add parameter type -->
    <maml:name>System.Management.Automation.SwitchParameter</maml:name>
  </dev:type>
</command:parameter>
```

## PR Context

When generate MAML help with `Export-MamlCommandHelp`, it looks like need to specify values for the parameters of the SwitchParameter.

```
SYNTAX:
    CommandName [-ParameterName <System.Management.Automation.SwitchParameter>]

...

PARAMETERS
    -ParameterName [<System.Management.Automation.SwitchParameter>]
        {{ Fill ParameterName Description }}

```

```xml
<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="Named" aliases="none">
  <maml:name>ParameterName</maml:name>
  <maml:description>
    <maml:para>{{ Fill ParameterName Description }}</maml:para>
  </maml:description>
  <command:parameterValue required="false" variableLength="true">System.Management.Automation.SwitchParameter</command:parameterValue>
</command:parameter>
```
