### PR TITLE
Improve how `Input` and `Output` markdown headers handles array types.

### DIFF
--- a/src/MarkdownReader/CommandHelpMarkdownReader.cs
+++ b/src/MarkdownReader/CommandHelpMarkdownReader.cs
@@ -962,7 +962,7 @@ namespace Microsoft.PowerShell.PlatyPS
             {
                 if (md.GetCurrent() is HeadingBlock inputOutputHeader)
                 {
-                    string inputType = inputOutputHeader?.Inline?.FirstChild?.ToString() ?? string.Empty;
+                    string inputType = string.Join("", inputOutputHeader.Inline ?? []);
                     md.Take();
                     if (md.GetCurrent() is ParagraphBlock pBlock)
                     {

--- a/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
+++ b/test/Pester/ImportMarkdownCommandHelp.Tests.ps1
@@ -121,12 +121,19 @@ Describe 'Import-MarkdownCommandHelp Tests' {
         BeforeAll {
             $ch1 = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Compare-CommandHelp.md"
             $ch2 = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Get-ChildItem.md"
+            $ch3 = Import-MarkdownCommandHelp "$PSScriptRoot/assets/Remove-SqlSensitivityClassification.md"
         }
 
         It "Should have the proper input content" {
             $ch1.Inputs.Count | Should -Be 1
             $ch1.Inputs[0].TypeName | Should -BeExactly "System.Management.Automation.HiThere"
             $ch1.Inputs[0].Description | Should -Be ""
+
+            $ch3.Inputs.Count | Should -Be 2
+            $ch3.Inputs[0].TypeName | Should -BeExactly "System.String[]"
+            $ch3.Inputs[0].Description | Should -Be ""
+            $ch3.Inputs[1].TypeName | Should -BeExactly "Microsoft.SqlServer.Management.Smo.Database"
+            $ch3.Inputs[1].Description | Should -Be ""
         }
 
         It "Should have the proper output content" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve how `Input` and `Output` headers array types are handled when reading markdown.

## PR Context

Input/Output type should read tokens of the inputOutputHeader.
For example:
`System.String[]`  is currently parsed as the first token, `System.String`, skipping the second and third  (`[`, `]`).

With this change, the array types are parsed correctly.

Sample markdown:
```markdown
## INPUTS

### System.String[]

You can pipe strings or string arrays to the cmdlet.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/838)
<!-- Reviewable:end -->
