### PR TITLE
Fix file writing mode in WriteToFile method to truncate existing content

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -24,7 +24,8 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         public static FileInfo WriteToFile(HelpItems helpItems, string path, Encoding encoding)
         {
             var outputFile = new FileInfo(path);
-            using(var writer = new StreamWriter(new FileStream(outputFile.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite), encoding))
+            using(var fs = new FileStream(outputFile.FullName, outputFile.Exists ? FileMode.Truncate : FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using(var writer = new StreamWriter(fs, encoding))
             {
                 helpItems.WriteTo(writer);
             }


### PR DESCRIPTION
# PR Summary

When overwriting existing content, old data remains without Truncate mode

## PR Context

When overwriting existing content, old data remains without Truncate mode
