### PR TITLE
Add CODEOWNERS file with default owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://help.github.com/articles/about-codeowners/
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following owners will be requested for
+# review when someone opens a pull request.
+*       @adityapatwardhan @sdwheeler


### PR DESCRIPTION
Set default code owners for the repository.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds a `CODEOWNERS` file to the repository, specifying default code owners for all files. This ensures that pull requests will automatically request reviews from the designated owners.

* Added a `.github/CODEOWNERS` file that sets `@adityapatwardhan` and `@sdwheeler` as default reviewers for all files in the repository.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
