### PR TITLE
Fix reading/writing syntax parameters in Maml help

### DIFF
--- a/src/Common/YamlUtils.cs
+++ b/src/Common/YamlUtils.cs
@@ -646,8 +646,6 @@ namespace Microsoft.PowerShell.PlatyPS
                         }
                     }
 
-                    // add the parameter name
-                    si.Parameters.ForEach(p => si.AddParameter(p));
                     syntaxes.Add(si);
                 }
             }

--- a/src/MamlWriter/DataType.cs
+++ b/src/MamlWriter/DataType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         /// <summary>
         ///     The data-type name.
         /// </summary>
-        [XmlElement("name", Namespace = Constants.XmlNamespace.Dev, Order = 0)]
+        [XmlElement("name", Namespace = Constants.XmlNamespace.MAML, Order = 0)]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             {
                 foreach (var syntax in commandHelp.Syntax)
                 {
-                    command.Syntax.Add(ConvertSyntax(syntax));
+                    command.Syntax.Add(ConvertSyntax(syntax, commandHelp.Parameters));
                 }
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             }
         }
 
-        private static SyntaxItem ConvertSyntax(Model.SyntaxItem syntax)
+        private static SyntaxItem ConvertSyntax(Model.SyntaxItem syntax, List<Model.Parameter> parameters)
         {
             var newSyntax = new SyntaxItem();
             var firstSpace = syntax.CommandName.IndexOf(' ');
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 newSyntax.CommandName = syntax.CommandName.Substring(0, firstSpace);
             }
             syntax.SortParameters();
-            newSyntax.Parameters.AddRange(syntax.SyntaxParameters.Select(ConvertSyntaxParameter));
+            newSyntax.Parameters.AddRange(syntax.SyntaxParameters.Select(sp => ConvertSyntaxParameter(sp, parameters)));
 
             return newSyntax;
         }
@@ -202,7 +202,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             return newParameter;
         }
 
-        private static Parameter ConvertSyntaxParameter(Model.SyntaxParameter syntaxParam)
+        private static Parameter ConvertSyntaxParameter(Model.SyntaxParameter syntaxParam, List<Model.Parameter> parameters)
         {
             var newParameter = new MAML.Parameter()
             {
@@ -215,6 +215,24 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                     IsMandatory = true,
                 },
             };
+            if (syntaxParam.IsSwitchParameter)
+            {
+                newParameter.Type = new DataType()
+                {
+                    Name = "System.Management.Automation.SwitchParameter"
+                };
+            }
+            else
+            {
+                var parameter = parameters.FirstOrDefault(p => string.Equals(p.Name, syntaxParam.ParameterName, StringComparison.Ordinal));
+                if (parameter is not null)
+                {
+                    newParameter.Type = new DataType()
+                    {
+                        Name = parameter.Type
+                    };
+                }
+            }
             return newParameter;
         }
 

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -199,6 +199,11 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 }
             }
 
+            if (parameter.Aliases.Count > 0)
+            {
+                newParameter.Aliases = string.Join(", ", parameter.Aliases);
+            }
+
             return newParameter;
         }
 
@@ -231,6 +236,10 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                     {
                         Name = parameter.Type
                     };
+                    if (parameter.Aliases.Count > 0)
+                    {
+                        newParameter.Aliases = string.Join(", ", parameter.Aliases);
+                    }
                 }
             }
             return newParameter;

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -211,6 +211,12 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 newParameter.Aliases = string.Join(", ", parameter.Aliases);
             }
 
+            if (parameter.AcceptedValues.Count > 0)
+            {
+                var acceptedValues = parameter.AcceptedValues.Select(val => new ParameterValue() { DataType = val });
+                newParameter.ParameterValueGroup = acceptedValues.ToList();
+            }
+
             return newParameter;
         }
 
@@ -247,6 +253,11 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                     if (parameter.Aliases.Count > 0)
                     {
                         newParameter.Aliases = string.Join(", ", parameter.Aliases);
+                    }
+                    if (parameter.AcceptedValues.Count > 0)
+                    {
+                        var acceptedValues = parameter.AcceptedValues.Select(val => new ParameterValue() { DataType = val });
+                        newParameter.ParameterValueGroup = acceptedValues.ToList();
                     }
                 }
             }

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -154,10 +154,8 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             {
                 newSyntax.CommandName = syntax.CommandName.Substring(0, firstSpace);
             }
