### PR TITLE
Update CI configuration to use windows-latest image

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -60,13 +60,13 @@ stages:
     parameters:
       jobName: TestPkgWin
       displayName: PowerShell Core on Windows
-      imageName: windows-2019
+      imageName: windows-latest
 
   - template: test.yml
     parameters:
       jobName: TestPkgWinPS
       displayName: Windows PowerShell on Windows
-      imageName: windows-2019
+      imageName: windows-latest
       powershellExecutable: powershell
 
   - template: test.yml


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the CI configuration to use the latest available Windows image for testing jobs, instead of the previously specified `windows-2019`. This ensures the CI pipeline runs on a more up-to-date and supported environment.

CI environment update:
* Updated the `imageName` parameter from `windows-2019` to `windows-latest` for both PowerShell Core and Windows PowerShell test jobs in `.ci/ci.yml`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/847)
<!-- Reviewable:end -->
