### PR TITLE
[Fix #793] - Fix the formatting of the Description in MAML

### DIFF
--- a/src/MamlWriter/MamlHelpers.cs
+++ b/src/MamlWriter/MamlHelpers.cs
@@ -65,12 +65,12 @@ namespace Microsoft.PowerShell.PlatyPS.MAML
         {
             var command = new Command();
             command.Details = ConvertCommandDetails(commandHelp);
+
+            // We don't break up these lines, but provide a single paragraph
+            // to get better formatting.
             if (commandHelp.Description is not null)
             {
-                foreach(string s in commandHelp.Description.Split(new string[] { "\n\n" }, StringSplitOptions.None))
-                {
-                    command.Description.Add(s.Replace("\n"," ").Trim());
-                }
+                command.Description.Add(commandHelp.Description);
             }
 
             // Notes are reconstituted as Alerts in AlertSet


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Fixes #793

## PR Context

Before this PR, when the cmdlet description was converted to MAML each line of each paragraph was joined into a single paragraph. This altered the formatting in several ways:
- extra spaces were inserted between the joined lines
- lists, tables, and block quotes were squashed into one continuous line making them unreadable

This PR preserves the structure of the markdown by not splitting the content. This follows the same pattern used for NOTES, and parameter descriptions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PowerShell/platyPS/855)
<!-- Reviewable:end -->