-            foreach(var parameter in syntax.GetParametersInOrder())
-            {
-                newSyntax.Parameters.Add(ConvertParameter(parameter));
-            }
+            syntax.SortParameters();
+            newSyntax.Parameters.AddRange(syntax.SyntaxParameters.Select(ConvertSyntaxParameter));
 
             return newSyntax;
         }
@@ -201,6 +199,22 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 }
             }
 
+            return newParameter;
+        }
+
+        private static Parameter ConvertSyntaxParameter(Model.SyntaxParameter syntaxParam)
+        {
+            var newParameter = new MAML.Parameter()
+            {
+                Name = syntaxParam.ParameterName,
+                IsMandatory = syntaxParam.IsMandatory,
+                Position = syntaxParam.Position,
+                Value = new MAML.ParameterValue()
+                {
+                    DataType = syntaxParam.ParameterType,
+                    IsMandatory = true,
+                },
+            };
             return newParameter;
         }
 

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -180,9 +180,9 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             {
                 parameterValue.DataType = parameter.Type;
                 parameterValue.IsVariableLength = parameter.VariableLength;
-                // We just mark mandatory if one of the parameter sets is mandatory since MAML doesn't
-                // have a way to disambiguate these.
-                parameterValue.IsMandatory = parameter.ParameterSets.Any(x => x.IsRequired);
+                // Should be `true`. This indicates not the parameter is mandatory or not, but the parameter **value** is mandatory or not.
+                // The parameter which parameter value is not required is SwitchParameter, but SwitchParameter does not ouput this element itself.
+                parameterValue.IsMandatory = true;
             }
             return parameterValue;
         }

--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -167,8 +167,14 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             return pipelineInput;
         }
 
