### PR TITLE
Assign alias values for parameter in MAML help generation

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -189,6 +189,11 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 }
             }
 
+            if (parameter.Aliases.Count > 0)
+            {
+                newParameter.Aliases = string.Join(", ", parameter.Aliases);
+            }
+
             return newParameter;
         }
 

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -87,6 +87,11 @@ Describe "Export-MamlCommandHelp tests" {
             $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).Parameters.parameter.Count | Should -Be 13
         }
 
+        It "Should have the proper aliases for Get-Date" {
+            $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).Parameters.parameter.
+                  Where({$_.Name -in @('Date', 'UnixTimeSeconds')}).aliases | Should -Be 'LastWriteTime', 'UnixTime'
+        }
+
         It "Should have the proper number of parameters for Import-Module" {
             $xml.SelectNodes('//command:command', $ns).Where({$_.details.name -eq "Import-Module"}).Parameters.parameter.Count | Should -Be 26
         }


### PR DESCRIPTION
# PR Summary

Fixed MAML help generation to set proper aliaes values.

```
    -Date <System.DateTime>
	    (snip)
   
        Required?                    false
        Position?                    0
        Default value
        Accept pipeline input?       false
        Aliases                      LastWriteTime <---
        Accept wildcard characters?  false
```


## PR Context

I noticed that all parameter's aliases are always `none` for generated MAML help 

```
    -Date <System.DateTime>
	    (snip)

        Required?                    false
        Position?                    0
        Default value
        Accept pipeline input?       false
        Aliases                      none          <---
        Accept wildcard characters?  false
```

