### PR TITLE
Fix handling duplicated parameters when array

### DIFF
--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -962,7 +962,8 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 if (md.GetCurrent() is HeadingBlock inputOutputHeader)
                 {
-                    string inputType = inputOutputHeader?.Inline?.FirstChild?.ToString() ?? string.Empty;
+                    // Extract full text content from all inline elements to handle arrays and other complex types
+                    string inputType = ExtractFullTextFromInline(inputOutputHeader?.Inline);
                     md.Take();
                     if (md.GetCurrent() is ParagraphBlock pBlock)
                     {
@@ -986,6 +987,50 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             return ioList;
+        }
+
+        /// <summary>
+        /// Extract the full text content from markdown inline elements, 
+        /// handling square brackets and other special characters correctly.
+        /// </summary>
+        /// <param name="inline">The inline container to extract text from</param>
+        /// <returns>The full text content</returns>
+        private static string ExtractFullTextFromInline(ContainerInline? inline)
+        {
+            if (inline == null) return string.Empty;
+            
+            StringBuilder sb = new StringBuilder();
+            ExtractTextRecursive(inline, sb);
+            return sb.ToString().Trim();
+        }
+
+        /// <summary>
+        /// Recursively extract text from inline elements
+        /// </summary>
+        /// <param name="inline">The inline element to process</param>
+        /// <param name="sb">The StringBuilder to append text to</param>
+        private static void ExtractTextRecursive(Inline inline, StringBuilder sb)
+        {
+            switch (inline)
+            {
+                case LiteralInline literal:
+                    sb.Append(literal.Content.ToString());
+                    break;
+                case ContainerInline container:
+                    foreach (var child in container)
+                    {
+                        ExtractTextRecursive(child, sb);
+                    }
+                    break;
+                default:
+                    // For other inline types, try to get their text representation
+                    var text = inline.ToString();
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        sb.Append(text);
+                    }
+                    break;
+            }
         }
 
         internal static string GetParameterSetName(HeadingBlock parameterSetBlock)

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -1001,7 +1001,14 @@ namespace Microsoft.PowerShell.PlatyPS
             
             StringBuilder sb = Constants.StringBuilderPool.Get();
             ExtractTextRecursive(inline, sb);
-            return sb.ToString().Trim();
+            try
+            {
+                return sb.ToString().Trim();
+            }
+            finally
+            {
+                Constants.StringBuilderPool.Return(sb);
+            }
         }
 
         /// <summary>

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -999,7 +999,7 @@ namespace Microsoft.PowerShell.PlatyPS
         {
             if (inline == null) return string.Empty;
             
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = Constants.StringBuilderPool.Get();
             ExtractTextRecursive(inline, sb);
             return sb.ToString().Trim();
         }

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 string outputName = outputType.Name;
                 if (outputName.EndsWith("[]"))
                 {
-                    outputName = FixUpTypeName(outputName);
+                    outputName = FixUpTypeName(outputName, preserveArrays: true);
                 }
 
                 if (!outputTypeNames.Contains(outputName))