-        private static ParameterValue GetParameterValue(Model.Parameter parameter)
+        private static ParameterValue? GetParameterValue(Model.Parameter parameter)
         {
+            // dont render <command:parameterValue> element when the parameter type is SwitchParameter
+            if (parameter.Type is "SwitchParameter" or "System.Management.Automation.SwitchParameter")
+            {
+                return null;
+            }
+
             var parameterValue = new ParameterValue();
             if (parameter is not null)
             {
@@ -190,6 +196,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             var pSet = parameter.ParameterSets.FirstOrDefault();
             newParameter.Position = pSet is null ? Model.Constants.NamedString : pSet.Position;
             newParameter.Value = GetParameterValue(parameter);
+            newParameter.Type = new DataType() { Name = parameter.Type };
 
             if (parameter.Description is not null)
             {
@@ -214,11 +221,6 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
                 Name = syntaxParam.ParameterName,
                 IsMandatory = syntaxParam.IsMandatory,
                 Position = syntaxParam.Position,
-                Value = new MAML.ParameterValue()
-                {
-                    DataType = syntaxParam.ParameterType,
-                    IsMandatory = true,
-                },
             };
             if (syntaxParam.IsSwitchParameter)
             {
@@ -229,6 +231,12 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
             }
             else
             {
+                newParameter.Value = new MAML.ParameterValue()
+                {
+                    DataType = syntaxParam.ParameterType,
+                    IsMandatory = true
+                };
+
                 var parameter = parameters.FirstOrDefault(p => string.Equals(p.Name, syntaxParam.ParameterName, StringComparison.Ordinal));
                 if (parameter is not null)
                 {

--- a/src/MamlWriter/Parameter.cs
+++ b/src/MamlWriter/Parameter.cs
@@ -31,6 +31,9 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         [XmlElement("parameterValue", Namespace = Constants.XmlNamespace.Command, Order = 2)]
         public ParameterValue Value { get; set; } = new ParameterValue();
 
+        [XmlElement("type", Namespace = Constants.XmlNamespace.Dev, Order = 3)]
+        public DataType? Type { get; set; }
+
         /// <summary>
         ///     Is the parameter mandatory?
         /// </summary>

--- a/src/MamlWriter/Parameter.cs
+++ b/src/MamlWriter/Parameter.cs
@@ -26,12 +26,19 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         public List<string> Description { get; set; } = new List<string>();
 
         /// <summary>
+        ///     The parameter value group information ("command:parameterValueGroup").
+        /// </summary>
+        [XmlArray("parameterValueGroup", Namespace = Constants.XmlNamespace.Command, Order = 2)]
+        [XmlArrayItem("parameterValue", Namespace = Constants.XmlNamespace.Command)]
+        public List<ParameterValue>? ParameterValueGroup { get; set; }
+
+        /// <summary>
         ///     The parameter value information ("command:parameterValue").
         /// </summary>
-        [XmlElement("parameterValue", Namespace = Constants.XmlNamespace.Command, Order = 2)]
+        [XmlElement("parameterValue", Namespace = Constants.XmlNamespace.Command, Order = 3)]
         public ParameterValue? Value { get; set; }
 
-        [XmlElement("type", Namespace = Constants.XmlNamespace.Dev, Order = 3)]
+        [XmlElement("type", Namespace = Constants.XmlNamespace.Dev, Order = 4)]
         public DataType? Type { get; set; }
 
         /// <summary>

--- a/src/MamlWriter/Parameter.cs
+++ b/src/MamlWriter/Parameter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         ///     The parameter value information ("command:parameterValue").
         /// </summary>
         [XmlElement("parameterValue", Namespace = Constants.XmlNamespace.Command, Order = 2)]
-        public ParameterValue Value { get; set; } = new ParameterValue();
+        public ParameterValue? Value { get; set; }
 
         [XmlElement("type", Namespace = Constants.XmlNamespace.Dev, Order = 3)]
         public DataType? Type { get; set; }

--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -256,6 +256,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 syntaxDiagnostics.ForEach(d => commandHelp.Diagnostics.TryAddDiagnostic(d));
             }
+            commandHelp.Syntax.ForEach(si => si.HasCmdletBinding = commandHelp.HasCmdletBinding);
 
             List<DiagnosticMessage> aliasesDiagnostics = new();
             bool aliasHeaderFound = false;

--- a/src/Model/CommandHelp.cs
+++ b/src/Model/CommandHelp.cs
@@ -202,34 +202,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
         internal void AddParameter(Parameter parameter)
         {
             Parameters.Add(parameter);
-            foreach(var parameterSet in parameter.ParameterSets)
-            {
-                if (string.Compare(parameterSet.Name, "(All)", StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    foreach(var syntax in SyntaxDictionary.Values)
-                    {
-                        try
-                        {
-                            syntax.AddParameter(parameter);
-                        }
-                        catch
-                        {
-                            // This is okay, we just don't want to add it to the syntax item if it's already there.
-                        }
-                    }
-                }
-                else if (SyntaxDictionary.TryGetValue(parameterSet.Name, out var syntaxItem))
-                {
-                    try
-                    {
-                        syntaxItem.AddParameter(parameter);
-                    }
-                    catch
-                    {
-                        // This is okay, we just don't want to add it to the syntax item if it's already there.
-                    }
-                }
-            }
         }
 
         public bool TryGetParameter(string name, out Parameter? parameter)

--- a/src/Model/SyntaxItem.cs
+++ b/src/Model/SyntaxItem.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
@@ -20,17 +19,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
 
         public List<SyntaxParameter> SyntaxParameters = new();
 
-        public List<Parameter> Parameters = new();
-
-        private List<string> _parameterNames = new();
-
-        public ReadOnlyCollection<string> ParameterNames {
-            get => new ReadOnlyCollection<string>(_parameterNames);
-        }
-
-        // Sort parameters by name
-        private SortedList<string, Parameter> _alphabeticOrderParameters;
-
         public bool IsDefaultParameterSet { get; }
 
         public SyntaxItem(string commandName, string parameterSetName, bool isDefaultParameterSet)
@@ -38,8 +26,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             CommandName = commandName;
             ParameterSetName = parameterSetName;
             IsDefaultParameterSet = isDefaultParameterSet;
-
-            _alphabeticOrderParameters = new SortedList<string, Parameter>();
         }
 
         /// <summary>
@@ -53,24 +39,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             IsDefaultParameterSet = syntaxItem.IsDefaultParameterSet;
             SyntaxParameters = new List<SyntaxParameter>(syntaxItem.SyntaxParameters);
             HasCmdletBinding = syntaxItem.HasCmdletBinding;
-            Parameters = new List<Parameter>(syntaxItem.Parameters);
-
-            _alphabeticOrderParameters = new SortedList<string, Parameter>(syntaxItem._alphabeticOrderParameters);
-            _parameterNames = new List<string>(syntaxItem._parameterNames);
-        }
-
-        public void AddParameter(Parameter parameter)
-        {
-            string name = parameter.Name;
-
-            if (Constants.CommonParametersNames.Contains(name))
-            {
-                HasCmdletBinding = true;
-                return;
-            }
-
-            _parameterNames.Add(name);
-            _alphabeticOrderParameters.Add(name, parameter);
         }
 
         /// <summary>
@@ -114,19 +82,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             }
 
             SyntaxParameters = sortedList;
-        }
-
-        public void AddParameter(SyntaxParameter parameter)
-        {
-            string name = parameter.ParameterName;
-
-            if (Constants.CommonParametersNames.Contains(name))
-            {
-                HasCmdletBinding = true;
-                return;
-            }
-
-            _parameterNames.Add(name);
         }
 
         private string GetFormattedSyntaxParameter(string paramName, string paramTypeName, bool isPositional, bool isRequired)

