### PR TITLE
Fix PowerShell 5.1 compatibility in New-HelpCabinetFile

### DIFF
--- a/src/Microsoft.PowerShell.PlatyPS.psm1
+++ b/src/Microsoft.PowerShell.PlatyPS.psm1
@@ -272,7 +272,7 @@ function New-HelpCabinetFile {
     )
 
     end {
-        if (! $IsWindows) {
+        if ($PSEdition -eq 'Core' -and ! $IsWindows) {
             throw "'New-HelpCabinetFile' is only supported on Windows."
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #842 `New-HelpCabinetFile` so it can run on Windows PowerShell 5.1 by avoiding unconditional use of the `$IsWindows` automatic variable

`$IsWindows` is available in PowerShell Core, but it is not defined in Windows PowerShell 5.1. The updated check only evaluates `$IsWindows` when `$PSEdition` is `Core`, while preserving the existing behavior that blocks this cmdlet on non-Windows platforms.

## PR Context

`New-HelpCabinetFile` is a Windows-only cmdlet, but the previous platform check could fail on Windows PowerShell 5.1 because `$IsWindows` does not exist there.

This change allows the cmdlet to continue working on Windows PowerShell 5.1 while still throwing the existing unsupported-platform error when running PowerShell Core on non-Windows systems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/843)
<!-- Reviewable:end -->