@@ -801,7 +801,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 foreach (dynamic ioType in typesInfo)
                 {
-                    string typeName = FixUpTypeName(ioType.type.name?.Split()?[0] ?? string.Empty);
+                    string typeName = FixUpTypeName(ioType.type.name?.Split()?[0] ?? string.Empty, preserveArrays: true);
                     if (! string.IsNullOrEmpty(typeName) && string.Compare(typeName, "None", true) != 0)
                     {
                         string description = GetStringFromDescriptionArray(ioType.description)?.Trim() ?? string.Empty;
@@ -818,7 +818,7 @@ namespace Microsoft.PowerShell.PlatyPS
                     // these are really multiple entries, so split them here.
                     if (name.IndexOf("\n") == -1 && string.Compare(name, "None", true) != 0)
                     {
-                        itemList.Add(new InputOutput(FixUpTypeName(name), Constants.FillInDescription));
+                        itemList.Add(new InputOutput(FixUpTypeName(name, preserveArrays: true), Constants.FillInDescription));
                     }
                     else
                     {
@@ -826,14 +826,14 @@ namespace Microsoft.PowerShell.PlatyPS
                         {
                             if (string.Compare(tName, "None", true) != 0)
                             {
-                                itemList.Add(new InputOutput(FixUpTypeName(tName), Constants.FillInDescription));
+                                itemList.Add(new InputOutput(FixUpTypeName(tName, preserveArrays: true), Constants.FillInDescription));
                             }
                         }
                     }
                 }
                 else
                 {
-                    string typeName = FixUpTypeName(ioTypes.type.name.ToString());
+                    string typeName = FixUpTypeName(ioTypes.type.name.ToString(), preserveArrays: true);
                     if (! string.IsNullOrEmpty(typeName) && string.Compare(typeName, "None", true) != 0)
                     {
                         string description = GetStringFromDescriptionArray(ioTypes.description).Trim();
@@ -847,7 +847,8 @@ namespace Microsoft.PowerShell.PlatyPS
 
         // We have to remove carriage returns that might be present from help
         // We also will remove trailing [] because we should generally return singletons
-        private string FixUpTypeName(string typename)
+        // For input/output types, preserve array notation as it's semantically important
+        private string FixUpTypeName(string typename, bool preserveArrays = false)
         {
             // If the type is a generic type, we need to remove the backtick and the number.
             string fixedString = typename.Replace("System.Nullable`1[[", string.Empty).Trim();
@@ -857,7 +858,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 fixedString = fixedString.Substring(0, commaIndex).Trim();
             }
 
-            if (fixedString.EndsWith("[]"))
+            if (!preserveArrays && fixedString.EndsWith("[]"))
             {
                 fixedString = fixedString.Remove(fixedString.Length - 2);
             }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -398,19 +398,20 @@ Write-Host 'Hello World!'
     }
 
     Context 'Array type handling in pipeline parameters' {
-        function global:Test-ArrayPipelineFunction
-        {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory, ValueFromPipeline)]
-                [string[]]$ComputerName,
-                
-                [Parameter()]
-                [int[]]$Numbers
-            )
-        }
 
         BeforeAll {
+            function global:Test-ArrayPipelineFunction
+            {
+                [CmdletBinding()]
+                param(
+                    [Parameter(Mandatory, ValueFromPipeline)]
+                    [string[]]$ComputerName,
+
+                    [Parameter()]
+                    [int[]]$Numbers
+                )
+            }
+
             $file = New-MarkdownCommandHelp -Command (Get-Command Test-ArrayPipelineFunction) -OutputFolder "$TestDrive/arrayTest" -Force
             $content = Import-MarkdownCommandHelp $file
         }
@@ -420,7 +421,7 @@ Write-Host 'Hello World!'
             $content.Inputs[0].Typename | Should -Be 'System.String[]'
         }
 
-        It 'should not duplicate array and element types in inputs' {            
+        It 'should not duplicate array and element types in inputs' {
             $inputTypes = $content.Inputs | ForEach-Object { $_.Typename }
             $inputTypes | Should -Not -Contain 'System.String'
             $inputTypes | Should -Contain 'System.String[]'
@@ -429,7 +430,7 @@ Write-Host 'Hello World!'
         It 'should preserve array notation in markdown and parsing roundtrip' {
             Update-MarkdownCommandHelp -Path $file -NoBackup
             $updatedContent = Import-MarkdownCommandHelp $file
-            
+
             $updatedContent.Inputs.Count | Should -Be 1
             $updatedContent.Inputs[0].Typename | Should -Be 'System.String[]'
         }

--- a/test/Pester/NewMarkdownHelp.Tests.ps1
+++ b/test/Pester/NewMarkdownHelp.Tests.ps1
@@ -397,6 +397,44 @@ Write-Host 'Hello World!'
         }
     }
 
+    Context 'Array type handling in pipeline parameters' {
+        function global:Test-ArrayPipelineFunction
+        {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory, ValueFromPipeline)]
+                [string[]]$ComputerName,
+                
+                [Parameter()]
+                [int[]]$Numbers
+            )
+        }
+
+        BeforeAll {
+            $file = New-MarkdownCommandHelp -Command (Get-Command Test-ArrayPipelineFunction) -OutputFolder "$TestDrive/arrayTest" -Force
+            $content = Import-MarkdownCommandHelp $file
+        }
+
+        It 'should generate correct input type for string array parameter' {
+            $content.Inputs.Count | Should -Be 1
+            $content.Inputs[0].Typename | Should -Be 'System.String[]'
+        }
+
+        It 'should not duplicate array and element types in inputs' {            
+            $inputTypes = $content.Inputs | ForEach-Object { $_.Typename }
+            $inputTypes | Should -Not -Contain 'System.String'
+            $inputTypes | Should -Contain 'System.String[]'
+        }
+
+        It 'should preserve array notation in markdown and parsing roundtrip' {
+            Update-MarkdownCommandHelp -Path $file -NoBackup
+            $updatedContent = Import-MarkdownCommandHelp $file
+            
+            $updatedContent.Inputs.Count | Should -Be 1
+            $updatedContent.Inputs[0].Typename | Should -Be 'System.String[]'
+        }
+    }
+
     Context 'Generated markdown features: no comment-based help' {
         function global:Test-PlatyPSFunction
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request addresses the issue when generating pipeline parameters of type array; duplicate input types were created in the output Markdown. It fixed type name handling to maintain array semantics for input/output types and preserves array notation when parsing Markdown.

## PR Context

Fix #789

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/820)
<!-- Reviewable:end -->