--- a/src/Model/SyntaxItem.cs
+++ b/src/Model/SyntaxItem.cs
@@ -28,16 +28,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             get => new ReadOnlyCollection<string>(_parameterNames);
         }
 
-        public ReadOnlyCollection<int> PositionalParameterKeys {
-            get => new ReadOnlyCollection<int>(_positionalParameters.Keys);
-        }
-
-        // Sort parameters by position
-        private SortedList<int, Parameter> _positionalParameters;
-
-        // Sort parameters by if they are Required by name
-        private SortedList<string, Parameter> _requiredParameters;
-
         // Sort parameters by name
         private SortedList<string, Parameter> _alphabeticOrderParameters;
 
@@ -49,8 +39,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             ParameterSetName = parameterSetName;
             IsDefaultParameterSet = isDefaultParameterSet;
 
-            _positionalParameters = new SortedList<int, Parameter>();
-            _requiredParameters = new SortedList<string, Parameter>();
             _alphabeticOrderParameters = new SortedList<string, Parameter>();
         }
 
@@ -67,8 +55,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             HasCmdletBinding = syntaxItem.HasCmdletBinding;
             Parameters = new List<Parameter>(syntaxItem.Parameters);
 
-            _positionalParameters = new SortedList<int, Parameter>(syntaxItem._positionalParameters);
-            _requiredParameters = new SortedList<string, Parameter>(syntaxItem._requiredParameters);
             _alphabeticOrderParameters = new SortedList<string, Parameter>(syntaxItem._alphabeticOrderParameters);
             _parameterNames = new List<string>(syntaxItem._parameterNames);
         }
@@ -180,24 +166,6 @@ namespace Microsoft.PowerShell.PlatyPS.Model
             else
             {
                 return string.Format(Constants.OptionalParamTemplate, paramName, paramType);
-            }
-        }
-
-        public IEnumerable<Parameter> GetParametersInOrder()
-        {
-            foreach (KeyValuePair<int, Parameter> kv in _positionalParameters)
-            {
-                yield return kv.Value;
-            }
-
-            foreach (KeyValuePair<string, Parameter> kv in _requiredParameters)
-            {
-                yield return kv.Value;
-            }
-
-            foreach (KeyValuePair<string, Parameter> kv in _alphabeticOrderParameters)
-            {
-                yield return kv.Value;
             }
         }
 

--- a/src/Transform/TransformBase.cs
+++ b/src/Transform/TransformBase.cs
@@ -376,8 +376,6 @@ namespace Microsoft.PowerShell.PlatyPS
                                 string.Compare(paramInfo.ParameterType.Name, "SwitchParameter", true) == 0)
                         );
                     }
-                    Parameter param = GetParameterInfo(cmdletInfo, helpItem, paramInfo);
-                    syn.AddParameter(param);
                 }
 
                 // now take the named parameters.
