### PR TITLE
Fix the XML namespace for Related Links URI

### DIFF
--- a/src/MamlWriter/RelatedLink.cs
+++ b/src/MamlWriter/RelatedLink.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         /// <summary>
         ///     The command parameters associated with this syntax.
         /// </summary>
-        [XmlElement("uri", Namespace = Constants.XmlNamespace.Command, Order = 1)]
+        [XmlElement("uri", Namespace = Constants.XmlNamespace.MAML, Order = 1)]
         public string Uri { get; set; } = string.Empty;
 
         public bool Equals(NavigationLink other)

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Export-MamlCommandHelp tests" {
             $mamlFile = $m | Export-MamlCommandHelp -OutputFolder "$outputDirectory/helpuri" -Force
             $mamlFile | Should -Exist
             $maml = Get-Content -Path $mamlFile -Raw
-            $maml | Should -BeLike '*<command:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>*'
+            $maml | Should -BeLike '*<maml:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>*'
         }
 
         It "Should have the proper aliases for Get-Date" {

--- a/test/Pester/ExportMamlCommandHelp.Tests.ps1
+++ b/test/Pester/ExportMamlCommandHelp.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Export-MamlCommandHelp tests" {
             $mamlFile = $m | Export-MamlCommandHelp -OutputFolder "$outputDirectory/helpuri" -Force
             $mamlFile | Should -Exist
             $maml = Get-Content -Path $mamlFile -Raw
-            $maml | Should -BeLike '*<maml:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>*'
+            $maml | Should -BeLike '*<maml:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</maml:uri>*'
         }
 
         It "Should have the proper aliases for Get-Date" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


This pull request makes a small but important change to the XML serialization of the `Uri` property in the `NavigationLink` class. The XML namespace for the `uri` element has been updated from `Constants.XmlNamespace.Command` to `Constants.XmlNamespace.MAML` to ensure correct XML output.

- Changed the XML namespace for the `Uri` property in `NavigationLink` from `Command` to `MAML` for proper serialization.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/849)
<!-- Reviewable:end -->
