### PR TITLE
Read accepted values from Cmdlet Help

### DIFF
--- a/src/Model/SyntaxItem.cs
+++ b/src/Model/SyntaxItem.cs
@@ -83,6 +83,7 @@ namespace Microsoft.PowerShell.PlatyPS.Model
                 return;
             }
 
+            Parameters.Add(parameter);
             _parameterNames.Add(name);
             _alphabeticOrderParameters.Add(name, parameter);
         }

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -233,6 +233,7 @@ namespace Microsoft.PowerShell.PlatyPS
 
                 param.DefaultValue = GetParameterDefaultValueFromHelp(helpItem, param.Name);
                 param.Aliases = parameterMetadata.Value.Aliases.ToList();
+                param.AddAcceptedValueRange(GetParameterAcceptedValuesFromHelp(helpItem, param.Name));
 
                 string descriptionFromHelp = GetParameterDescriptionFromHelp(helpItem, param.Name) ?? param.HelpMessage ?? string.Empty;
                 param.Description = string.IsNullOrEmpty(descriptionFromHelp) ?
@@ -625,6 +626,8 @@ namespace Microsoft.PowerShell.PlatyPS
                 Constants.NoneString :
                 defaultValueFromHelp;
 
+            param.AddAcceptedValueRange(GetParameterAcceptedValuesFromHelp(helpItem, param.Name));
+
             return param;
         }
 
@@ -901,6 +904,46 @@ namespace Microsoft.PowerShell.PlatyPS
             finally
             {
                 Constants.StringBuilderPool.Return(sb);
+            }
+        }
+
+        protected IEnumerable<string> GetParameterAcceptedValuesFromHelp(dynamic? helpItem, string parameterName)
+        {
+            if (helpItem?.Syntax?.syntaxItem is null)
+            {
+                yield break;
+            }
+
+            Collection<PSObject>? syntaxItemCollection = MakePSObjectEnumerable(helpItem.Syntax.syntaxItem);
+
+            dynamic? param = null;
+            foreach (dynamic syntaxItem in syntaxItemCollection)
+            {
+                if (syntaxItem.parameter is null)
+                {
+                    continue;
+                }
+                var parameterAsCollection = MakePSObjectEnumerable(syntaxItem.parameter);
+                foreach (dynamic parameter in parameterAsCollection)
+                {
+                    var name = parameter.name as string;
+                    if (string.Equals(name, parameterName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        param = parameter;
+                        goto exitLoop;
+                    }
+                }
+            }
+            exitLoop:
+
+            var values = param?.parameterValueGroup?.parameterValue as object[];
+            if (values is null)
+            {
+                yield break;
+            }
+            foreach (object item in values)
+            {
+                yield return item.ToString();
             }
         }
 

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -202,4 +202,20 @@ Describe "New-CommandHelp tests" {
             $io.inputs.typename | Should -Be "System.Int32"
         }
     }
+
+    Context "AcceptedValues Validation" {
+        BeforeAll {
+            $cmd = Get-Command Get-Command
+            $ch = $cmd | New-CommandHelp
+            $expectedValues = 'Alias', 'Function', 'Filter', 'Cmdlet', 'ExternalScript', 'Application', 'Script', 'Configuration', 'All'
+        }
+
+        It "Parameter in Parameters should have proper accepted values" {
+            $ch.Parameters.Where({$_.Name -eq "CommandType"}).AcceptedValues | Should -Be $expectedValues
+        }
+
+        It "Parameter in Syntax should have proper accepted values" {
+            $ch.Syntax.Parameters.Where({$_.Name -eq "CommandType"}).AcceptedValues | Should -Be $expectedValues
+        }
+    }
 }


### PR DESCRIPTION
# PR Summary

Implemented new feature to read *accepted values* from Cmdlet Help when creating a new CommandHelp with `New-CommandHelp`.

## PR Context

Currently, the `New-CommandHelp` command sets all *accepted values* to `none`.