@@ -393,8 +391,6 @@ namespace Microsoft.PowerShell.PlatyPS
                             string.Compare(paramInfo.ParameterType.Name, "SwitchParameter", true) == 0);
                         syn.SyntaxParameters.Add(sParm);
                     }
-                    Parameter param = GetParameterInfo(cmdletInfo, helpItem, paramInfo);
-                    syn.AddParameter(param);
                 }
 
                 syntaxItems.Add(syn);

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -420,42 +420,27 @@ namespace Microsoft.PowerShell.PlatyPS
                     unnamedParameterSetName,
                     isDefaultParameterSet: false);
 
+                int position = int.MaxValue;
+                List<SyntaxParameter> positionalSyntaxParameters = [];
                 while (reader.ReadToNextSibling(Constants.MamlCommandParameterTag))
                 {
-                    var parameter = ReadParameter(reader.ReadSubtree(), parameterSetCount: -1);
-                    syntaxItem.SyntaxParameters.Add(new SyntaxParameter(parameter));
-                    try
+                    var syntaxParameter = ReadSyntaxParameter(reader.ReadSubtree());
+                    syntaxItem.SyntaxParameters.Add(syntaxParameter);
+                    if (syntaxParameter.IsPositional)
                     {
-                        // This may possibly throw because the position is duplicated.
-                        // This is because we don't have a way to disambiguate between a positional parameter
-                        // in one parameter set and a non-positional parameter in another parameter set.
-                        // In this case, we will try to add the parameter with a negative position to show we
-                        // could not assign it appropriately.
-                        syntaxItem.AddParameter(parameter);
-                        syntaxItem.SyntaxParameters.Add(new SyntaxParameter(parameter));
+                        positionalSyntaxParameters.Add(syntaxParameter);
+                        // set the position value to the minimum value in each parameter
+                        if (int.TryParse(syntaxParameter.Position, NumberStyles.None, CultureInfo.InvariantCulture, out var p))
+                        {
+                            position = Math.Min(p, position);
+                        }
                     }
-                    catch
-                    {
-                        int minKey = syntaxItem.PositionalParameterKeys.Min(x => x);
-                        if (minKey >= 0)
-                        {
-                            minKey = -1;
-                        }
-                        else
-                        {
-                            minKey--;
-                        }
+                }
 
-                        parameter.ParameterSets.ForEach(x => x.Position = minKey.ToString());
-                        try
-                        {
-                            syntaxItem.AddParameter(parameter);
-                        }
-                        catch (Exception exception)
-                        {
-                            throw new InvalidOperationException($"Error adding parameter '{parameter.Name}' to syntax item {commandName}", exception);
-                        }
-                    }
+                // re-numbering positional parameters from the minimum value
+                foreach (var p in positionalSyntaxParameters.OrderBy(p => int.Parse(p.Position)))
+                {
+                    p.Position = (position++).ToString();
                 }
 
                 foreach(var paramName in syntaxItem.ParameterNames)
@@ -474,6 +459,76 @@ namespace Microsoft.PowerShell.PlatyPS
             }
 
             return null;
