### PR TITLE
Fix pipeline input in help preview MAML

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -164,8 +164,24 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
 
         private static PipelineInputType GetPipelineInputType(Model.Parameter parameter)
         {
+            var pipelineInput = PipelineInputType.None;
 
-            var pipelineInput = new PipelineInputType();
+            bool byValue = parameter.ParameterSets.Any(ps => ps.ValueFromPipeline);
+            bool byPropertyName = parameter.ParameterSets.Any(ps => ps.ValueFromPipelineByPropertyName);
+
+            if (byValue && byPropertyName)
+            {
+                pipelineInput = PipelineInputType.ByValue | PipelineInputType.ByPropertyName;
+            }
+            else if (byValue)
+            {
+                pipelineInput = PipelineInputType.ByValue;
+            }
+            else if (byPropertyName)
+            {
+                pipelineInput = PipelineInputType.ByPropertyName;
+            }
+
             return pipelineInput;
         }
 
@@ -192,6 +208,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             var pSet = parameter.ParameterSets.FirstOrDefault();
             newParameter.Position = pSet is null ? Model.Constants.NamedString : pSet.Position;
             newParameter.Value = GetParameterValue(parameter);
+            newParameter.SupportsPipelineInput = GetPipelineInputType(parameter);
 
             if (parameter.Description is not null)
             {
@@ -259,4 +276,3 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
 
     }
 }
-

--- a/src/MamlWriter/Parameter.cs
+++ b/src/MamlWriter/Parameter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         ///     Can the parameter accept its value from the pipeline?
         /// </summary>
         /// <remarks>
-        ///     Either "true (ByValue)", "true (ByPropertyName)", or "false".
+        ///     Either "true (ByValue)", "true (ByPropertyName)", "true (ByValue, ByPropertyName)", or "false".
         /// </remarks>
         [XmlAttribute("pipelineInput")]
         public string PipelineInputString
@@ -58,22 +58,14 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             set { throw new System.NotImplementedException(); }
             get
             {
-                if (SupportsPipelineInput == PipelineInputType.ByValue && SupportsPipelineInput == PipelineInputType.ByPropertyName)
+                return SupportsPipelineInput switch
                 {
-                    return "true (ByValue, ByPropertyName)";
-                }
-                else if (SupportsPipelineInput == PipelineInputType.ByValue)
-                {
-                    return "true (ByValue)";
-                }
-                else if (SupportsPipelineInput == PipelineInputType.ByPropertyName)
-                {
-                    return "true (ByPropertyName)";
-                }
-                else
-                {
-                    return "false";
-                }
+                    PipelineInputType.None => "false",
+                    PipelineInputType.ByValue => "true (ByValue)",
+                    PipelineInputType.ByPropertyName => "true (ByPropertyName)",
+                    PipelineInputType.ByValueAndByPropertyName => "true (ByValue, ByPropertyName)",
+                    _ => "false"
+                };
             }
         }
 

--- a/src/MamlWriter/PipelineInputType.cs
+++ b/src/MamlWriter/PipelineInputType.cs
@@ -25,6 +25,12 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         ///     Parameter can take its value from a property of the same name on objects in the pipeline.
         /// </summary>
         [XmlEnum("true (ByPropertyName)")]
-        ByPropertyName = 2
+        ByPropertyName = 2,
+
+        /// <summary>
+        ///     Parameter can take its value from the pipeline both by value and by property name.
+        /// </summary>
+        [XmlEnum("true (ByValue, ByPropertyName)")]
+        ByValueAndByPropertyName = ByValue | ByPropertyName
     }
 }

--- a/test/Pester/Cmdlet.Tests.ps1
+++ b/test/Pester/Cmdlet.Tests.ps1
@@ -172,6 +172,11 @@ Describe "Miscellaneous cmdlet tests" {
             $help.name | Should -BeExactly "Get-ChildItem"
         }
 
-
+        It "Should have correct ByValue and ByPropertyName for the Path parameter" {
+            $help = Show-HelpPreview -Path $mamlPath
+            $param = $help.parameters.parameter | Where-Object -Property Name -EQ "Path"
+            $param | Should -Not -BeNullOrEmpty
+            $param.pipelineInput | Should -Be "true (ByValue, ByPropertyName)"
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces a new explicit handling for parameters that accept both `ByValue` and `ByPropertyName` for pipeline input. It aligns the enum serialization and updates the conversion logic to emit pipeline metadata for the affected parameter.

Added Pester test in `Cmdlet.Test.ps1`.

## PR Context

- Fix #804

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/819)
<!-- Reviewable:end -->
