### PR TITLE
Make the parameter value's notation in the MAML help non abbreviated

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -164,9 +164,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             {
                 parameterValue.DataType = parameter.Type;
                 parameterValue.IsVariableLength = parameter.VariableLength;
-                // We just mark mandatory if one of the parameter sets is mandatory since MAML doesn't
-                // have a way to disambiguate these.
-                parameterValue.IsMandatory = parameter.ParameterSets.Any(x => x.IsRequired);
+                parameterValue.IsMandatory = true;
             }
             return parameterValue;
         }


### PR DESCRIPTION
# PR Summary

Always set `required` attribute in command:parameterValue element to `true`.

This change will result in the following changes in the help display:

Before:
```
PRAMETERS:
    -Name [<string>]
```

Aflter:
```
PRAMETERS:
    -Name <string>
```

## PR Context

Parameter values in the generated MAML help are in abbreviated notation.