+        }
+
+        private SyntaxParameter ReadSyntaxParameter(XmlReader reader)
+        {
+            string name = string.Empty;
+            string type = string.Empty;
+            string position = Constants.NamedString;
+            bool required = false;
+
+            reader.Read();
+
+            if (reader.HasAttributes)
+            {
+                if (reader.MoveToAttribute("required"))
+                {
+                    bool.TryParse(reader.Value, out required);
+                }
+
+                if (reader.MoveToAttribute("position"))
+                {
+                    // Value is like '0' or 'named'
+                    position = reader.Value;
+                }
+
+                reader.MoveToElement();
+            }
+
+            if (reader.ReadToDescendant(Constants.MamlNameTag))
+            {
+                name = reader.ReadElementContentAsString();
+            }
+
+            // We read the next element and check the name as it could parameterValue or dev:type
+            while (reader.Read())
+            {
+                if (string.Equals(reader.Name, Constants.MamlCommandParameterValueTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    type = reader.ReadElementContentAsString();
+                }
+                else if (string.IsNullOrEmpty(type)
+                         && string.Equals(reader.Name, Constants.MamlDevTypeTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (reader.ReadToDescendant(Constants.MamlNameTag))
+                    {
+                        type = reader.ReadElementContentAsString();
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new InvalidDataException($"Invalid syntaxItem.parameter data: <command:parameterValue> or <dev:type> is none");
+            }
+
+            SyntaxParameter syntaxParameter = new SyntaxParameter(name)
+            {
+                IsMandatory = required,
+                ParameterType = type,
+                IsPositional = int.TryParse(position, NumberStyles.None, CultureInfo.InvariantCulture, out _),
+                Position = position,
+                IsSwitchParameter = type is "SwitchParameter" or "System.Management.Automation.SwitchParameter",
+            };
+
+            // need to go the end of command:parameter
+            if (reader.ReadState != ReadState.EndOfFile)
+            {
+                reader.ReadEndElement();
+            }
+
+            return syntaxParameter;
         }
 
         private Parameter ReadParameter(XmlReader reader, int parameterSetCount)

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -115,6 +115,7 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     cmdHelp.Parameters.RemoveAll(p => string.Compare(p.Name, MAML.Constants.NoCommonParameter, true) == 0);
                 }
+                cmdHelp.Syntax.ForEach(si => si.HasCmdletBinding = cmdHelp.HasCmdletBinding);
 
                 cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadata(cmdHelp);
             }

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -19,9 +19,6 @@ namespace Microsoft.PowerShell.PlatyPS
 {
     internal class TransformMaml : TransformBase
     {
-        // Dictionary of parameter name -> parameterset which it belongs
-        private Dictionary<string, List<string>> _paramSetMap = new();
-
         public TransformMaml(TransformSettings settings) : base(settings)
         {
         }
@@ -120,8 +117,6 @@ namespace Microsoft.PowerShell.PlatyPS
                 }
 
                 cmdHelp.Metadata = MetadataUtils.GetCommandHelpBaseMetadata(cmdHelp);
-
-                _paramSetMap.Clear();
             }
             else
             {
@@ -441,18 +436,6 @@ namespace Microsoft.PowerShell.PlatyPS
                 foreach (var p in positionalSyntaxParameters.OrderBy(p => int.Parse(p.Position)))
                 {
                     p.Position = (position++).ToString();
-                }
-
-                foreach(var paramName in syntaxItem.ParameterNames)
-                {
-                    if (_paramSetMap.ContainsKey(paramName))
-                    {
-                        _paramSetMap[paramName].Add(unnamedParameterSetName);
-                    }
-                    else
-                    {
-                        _paramSetMap.Add(paramName, new List<string>() { unnamedParameterSetName });
-                    }
                 }
 
                 return syntaxItem;

--- a/test/Pester/CompareCommandHelp.Tests.ps1
+++ b/test/Pester/CompareCommandHelp.Tests.ps1
@@ -15,23 +15,22 @@ Describe "Compare-CommandHelp can find differences" {
     }
 
     It "Should properly identify the number of differences" {
-        $result1.where({$_ -match "are not the same|are different"}).Count | Should -Be 11
+        $result1.where({$_ -match "are not the same|are different"}).Count | Should -Be 7
     }
 
     It "Should properly identify the elements which are different" {
-        $expected = "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames", "CommandHelp.Syntax.ParameterSetName",
-            "CommandHelp.Syntax.ParameterNames", "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames",
-            "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames", "CommandHelp.Examples.Title",
-            "CommandHelp.Examples.Remarks", "CommandHelp.Diagnostics"
+        $expected = "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterSetName",
+                    "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterSetName",
+                    "CommandHelp.Examples.Title", "CommandHelp.Examples.Remarks",
+                    "CommandHelp.Diagnostics"
         $observed = $result1.split("`n").Where({$_ -match "are not the same|are different"}).foreach({$_.Substring(2).trim().split()[0]})
         $observed | Should -Be $expected
     }
 
     It "Should be possible to exclude an element from comparison" {
-        $expected = "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames", "CommandHelp.Syntax.ParameterSetName",
-            "CommandHelp.Syntax.ParameterNames", "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames",
-            "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterNames", "CommandHelp.Examples.Title",
-            "CommandHelp.Examples.Remarks"
+        $expected = "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterSetName",
+                    "CommandHelp.Syntax.ParameterSetName", "CommandHelp.Syntax.ParameterSetName",
+                    "CommandHelp.Examples.Title", "CommandHelp.Examples.Remarks"
         $observed = $result2.split("`n").Where({$_ -match "are not the same|are different"}).foreach({$_.Substring(2).trim().split()[0]})
         $observed | Should -Be $expected
 
@@ -39,8 +38,7 @@ Describe "Compare-CommandHelp can find differences" {
 
     It "Default excluded properties should be Diagnostics and ParameterNames" {
         $expected = "M excluding comparison of CommandHelp.AliasHeaderFound",
-                    "M excluding comparison of CommandHelp.Diagnostics",
-                    "M excluding comparison of CommandHelp.Syntax.ParameterNames"
+                    "M excluding comparison of CommandHelp.Diagnostics"
         $observed = $result3.split("`n").Where({$_ -match "excluding comparison"})|Sort-Object -Unique
         $observed | Should -Be $expected
     }

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -143,5 +143,10 @@ Describe "Export-MamlCommandHelp tests" {
             $maml = Get-Content -Path $mamlFile -Raw
             $maml | Should -BeLike '*<command:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>*'
         }
+
+        It "Should have the proper aliases for Get-Date" {
+            $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).Parameters.parameter.
+                  Where({$_.Name -in @('Date', 'UnixTimeSeconds')}).aliases | Should -Be 'LastWriteTime', 'UnixTime'
+        }
     }
 }

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -155,5 +155,53 @@ Describe "Export-MamlCommandHelp tests" {
             $parameter.SelectNodes('./command:parameterValueGroup/command:parameterValue', $ns2).'#text' |
                 Should -BeExactly 'Date', 'Time', 'DateTime'
         }
+
+        It "Should have the proper values for '<name>' syntax parameter of Get-Date" -testcases @(
+            @{ name = "Date";  position = "0";     aliases = "LastWriteTime"; parameterValue = "DateTime"; type = "System.DateTime"; },
+            @{ name = "Year";  position = "named"; aliases = "none";          parameterValue = "Int32";    type = "System.Int32"; },
+            @{ name = "AsUTC"; position = "named"; aliases = "none";          parameterValue = $null;      type = "System.Management.Automation.SwitchParameter" }
+        ) {
+            param($name, $position, $aliases, $parameterValue, $type)
+
+            $command = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"})
+            $syntaxParam = $command.syntax.syntaxItem[0].parameter.Where({$_.name -eq $name});
+            $syntaxParam.Count | Should -Be 1;
+            $syntaxParam.position | Should -BeExactly $position
+            $syntaxParam.aliases | Should -BeExactly $aliases
+            if ($null -eq $parameterValue)
+            {
+                $syntaxParam.parameterValue | Should -BeNullOrEmpty
+            }
+            else
+            {
+                $syntaxParam.parameterValue."#text" | Should -BeExactly $parameterValue
+                $syntaxParam.parameterValue.required | Should -BeExactly 'true'
+            }
+            $syntaxParam.type.name | Should -BeExactly $type
+        }
+
+        It "Should have the proper values for '<name>' parameter of Get-Date" -testcases @(
+            @{ name = "Date";  position = "0";     aliases = "LastWriteTime"; parameterValue = "System.DateTime"; type = "System.DateTime"; },
+            @{ name = "Year";  position = "Named"; aliases = "none";          parameterValue = "System.Int32";    type = "System.Int32"; },
+            @{ name = "AsUTC"; position = "Named"; aliases = "none";          parameterValue = $null;             type = "System.Management.Automation.SwitchParameter" }
+        ) {
+            param($name, $position, $aliases, $parameterValue, $type)
+
+            $command = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"})
+            $param = $command.parameters.parameter.Where({$_.name -eq $name});
+            $param.Count | Should -Be 1;
+            $param.position | Should -BeExactly $position
+            $param.aliases | Should -BeExactly $aliases
+            if ($null -eq $parameterValue)
+            {
+                $param.parameterValue | Should -BeNullOrEmpty
+            }
+            else
+            {
+                $param.parameterValue."#text" | Should -BeExactly $parameterValue
+                $param.parameterValue.required | Should -BeExactly 'true'
+            }
+            $param.type.name | Should -BeExactly $type
+        }
     }
 }

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -148,5 +148,12 @@ Describe "Export-MamlCommandHelp tests" {
             $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).Parameters.parameter.
                   Where({$_.Name -in @('Date', 'UnixTimeSeconds')}).aliases | Should -Be 'LastWriteTime', 'UnixTime'
         }
