### PR TITLE
Fix read Inputs/Outputs for Import-MamlHelp

### DIFF
--- a/src/MamlWriter/DataType.cs
+++ b/src/MamlWriter/DataType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         /// <summary>
         ///     The data-type name.
         /// </summary>
-        [XmlElement("name", Namespace = Constants.XmlNamespace.Dev, Order = 0)]
+        [XmlElement("name", Namespace = Constants.XmlNamespace.MAML, Order = 0)]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -288,6 +288,48 @@ namespace Microsoft.PowerShell.PlatyPS
             }
         }
 
+        /// <summary>
+        /// Reads nodes in &lt;command:inputType&gt; or &lt;command:returnValue&gt;
+        /// and returns <see cref="InputOutput"/> object if possible.
+        /// </summary>
+        /// <param name="subTreeReader">Sub tree instance of <see cref="XmlReader"/>.</param>
+        private static InputOutput? ReadInputOutput(XmlReader subTreeReader)
+        {
+            string? typeName = null;
+            StringBuilder typeDescription = Constants.StringBuilderPool.Get();
+
+            try
+            {
+                while (subTreeReader.Read())
+                {
+                    switch (subTreeReader.Name)
+                    {
+                        // Supports both `<maml:name>` and `<dev:name>`.
+                        // `<dev:name>` is wrong namespace, but used in PlatyPS v1.0.1 
+                        case Constants.MamlNameTag:
+                        case "dev:name":
+                            typeName = subTreeReader.ReadElementContentAsString();
+                            continue;
+                        case Constants.MamlParaTag:
+                            typeDescription.AppendLine(subTreeReader.ReadElementContentAsString().Trim())
+                                           .AppendLine();
+                            continue;
+                    }
+                }
+
+                if (typeName is not null)
+                {
+                    return new InputOutput(typeName, typeDescription.ToString().Trim());
+                }
+
+                return null;
+            }
+            finally
+            {
+                Constants.StringBuilderPool.Return(typeDescription);
+            }
+        }
+
         private List<InputOutput> ReadInput(XmlReader reader)
         {
             List<InputOutput> inputItem = new();
@@ -298,24 +340,11 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     do
                     {
-                        string? typeName = null;
-                        string? typeDescription = null;
-
-                        if (reader.ReadToFollowing(Constants.MamlNameTag))
+                        var input = ReadInputOutput(reader.ReadSubtree());
+                        if (input is not null)
                         {
-                            typeName = reader.ReadElementContentAsString();
+                            inputItem.Add(input);
                         }
-
-                        if (reader.ReadToFollowing(Constants.MamlParaTag))
-                        {
-                            typeDescription = reader.ReadElementContentAsString();
-                        }
-
-                        if (typeName is not null && typeDescription is not null)
-                        {
-                            inputItem.Add(new InputOutput(typeName, typeDescription));
-                        }
-
                     } while (reader.ReadToNextSibling(Constants.MamlCommandInputTypeTag));
                 }
             }
@@ -333,24 +362,11 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     do
                     {
-                        string? typeName = null;
-                        string? typeDescription = null;
-
-                        if (reader.ReadToFollowing(Constants.MamlNameTag))
+                        var output = ReadInputOutput(reader.ReadSubtree());
+                        if (output is not null)
                         {
-                            typeName = reader.ReadElementContentAsString();
+                            outputItem.Add(output);
                         }
-
-                        if (reader.ReadToFollowing(Constants.MamlParaTag))
-                        {
-                            typeDescription = reader.ReadElementContentAsString();
-                        }
-
-                        if (typeName is not null && typeDescription is not null)
-                        {
-                            outputItem.Add(new InputOutput(typeName, typeDescription));
-                        }
-
                     } while (reader.ReadToNextSibling(Constants.MamlCommandReturnValueTag));
                 }
             }

--- a/test/Pester/ImportMamlHelp.Tests.ps1
+++ b/test/Pester/ImportMamlHelp.Tests.ps1
@@ -46,5 +46,30 @@ Describe "Import-YamlHelp tests" {
                 $cmdlet.Metadata[$key] | Should -Be $Value
             }
         }
+
+        Context "Inputs/Outputs check" {
+            It "has the proper Inputs for the '<name>' cmdlet" -testcases @(
+                @{ name = 'Add-Member'; expectedValues = 'System.Management.Automation.PSObject' },
+                @{ name = 'Get-PSBreakpoint'; expectedValues = 'System.Int32', 'Microsoft.PowerShell.Commands.BreakpointType' }
+            ) {
+                param ([string]$name, [string[]]$expectedValues)
+
+                $values = $importedCmds.Where({$_.Title -eq $name}).Inputs.Typename
+                $values | Should -BeExactly $expectedValues
+            }
+
+            It "has the proper Outputs for the '<name>' cmdlet" -testcases @(
+                @{ name = 'Add-Member'; expectedValues = 'None', 'System.Object' },
+                @{ name = 'Get-PSBreakpoint'; expectedValues = 'System.Management.Automation.CommandBreakpoint',
+                                                               'System.Management.Automation.LineBreakpoint',
+                                                               'System.Management.Automation.VariableBreakpoint',
+                                                               'System.Management.Automation.Breakpoint' }
+            ) {
+                param ([string]$name, [string[]]$expectedValues)
+
+                $values = $importedCmds.Where({$_.Title -eq $name}).Outputs.Typename
+                $values | Should -BeExactly $expectedValues
+            }
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

Fix issue Inputs(`<command:inputType>`) and Outputs(`<command:returnValue>`) are not read correctly for Import-MamlHelp cmdlet.
Additionally, fixed the namespace of the `name` element in the `<dev:type>` is incorrect for `Export-MamlHelp` cmdlet.

## PR Context

Fixes following issues:
- https://github.com/PowerShell/platyPS/issues/825

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/826)
<!-- Reviewable:end -->
