### PR TITLE
Test fixes due to change in cmdlet

### DIFF
--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -159,8 +159,13 @@ Describe "New-CommandHelp tests" {
             $io = New-CommandHelp -Command (Get-Command Test-InputOutputTypes)
         }
 
-        It "Should have the proper number of output types" {            
-            $ch.outputs.Count | should be 9
+        It "Should have the proper number of output types" {
+            if ($PSVersionTable.PSVersion.Major -eq 5) {
+                $expectedCount = 9
+            }
+            else {
+                $expectedCount = 8
+            }
         }
 
         It "Should have the output type '<type>'" -TestCases @(

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -63,7 +63,6 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'All'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'ArgumentList'; Type = 'System.Object[]' },
             @{ Name = 'CommandType'; Type = 'System.Management.Automation.CommandTypes' },
-            @{ Name = 'ExcludeModule'; Type = 'System.String[]' },
             @{ Name = 'FullyQualifiedModule'; Type = 'Microsoft.PowerShell.Commands.ModuleSpecification[]' },
             @{ Name = 'ListImported'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'Module'; Type = 'System.String[]' },
@@ -76,6 +75,7 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'TotalCount'; Type = 'System.Int32' },
             @{ Name = 'Verb'; Type = 'System.String[]' }
             if ($PSVersionTable.PSVersion.Major -gt 5) {
+                @{ Name = 'ExcludeModule'; Type = 'System.String[]' },
                 @{ Name = 'FuzzyMinimumDistance'; Type = 'System.UInt32' },
                 @{ Name = 'UseAbbreviationExpansion'; Type = 'System.Management.Automation.SwitchParameter' },
                 @{ Name = 'UseFuzzyMatching'; Type = 'System.Management.Automation.SwitchParameter' }

--- a/test/Pester/ConvertToCommandHelp.Tests.ps1
+++ b/test/Pester/ConvertToCommandHelp.Tests.ps1
@@ -52,7 +52,7 @@ Describe "New-CommandHelp tests" {
                 $expectedCount = 14
             }
             else {
-                $expectedCount = 17
+                $expectedCount = 18
             }
 
             $parameters.Count | Should -Be $expectedCount
@@ -63,6 +63,7 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'All'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'ArgumentList'; Type = 'System.Object[]' },
             @{ Name = 'CommandType'; Type = 'System.Management.Automation.CommandTypes' },
+            @{ Name = 'ExcludeModule'; Type = 'System.String[]' },
             @{ Name = 'FullyQualifiedModule'; Type = 'Microsoft.PowerShell.Commands.ModuleSpecification[]' },
             @{ Name = 'ListImported'; Type = 'System.Management.Automation.SwitchParameter' },
             @{ Name = 'Module'; Type = 'System.String[]' },
@@ -90,6 +91,7 @@ Describe "New-CommandHelp tests" {
             @{ Name = 'All'; alias = '' },
             @{ Name = 'ArgumentList'; alias = 'Args' },
             @{ Name = 'CommandType'; alias = 'Type' },
+            @{ Name = 'ExcludeModule'; alias = '' },
             @{ Name = 'FullyQualifiedModule'; alias = '' },
             @{ Name = 'FuzzyMinimumDistance'; alias = '' },
             @{ Name = 'ListImported'; alias = '' },
@@ -115,8 +117,8 @@ Describe "New-CommandHelp tests" {
             $observed | Should -Be $expected
         }
         It "Should have the proper parameters in parameterset '<ParameterSetName>'" -Skip:($PSVersionTable.PSVersion.Major -eq 5) -TestCases @(
-            @{ ParameterSetName = 'CmdletSet';     Parameters = 'All:ArgumentList:FullyQualifiedModule:ListImported:Module:Noun:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:Verb' }
-            @{ ParameterSetName = 'AllCommandSet'; Parameters = 'All:ArgumentList:CommandType:FullyQualifiedModule:FuzzyMinimumDistance:ListImported:Module:Name:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:UseAbbreviationExpansion:UseFuzzyMatching' }
+            @{ ParameterSetName = 'CmdletSet';     Parameters = 'All:ArgumentList:ExcludeModule:FullyQualifiedModule:ListImported:Module:Noun:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:Verb' }
+            @{ ParameterSetName = 'AllCommandSet'; Parameters = 'All:ArgumentList:CommandType:ExcludeModule:FullyQualifiedModule:FuzzyMinimumDistance:ListImported:Module:Name:ParameterName:ParameterType:ShowCommandInfo:Syntax:TotalCount:UseAbbreviationExpansion:UseFuzzyMatching' }
         ) {
             param ($ParameterSetName, $Parameters)
             $observedParameters = ($ch.parameters.Where({$_.parametersets.Name -match "$ParameterSetName|\(All\)"})|sort-object name).name -join ":"
@@ -157,14 +159,8 @@ Describe "New-CommandHelp tests" {
             $io = New-CommandHelp -Command (Get-Command Test-InputOutputTypes)
         }
 
-        It "Should have the proper number of output types" {
-            if ($PSVersionTable.PSVersion.Major -eq 5) {
-                $expectedCount = 9
-            }
-            else {
-                $expectedCount = 8
-            }
-            $ch.outputs.Count | should be $expectedCount
+        It "Should have the proper number of output types" {            
+            $ch.outputs.Count | should be 9
         }
 
         It "Should have the output type '<type>'" -TestCases @(


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


This pull request updates the `New-CommandHelp` tests to account for the addition of the `ExcludeModule` parameter. The changes ensure that all relevant test cases and expected values reflect this new parameter, and they standardize the expected output type count.

**Test updates for new parameter:**

* Added `ExcludeModule` to the expected parameters list and alias checks in the test cases. [[1]](diffhunk://#diff-478faade5a2a1496acacb86a06dc8c54204a4d7928aab5995d58c21f56fa71ceR66) [[2]](diffhunk://#diff-478faade5a2a1496acacb86a06dc8c54204a4d7928aab5995d58c21f56fa71ceR94)
* Updated expected parameter sets to include `ExcludeModule` for both `CmdletSet` and `AllCommandSet`.
* Increased the expected parameter count from 17 to 18 for non-PSVersion 5 environments.

**Output type count standardization:**

* Set the expected output type count to 9 for all environments, removing the conditional logic based on PowerShell version.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/848)
<!-- Reviewable:end -->
