### PR TITLE
Fix Locale in Metadata for New-MarkdownCommandHelp

### DIFF
--- a/src/Common/MetadataUtils.cs
+++ b/src/Common/MetadataUtils.cs
@@ -42,14 +42,14 @@ namespace Microsoft.PowerShell.PlatyPS
         /// </summary>
         /// <param name="commandInfo"></param>
         /// <returns></returns>
-        public static OrderedDictionary GetCommandHelpBaseMetadataFromCommandInfo(CommandInfo commandInfo)
+        public static OrderedDictionary GetCommandHelpBaseMetadataFromCommandInfo(CommandInfo commandInfo, CultureInfo locale)
         {
             OrderedDictionary metadata = new()
             {
                 { "document type", "cmdlet" },
                 { "title", commandInfo.Name },
                 { "Module Name", commandInfo.ModuleName },
-                { "Locale", CultureInfo.CurrentCulture.Name == string.Empty ? "en-US" : CultureInfo.CurrentCulture.Name },
+                { "Locale", string.IsNullOrEmpty(locale.Name) ? "en-US" : locale.Name },
                 { "PlatyPS schema version", "2024-05-01" }, // was schema
                 { "HelpUri", GetHelpCodeMethods.GetHelpUri(new PSObject(commandInfo)) }, // was online version
                 { "ms.date", DateTime.Now.ToString("MM/dd/yyyy") },

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -55,8 +55,8 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             CommandHelp cmdHelp = new(commandInfo.Name, commandInfo.ModuleName, Settings.Locale);
-            cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo);
-            cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"].ToString() ?? string.Empty;
+            cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadata(cmdHelp);
+            cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"] as string ?? string.Empty;
             cmdHelp.OnlineVersionUrl = Settings.OnlineVersionUrl ?? cmdHelp.Metadata["HelpUri"] as string;
             cmdHelp.SchemaVersion = cmdHelp.Metadata["PlatyPS schema version"] as string ?? string.Empty;
             cmdHelp.Synopsis = GetSynopsis(helpItem, addDefaultStrings);

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -55,8 +55,8 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             CommandHelp cmdHelp = new(commandInfo.Name, commandInfo.ModuleName, Settings.Locale);
-            cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo);
-            cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"].ToString() ?? string.Empty;
+            cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo, Settings.Locale);
+            cmdHelp.ExternalHelpFile = cmdHelp.Metadata["external help file"] as string ?? string.Empty;
             cmdHelp.OnlineVersionUrl = Settings.OnlineVersionUrl ?? cmdHelp.Metadata["HelpUri"] as string;
             cmdHelp.SchemaVersion = cmdHelp.Metadata["PlatyPS schema version"] as string ?? string.Empty;
             cmdHelp.Synopsis = GetSynopsis(helpItem, addDefaultStrings);

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -683,4 +683,31 @@ Write-Host 'Hello World!'
             $commandHelp.Syntax[0].ToString() | Should -Not -Match 'Hidden|Break'
         }
     }
+
+    Context 'Locale parameter' {
+        BeforeAll {
+            function global:Test-Locale {
+                [CmdletBinding()]
+                param()
+            }
+        }
+
+        It 'No Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: en-US"
+        }
+
+        It 'Invariant Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale C
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: en-US"
+        }
+
+        It 'ja-JP Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale ja-JP
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: ja-JP"
+        }
+    }
 }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -657,4 +657,31 @@ Write-Host 'Hello World!'
             $file | Should -FileContentMatch 'Runs the command in a mode that only reports what would happen without performing the actions.'
         }
     }
+
+    Context 'Locale parameter' {
+        BeforeAll {
+            function global:Test-Locale {
+                [CmdletBinding()]
+                param()
+            }
+        }
+
+        It 'No Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: en-US"
+        }
+
+        It 'Invariant Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale C
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: en-US"
+        }
+
+        It 'ja-JP Locale parameter' {
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale ja-JP
+
+            Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: ja-JP"
+        }
+    }
 }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -738,7 +738,7 @@ Write-Host 'Hello World!'
         }
 
         It 'Invariant Locale parameter' {
-            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale C
+            $file = New-MarkdownCommandHelp -Command (Get-Command 'Test-Locale') -OutputFolder "$TestDrive/NewMarkdownHelp" -Force -Locale ([System.Globalization.CultureInfo]::InvariantCulture).ToString()
 
             Get-Content -Path $file -First 10 | Where-Object { $_ -match "^Locale" } | Should -Be "Locale: en-US"
         }


### PR DESCRIPTION
# PR Summary

use `MetadataUtils.GetCommandHelpBaseMetadata(cmdHelp)` instead of `MetadataUtils.GetCommandHelpBaseMetadataFromCommandInfo(commandInfo)`

## PR Context

To fix issue:
- https://github.com/PowerShell/platyPS/issues/763

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/813)
<!-- Reviewable:end -->
