### PR TITLE
Fix file writing mode in WriteToFile method when overwriting

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -24,7 +24,8 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         public static FileInfo WriteToFile(HelpItems helpItems, string path, Encoding encoding)
         {
             var outputFile = new FileInfo(path);
-            using(var writer = new StreamWriter(new FileStream(outputFile.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite), encoding))
+            using(var fs = new FileStream(outputFile.FullName, outputFile.Exists ? FileMode.Truncate : FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using(var writer = new StreamWriter(fs, encoding))
             {
                 helpItems.WriteTo(writer);
             }


### PR DESCRIPTION
# PR Summary

Set FileMode to `Truncate` when overwriting existing content,

## PR Context

I noticed that when I overwrite Maml help with `Export-MamlCommandHelp -Force`, which results in a smaller file size than before, the previous data remains at the end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/814)
<!-- Reviewable:end -->
