### PR TITLE
Fix Import-MamlHelp failing to read `<command:uri>` in related links

### DIFF
--- a/src/MamlWriter/MamlConstants.cs
+++ b/src/MamlWriter/MamlConstants.cs
@@ -39,5 +39,15 @@ namespace Microsoft.PowerShell.PlatyPS.Model
         internal const string MamlLinkTextTag = "maml:linkText";
         internal const string MamlUriTag = "maml:uri";
         internal const string MamlFileExtensionSuffix = "-help.xml";
+        // Legacy compatibility:
+        // Older versions of platyPS (prior to 1.0.2) emitted `<command:url>`
+        // in Export-MamlCommandHelp, and some existing MAML help files still
+        // use `<command:uri>`. PowerShell’s built-in MAML reader accepts both
+        // because it matches only the local-name `uri`.
+        //
+        // Import-MamlHelp must continue to support `<command:uri>` for
+        // compatibility with legacy MAML content. This constant can be removed
+        // once all supported MAML formats use `<maml:uri>` exclusively.
+        internal const string MamlCommandUriTag = "command:uri";
     }
 }

--- a/src/Transform/TransformMaml.cs
+++ b/src/Transform/TransformMaml.cs
@@ -137,26 +137,34 @@ namespace Microsoft.PowerShell.PlatyPS
                 {
                     do
                     {
+                        var subTree = reader.ReadSubtree();
+
                         string? linkText = null;
                         string? uri = null;
 
-                        if (reader.ReadToFollowing(Constants.MamlLinkTextTag))
+                        while (subTree.Read())
                         {
-                            linkText = reader.ReadElementContentAsString();
-                        }
-
-                        if (reader.ReadToFollowing(Constants.MamlUriTag))
-                        {
-                            uri = reader.ReadElementContentAsString();
+                            switch (subTree.Name)
+                            {
+                                case Constants.MamlLinkTextTag:
+                                    linkText = reader.ReadElementContentAsString();
+                                    continue;
+                                case Constants.MamlUriTag:
+                                case Constants.MamlCommandUriTag:
+                                    // Support `<command:uri>` for legacy MAML compatibility.
+                                    // PowerShell’s built-in MAML reader accepts both `<maml:uri>` and
+                                    // `<command:uri>` (matching only the local-name `uri`), so platyPS
+                                    // must do the same. This branch can be removed once legacy MAML
+                                    // formats are no longer supported.
+                                    uri = reader.ReadElementContentAsString();
+                                    continue;
+                            }
                         }
 
                         if (linkText != null && uri != null)
                         {
                             relatedLinks.Add(new Links(uri, linkText));
                         }
-
-                        reader.ReadEndElement();
-
                     } while (reader.ReadToNextSibling(Constants.MamlNavigationLinkTag));
                 }
             }

--- a/test/Pester/ImportMamlHelp.Tests.ps1
+++ b/test/Pester/ImportMamlHelp.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe "Import-YamlHelp tests" {
+Describe "Import-MamlHelp tests" {
     Context "Basic tests" {
         BeforeAll {
             $mamlFile = "${PSScriptRoot}/assets/Microsoft.PowerShell.Commands.Utility.dll-Help.xml"
@@ -95,6 +95,14 @@ Describe "Import-YamlHelp tests" {
 
                 $values = $importedCmds.Where({$_.Title -eq $name}).Outputs.Typename
                 $values | Should -BeExactly $expectedValues
+            }
+        }
+
+        Context 'Load legacy' {
+            It 'load <command:uri> in related links' {
+                $mamlFile = "${PSScriptRoot}/assets/legacy-maml/command-uri-in-related-links.xml"
+                $importedCmd = Import-MamlHelp $mamlFile
+                $importedCmd.RelatedLinks[0].Uri | Should -Be "https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&WT.mc_id=ps-gethelp"
             }
         }
     }

--- a/test/Pester/assets/legacy-maml/command-uri-in-related-links.xml
+++ b/test/Pester/assets/legacy-maml/command-uri-in-related-links.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" schema="maml" xmlns="http://msh">
+  <command:command>
+    <command:details>
+      <command:name>Get-Date</command:name>
+      <maml:description>
+        <maml:para>Gets the current date and time.</maml:para>
+      </maml:description>
+      <command:verb>Get</command:verb>
+      <command:noun>Date</command:noun>
+    </command:details>
+    <maml:description>
+      <maml:para />
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-Date</maml:name>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters />
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para />
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples />
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version</maml:linkText>
+        <command:uri>https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-date?view=powershell-7.4&amp;WT.mc_id=ps-gethelp</command:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>


### PR DESCRIPTION
# PR Summary

This PR fixes an issue where Import-MamlHelp fails to read `<command:uri>` in `<maml:navigationLink>` and throws an XmlException.

PowerShell’s built-in MAML reader (Get-Help / Show-HelpPreview) correctly reads `<command:uri>` because it matches only the local-name `uri` and does not require the `maml:` namespace. platyPS should maintain compatibility with this behavior.

Older versions of platyPS (prior to 1.0.2) also emitted `<command:url>` in Export-MamlCommandHelp, so Import-MamlHelp must support this legacy format to ensure round‑trip compatibility.

This PR updates TransformMaml.ReadRelatedLinks to safely read both `<maml:uri>` and `<command:uri>` using `ReadSubtree()`, and removes the incorrect `ReadEndElement()` call that caused the XmlException.

## PR Context

Fixes #852

### Summary of changes

- Add support for `<command:uri>` in related links (legacy MAML format)
- Use `ReadSubtree()` to safely iterate navigationLink contents
- Read both `<maml:uri>` and `<command:uri>` for compatibility with  PowerShell’s MAML reader
- Remove incorrect `ReadEndElement()` call that caused XmlException
- Add failing test (`command:uri-in-related-links.xml`) and ensure it passes  after the fix
- Add comments explaining legacy compatibility and future removal conditions

### Why this change is needed

Import-MamlHelp currently crashes when `<command:uri>` is present, even though PowerShell itself reads such MAML files without issue.
This breaks compatibility with legacy help content and prevents round‑trip conversion for modules that still use the older format.

This PR restores compatibility and aligns platyPS with PowerShell’s behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/854)
<!-- Reviewable:end -->