+
+        It "Should have the proper parameterValueGroup for 'DisplayHint' parameter of Get-Date" {
+            $parameter = $xml2.SelectNodes('//command:command', $ns2).Where({$_.details.name -eq "Get-Date"}).
+                               parameters.parameter.Where({$_.Name -eq 'DisplayHint'})
+            $parameter.SelectNodes('./command:parameterValueGroup/command:parameterValue', $ns2).'#text' |
+                Should -BeExactly 'Date', 'Time', 'DateTime'
+        }
     }
 }

--- a/test/Pester/ImportMamlHelp.Tests.ps1
+++ b/test/Pester/ImportMamlHelp.Tests.ps1
@@ -46,5 +46,31 @@ Describe "Import-YamlHelp tests" {
                 $cmdlet.Metadata[$key] | Should -Be $Value
             }
         }
+
+        Context "Syntax parameters checks" {
+            It "Add-Member cmdlet has correct number of syntax parameters" {
+                $cmdlet.Syntax[0].SyntaxParameters.Count | Should -be 8
+            }
+
+            It "'<Name>' of syntax parameter for Add-Member cmdlet has correct property values" -testcases @(
+                @{ Name = 'MemberType';  Type = 'System.Management.Automation.PSMemberTypes';   Position = '0';     IsMandatory = $true;  IsPositional = $true;  IsSwitchParameter = $false },
+                @{ Name = 'Name';        Type = 'System.String';                                Position = '1';     IsMandatory = $true;  IsPositional = $true;  IsSwitchParameter = $false },
+                @{ Name = 'Value';       Type = 'System.Object';                                Position = '2';     IsMandatory = $false; IsPositional = $true;  IsSwitchParameter = $false },
+                @{ Name = 'SecondValue'; Type = 'System.Object';                                Position = '3';     IsMandatory = $false; IsPositional = $true;  IsSwitchParameter = $false },
+                @{ Name = 'Force';       Type = 'System.Management.Automation.SwitchParameter'; Position = 'named'; IsMandatory = $false; IsPositional = $false; IsSwitchParameter = $true },
+                @{ Name = 'InputObject'; Type = 'System.Management.Automation.PSObject';        Position = 'named'; IsMandatory = $true;  IsPositional = $false; IsSwitchParameter = $false },
+                @{ Name = 'PassThru';    Type = 'System.Management.Automation.SwitchParameter'; Position = 'named'; IsMandatory = $false; IsPositional = $false; IsSwitchParameter = $true },
+                @{ Name = 'TypeName';    Type = 'System.String';                                Position = 'named'; IsMandatory = $false; IsPositional = $false; IsSwitchParameter = $false }
+            ) {
+                param ([string]$Name, [string]$Type, [string]$Position, [bool]$IsMandatory, [bool]$IsPositional, [bool]$IsSwitchParameter)
+                $syntaxParam = $cmdlet.Syntax[0].SyntaxParameters.Where({$_.ParameterName -eq $Name})
+                $syntaxParam.ParameterName | Should -be $Name
+                $syntaxParam.ParameterType | Should -be $Type
+                $syntaxParam.Position | should -be $Position
+                $syntaxParam.IsMandatory | should -be $IsMandatory
+                $syntaxParam.IsPositional | should -be $IsPositional
+                $syntaxParam.IsSwitchParameter | should -be $IsSwitchParameter
+            }
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

This patch fixes a problem with reading and writing syntax parameters in the Maml help.

Fix following issues:
- https://github.com/PowerShell/platyPS/issues/815
- https://github.com/PowerShell/platyPS/issues/816
- Problem with alphabetical order of parameters when generating Maml help
  (The order of syntax parameters should be: positional parameters, required parameters, others in that order.)

Additionaly, removed no longer needed codes.

## PR Context

To fix following issues:
- https://github.com/PowerShell/platyPS/issues/815
- https://github.com/PowerShell/platyPS/issues/816

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/821)
<!-- Reviewable:end -->
